### PR TITLE
feat: Live message ticker

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "express": "^4.21.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
-        "socket.io": "^4.8.0"
+        "socket.io": "^4.8.0",
+        "socket.io-client": "^4.8.3"
       },
       "devDependencies": {
         "@types/express": "^5.0.0",
@@ -1827,6 +1828,19 @@
         "node": ">=10.2.0"
       }
     },
+    "node_modules/engine.io-client": {
+      "version": "6.6.4",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.6.4.tgz",
+      "integrity": "sha512-+kjUJnZGwzewFDw951CDWcwj35vMNf2fcj7xQWOctq1F2i1jkDdVvdFG9kM/BEChymCH36KgjnW0NsL58JYRxw==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1",
+        "engine.io-parser": "~5.2.1",
+        "ws": "~8.18.3",
+        "xmlhttprequest-ssl": "~2.1.1"
+      }
+    },
     "node_modules/engine.io-parser": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
@@ -2883,6 +2897,21 @@
         "ws": "~8.18.3"
       }
     },
+    "node_modules/socket.io-client": {
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.3.tgz",
+      "integrity": "sha512-uP0bpjWrjQmUt5DTHq9RuoCBdFJF10cdX9X+a368j/Ft0wmaVgxlrjvK3kjvgCODOMMOz9lcaRzxmso0bTWZ/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1",
+        "engine.io-client": "~6.6.1",
+        "socket.io-parser": "~4.2.4"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/socket.io-parser": {
       "version": "4.2.6",
       "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.6.tgz",
@@ -3709,6 +3738,14 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xmlhttprequest-ssl": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.1.2.tgz",
+      "integrity": "sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/y18n": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "express": "^4.21.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "socket.io": "^4.8.0"
+    "socket.io": "^4.8.0",
+    "socket.io-client": "^4.8.3"
   },
   "devDependencies": {
     "@types/express": "^5.0.0",

--- a/server/index.ts
+++ b/server/index.ts
@@ -11,6 +11,7 @@ import express from "express";
 import { createServer } from "http";
 import { Server as SocketIOServer } from "socket.io";
 import { readFileSync, writeFileSync, existsSync, mkdirSync, readdirSync, unlinkSync } from "node:fs";
+import { stat as statAsync } from "node:fs/promises";
 import { join, dirname } from "node:path";
 import { createReadStream } from "node:fs";
 import { createInterface } from "node:readline";
@@ -101,6 +102,8 @@ for (const [id, prefs] of savedPrefs) {
 // ---- State ----
 
 const agentStates = new Map<string, AgentState>();
+/** Transcript paths discovered from CLI session data, keyed by agentId */
+const agentTranscriptPaths = new Map<string, string>();
 
 // ---- CLI data source ----
 
@@ -292,8 +295,11 @@ const TICKER_MAX_CHARS = 150;
 const TICKER_MAX_AGE = 5 * 60 * 1000; // 5 minutes
 
 const tickerMessages: TickerMessage[] = [];
-/** Track the last seen sequence per transcript to avoid re-reading entire files */
-const lastSeenSeq = new Map<string, number>();
+/**
+ * Track the byte offset of the last read position per transcript so we only
+ * read newly-appended lines on each poll cycle instead of the whole file.
+ */
+const lastReadOffset = new Map<string, number>();
 
 /**
  * Extract displayable text from a message content block.
@@ -305,10 +311,12 @@ function extractText(content: unknown): string {
   }
   if (Array.isArray(content)) {
     for (const block of content) {
-      if (block && typeof block === 'object' && block.type === 'text' && typeof block.text === 'string') {
-        // Skip tool calls and thinking blocks
-        if (block.type === 'thinking' || block.type === 'toolCall') continue;
-        return block.text.slice(0, TICKER_MAX_CHARS);
+      if (!block || typeof block !== 'object') continue;
+      const b = block as Record<string, unknown>;
+      // Skip non-text content blocks (thinking, tool calls, tool results)
+      if (b.type === 'thinking' || b.type === 'tool_use' || b.type === 'tool_result') continue;
+      if (b.type === 'text' && typeof b.text === 'string') {
+        return b.text.slice(0, TICKER_MAX_CHARS);
       }
     }
   }
@@ -317,7 +325,8 @@ function extractText(content: unknown): string {
 
 /**
  * Tail the transcript JSONL for a given session and extract new messages.
- * Uses the `__openclaw.seq` field to track what we've already seen.
+ * Uses a byte-offset to seek directly to the end of what was already read,
+ * so each poll cycle reads only the newly-appended lines.
  */
 async function tailTranscript(
   agentId: string,
@@ -327,62 +336,60 @@ async function tailTranscript(
   if (!transcriptPath || !existsSync(transcriptPath)) return [];
 
   const key = `${agentId}:${transcriptPath}`;
-  const lastSeq = lastSeenSeq.get(key) ?? 0;
+  const offset = lastReadOffset.get(key) ?? 0;
+
+  // Snapshot the file size before reading so we have a stable upper bound even
+  // if the file is still being written to during the read.
+  let fileSize: number;
+  try {
+    fileSize = (await statAsync(transcriptPath)).size;
+  } catch {
+    return [];
+  }
+
+  // Nothing new since we last read (also ensures fileSize > offset, so
+  // end = fileSize - 1 is always a valid range below)
+  if (fileSize <= offset) return [];
+
   const newMessages: TickerMessage[] = [];
-  let maxSeq = lastSeq;
 
   return new Promise((resolve) => {
-    const rl = createInterface({
-      input: createReadStream(transcriptPath, { encoding: 'utf-8' }),
-      crlfDelay: Infinity,
+    const stream = createReadStream(transcriptPath, {
+      encoding: 'utf-8',
+      start: offset,
+      end: fileSize - 1,
     });
+    const rl = createInterface({ input: stream, crlfDelay: Infinity });
 
-    let lineCount = 0;
     rl.on('line', (line) => {
-      lineCount++;
       if (!line.trim()) return;
       try {
         const msg = JSON.parse(line);
-
-        // Track sequence number
-        const seq = msg?.__openclaw?.seq ?? 0;
-        if (seq <= lastSeq) return;
-        if (seq > maxSeq) maxSeq = seq;
 
         // Only extract assistant and user messages with text
         const role = msg.role;
         if (role !== 'assistant' && role !== 'user') return;
 
         const text = extractText(msg.content);
-        if (!text) return;
-
-        // Skip very short/empty messages
-        if (text.length < 5) return;
+        if (!text || text.length < 5) return;
 
         // Skip heartbeat messages
         if (text.startsWith('HEARTBEAT_OK') || text.includes('HEARTBEAT.md')) return;
 
-        const id = msg.__openclaw?.id || `${agentId}-${seq}`;
+        const id = msg.__openclaw?.id || `${agentId}-${msg.__openclaw?.seq ?? Date.now()}`;
         const timestamp = msg.timestamp || msg.__openclaw?.ts || Date.now();
 
         // Age check
         if (Date.now() - timestamp > TICKER_MAX_AGE) return;
 
-        newMessages.push({
-          id,
-          agentId,
-          agentName,
-          role,
-          text,
-          timestamp,
-        });
+        newMessages.push({ id, agentId, agentName, role, text, timestamp });
       } catch {
         // Skip malformed lines
       }
     });
 
     rl.on('close', () => {
-      lastSeenSeq.set(key, maxSeq);
+      lastReadOffset.set(key, fileSize);
       resolve(newMessages);
     });
 
@@ -399,12 +406,9 @@ async function pollMessages(): Promise<void> {
   for (const [agentId, state] of agentStates) {
     if (!state.active) continue;
 
-    // Find the transcript path from CLI session data
     const known = AGENT_REGISTRY.get(agentId);
     if (!known) continue;
 
-    // We need to look up the transcript path from the CLI data
-    // Store it during pollSessions
     const transcriptPath = agentTranscriptPaths.get(agentId);
     if (transcriptPath) {
       promises.push(tailTranscript(agentId, known.name, transcriptPath));
@@ -413,6 +417,12 @@ async function pollMessages(): Promise<void> {
 
   const results = await Promise.all(promises);
   const newMsgs = results.flat();
+
+  // Prune messages older than TICKER_MAX_AGE from the rolling buffer
+  const cutoff = Date.now() - TICKER_MAX_AGE;
+  let i = 0;
+  while (i < tickerMessages.length && tickerMessages[i].timestamp < cutoff) i++;
+  if (i > 0) tickerMessages.splice(0, i);
 
   if (newMsgs.length > 0) {
     // Add new messages and sort by timestamp
@@ -428,9 +438,6 @@ async function pollMessages(): Promise<void> {
     io.emit('ticker:messages', tickerMessages);
   }
 }
-
-/** Store transcript paths from CLI session data */
-const agentTranscriptPaths = new Map<string, string>();
 
 // ---- Polling loop ----
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -368,6 +368,7 @@ async function tailTranscript(
     // trailing partial line (no terminating newline) is NOT counted and
     // will be re-read on the next poll cycle.
     let bytesConsumed = 0;
+    let errored = false;
 
     rl.on("line", (line) => {
       // +1 for the newline character that readline strips
@@ -400,6 +401,11 @@ async function tailTranscript(
     });
 
     rl.on("close", () => {
+      // On stream error, rl.close() is called which fires this handler.
+      // Guard against advancing the offset or resolving with partial data
+      // when the read was interrupted by an I/O error.
+      if (errored) return;
+
       // Only advance the cursor by bytes we know ended at a newline.
       // If the file was appended mid-line during our read, the partial
       // fragment (fileSize - bytesConsumed) will be re-read next cycle.
@@ -411,6 +417,7 @@ async function tailTranscript(
 
     // readline.Interface does not emit "error"; handle errors on the underlying stream.
     stream.on("error", () => {
+      errored = true;
       rl.close();
       stream.destroy();
       resolve([]);

--- a/server/index.ts
+++ b/server/index.ts
@@ -12,7 +12,9 @@ import { createServer } from "http";
 import { Server as SocketIOServer } from "socket.io";
 import { readFileSync, writeFileSync, existsSync, mkdirSync, readdirSync, unlinkSync } from "node:fs";
 import { join, dirname } from "node:path";
-import type { AgentState, AgentActivity, SubAgentInfo } from "../shared/types";
+import { createReadStream } from "node:fs";
+import { createInterface } from "node:readline";
+import type { AgentState, AgentActivity, SubAgentInfo, TickerMessage } from "../shared/types";
 
 const app = express();
 const server = createServer(app);
@@ -29,6 +31,8 @@ const ACTIVE_THRESHOLD_MIN = parseInt(process.env.ACTIVE_MINUTES || "30", 10);
 const OPENCLAW_BIN = process.env.OPENCLAW_BIN || "openclaw";
 const DATA_DIR = process.env.DATA_DIR || join(dirname(import.meta.dirname || __dirname), "data");
 const PERSIST_PATH = join(DATA_DIR, "agent-prefs.json");
+/** Base directory for OpenClaw agent session transcripts */
+const AGENTS_DIR = process.env.OPENCLAW_AGENTS_DIR || join(process.env.HOME || "/root", ".openclaw", "agents");
 
 // ---- Known agents from config ----
 
@@ -220,6 +224,12 @@ function mapToAgentStates(cliSessions: CliSession[]): AgentState[] {
         ? `${latestSession.modelProvider}/${latestSession.model}`
         : "unknown";
 
+      // Capture transcript path for message ticker polling
+      if (latestSession.sessionId) {
+        const transcriptPath = join(AGENTS_DIR, agentId, "sessions", `${latestSession.sessionId}.jsonl`);
+        agentTranscriptPaths.set(agentId, transcriptPath);
+      }
+
       const state: AgentState = {
         id: agentId,
         name: known.name,
@@ -272,6 +282,156 @@ function mapToAgentStates(cliSessions: CliSession[]): AgentState[] {
   return results;
 }
 
+// ---- Message Ticker ----
+
+/** Maximum messages to keep in the rolling buffer */
+const TICKER_BUFFER_SIZE = 30;
+/** Maximum characters per ticker message */
+const TICKER_MAX_CHARS = 150;
+/** How far back to look for messages (ms) */
+const TICKER_MAX_AGE = 5 * 60 * 1000; // 5 minutes
+
+const tickerMessages: TickerMessage[] = [];
+/** Track the last seen sequence per transcript to avoid re-reading entire files */
+const lastSeenSeq = new Map<string, number>();
+
+/**
+ * Extract displayable text from a message content block.
+ * Returns the first text content found, truncated.
+ */
+function extractText(content: unknown): string {
+  if (typeof content === 'string') {
+    return content.slice(0, TICKER_MAX_CHARS);
+  }
+  if (Array.isArray(content)) {
+    for (const block of content) {
+      if (block && typeof block === 'object' && block.type === 'text' && typeof block.text === 'string') {
+        // Skip tool calls and thinking blocks
+        if (block.type === 'thinking' || block.type === 'toolCall') continue;
+        return block.text.slice(0, TICKER_MAX_CHARS);
+      }
+    }
+  }
+  return '';
+}
+
+/**
+ * Tail the transcript JSONL for a given session and extract new messages.
+ * Uses the `__openclaw.seq` field to track what we've already seen.
+ */
+async function tailTranscript(
+  agentId: string,
+  agentName: string,
+  transcriptPath: string | undefined,
+): Promise<TickerMessage[]> {
+  if (!transcriptPath || !existsSync(transcriptPath)) return [];
+
+  const key = `${agentId}:${transcriptPath}`;
+  const lastSeq = lastSeenSeq.get(key) ?? 0;
+  const newMessages: TickerMessage[] = [];
+  let maxSeq = lastSeq;
+
+  return new Promise((resolve) => {
+    const rl = createInterface({
+      input: createReadStream(transcriptPath, { encoding: 'utf-8' }),
+      crlfDelay: Infinity,
+    });
+
+    let lineCount = 0;
+    rl.on('line', (line) => {
+      lineCount++;
+      if (!line.trim()) return;
+      try {
+        const msg = JSON.parse(line);
+
+        // Track sequence number
+        const seq = msg?.__openclaw?.seq ?? 0;
+        if (seq <= lastSeq) return;
+        if (seq > maxSeq) maxSeq = seq;
+
+        // Only extract assistant and user messages with text
+        const role = msg.role;
+        if (role !== 'assistant' && role !== 'user') return;
+
+        const text = extractText(msg.content);
+        if (!text) return;
+
+        // Skip very short/empty messages
+        if (text.length < 5) return;
+
+        // Skip heartbeat messages
+        if (text.startsWith('HEARTBEAT_OK') || text.includes('HEARTBEAT.md')) return;
+
+        const id = msg.__openclaw?.id || `${agentId}-${seq}`;
+        const timestamp = msg.timestamp || msg.__openclaw?.ts || Date.now();
+
+        // Age check
+        if (Date.now() - timestamp > TICKER_MAX_AGE) return;
+
+        newMessages.push({
+          id,
+          agentId,
+          agentName,
+          role,
+          text,
+          timestamp,
+        });
+      } catch {
+        // Skip malformed lines
+      }
+    });
+
+    rl.on('close', () => {
+      lastSeenSeq.set(key, maxSeq);
+      resolve(newMessages);
+    });
+
+    rl.on('error', () => resolve([]));
+  });
+}
+
+/**
+ * Poll messages from all active agent transcripts.
+ */
+async function pollMessages(): Promise<void> {
+  const promises: Promise<TickerMessage[]>[] = [];
+
+  for (const [agentId, state] of agentStates) {
+    if (!state.active) continue;
+
+    // Find the transcript path from CLI session data
+    const known = AGENT_REGISTRY.get(agentId);
+    if (!known) continue;
+
+    // We need to look up the transcript path from the CLI data
+    // Store it during pollSessions
+    const transcriptPath = agentTranscriptPaths.get(agentId);
+    if (transcriptPath) {
+      promises.push(tailTranscript(agentId, known.name, transcriptPath));
+    }
+  }
+
+  const results = await Promise.all(promises);
+  const newMsgs = results.flat();
+
+  if (newMsgs.length > 0) {
+    // Add new messages and sort by timestamp
+    tickerMessages.push(...newMsgs);
+    tickerMessages.sort((a, b) => a.timestamp - b.timestamp);
+
+    // Trim to buffer size
+    while (tickerMessages.length > TICKER_BUFFER_SIZE) {
+      tickerMessages.shift();
+    }
+
+    // Broadcast
+    io.emit('ticker:messages', tickerMessages);
+  }
+}
+
+/** Store transcript paths from CLI session data */
+const agentTranscriptPaths = new Map<string, string>();
+
 // ---- Polling loop ----
 
 async function pollAndBroadcast(): Promise<void> {
@@ -280,6 +440,9 @@ async function pollAndBroadcast(): Promise<void> {
 
   // Broadcast to all connected WebSocket clients
   io.emit("agents:update", agentList);
+
+  // Poll messages from transcripts
+  await pollMessages();
 }
 
 // ---- REST API ----
@@ -296,6 +459,10 @@ app.get("/api/status", (_req, res) => {
     activeCount: agents.filter((a) => a.active).length,
     uptime: process.uptime(),
   });
+});
+
+app.get("/api/messages", (_req, res) => {
+  res.json({ messages: tickerMessages });
 });
 
 app.post("/api/agents/:id/toggle", (req, res) => {
@@ -509,6 +676,7 @@ io.on("connection", (socket) => {
 
   // Send current state on connect
   socket.emit("agents:update", Array.from(agentStates.values()));
+  socket.emit("ticker:messages", tickerMessages);
 
   socket.on("disconnect", () => {
     console.log("[ws] Client disconnected:", socket.id);

--- a/server/index.ts
+++ b/server/index.ts
@@ -362,7 +362,17 @@ async function tailTranscript(
     });
     const rl = createInterface({ input: stream, crlfDelay: Infinity });
 
+    // Track how many bytes we've consumed through complete newlines.
+    // `readline` only emits a "line" event after encountering a newline
+    // delimiter, so bytesConsumed always ends at a clean boundary — any
+    // trailing partial line (no terminating newline) is NOT counted and
+    // will be re-read on the next poll cycle.
+    let bytesConsumed = 0;
+
     rl.on("line", (line) => {
+      // +1 for the newline character that readline strips
+      bytesConsumed += Buffer.byteLength(line, "utf-8") + 1;
+
       if (!line.trim()) return;
       try {
         const msg = JSON.parse(line);
@@ -390,7 +400,12 @@ async function tailTranscript(
     });
 
     rl.on("close", () => {
-      lastReadOffset.set(key, fileSize);
+      // Only advance the cursor by bytes we know ended at a newline.
+      // If the file was appended mid-line during our read, the partial
+      // fragment (fileSize - bytesConsumed) will be re-read next cycle.
+      if (bytesConsumed > 0) {
+        lastReadOffset.set(key, offset + bytesConsumed);
+      }
       resolve(newMessages);
     });
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -306,21 +306,21 @@ const lastReadOffset = new Map<string, number>();
  * Returns the first text content found, truncated.
  */
 function extractText(content: unknown): string {
-  if (typeof content === 'string') {
+  if (typeof content === "string") {
     return content.slice(0, TICKER_MAX_CHARS);
   }
   if (Array.isArray(content)) {
     for (const block of content) {
-      if (!block || typeof block !== 'object') continue;
+      if (!block || typeof block !== "object") continue;
       const b = block as Record<string, unknown>;
       // Skip non-text content blocks (thinking, tool calls, tool results)
-      if (b.type === 'thinking' || b.type === 'tool_use' || b.type === 'tool_result') continue;
-      if (b.type === 'text' && typeof b.text === 'string') {
+      if (b.type === "thinking" || b.type === "tool_use" || b.type === "tool_result") continue;
+      if (b.type === "text" && typeof b.text === "string") {
         return b.text.slice(0, TICKER_MAX_CHARS);
       }
     }
   }
-  return '';
+  return "";
 }
 
 /**
@@ -333,7 +333,7 @@ async function tailTranscript(
   agentName: string,
   transcriptPath: string | undefined,
 ): Promise<TickerMessage[]> {
-  if (!transcriptPath || !existsSync(transcriptPath)) return [];
+  if (!transcriptPath) return [];
 
   const key = `${agentId}:${transcriptPath}`;
   const offset = lastReadOffset.get(key) ?? 0;
@@ -344,6 +344,7 @@ async function tailTranscript(
   try {
     fileSize = (await statAsync(transcriptPath)).size;
   } catch {
+    // File doesn't exist or is unreadable — skip silently
     return [];
   }
 
@@ -355,26 +356,26 @@ async function tailTranscript(
 
   return new Promise((resolve) => {
     const stream = createReadStream(transcriptPath, {
-      encoding: 'utf-8',
+      encoding: "utf-8",
       start: offset,
       end: fileSize - 1,
     });
     const rl = createInterface({ input: stream, crlfDelay: Infinity });
 
-    rl.on('line', (line) => {
+    rl.on("line", (line) => {
       if (!line.trim()) return;
       try {
         const msg = JSON.parse(line);
 
         // Only extract assistant and user messages with text
         const role = msg.role;
-        if (role !== 'assistant' && role !== 'user') return;
+        if (role !== "assistant" && role !== "user") return;
 
         const text = extractText(msg.content);
         if (!text || text.length < 5) return;
 
         // Skip heartbeat messages
-        if (text.startsWith('HEARTBEAT_OK') || text.includes('HEARTBEAT.md')) return;
+        if (text.startsWith("HEARTBEAT_OK") || text.includes("HEARTBEAT.md")) return;
 
         const id = msg.__openclaw?.id || `${agentId}-${msg.__openclaw?.seq ?? Date.now()}`;
         const timestamp = msg.timestamp || msg.__openclaw?.ts || Date.now();
@@ -388,12 +389,17 @@ async function tailTranscript(
       }
     });
 
-    rl.on('close', () => {
+    rl.on("close", () => {
       lastReadOffset.set(key, fileSize);
       resolve(newMessages);
     });
 
-    rl.on('error', () => resolve([]));
+    // readline.Interface does not emit "error"; handle errors on the underlying stream.
+    stream.on("error", () => {
+      rl.close();
+      stream.destroy();
+      resolve([]);
+    });
   });
 }
 
@@ -438,22 +444,34 @@ async function pollMessages(): Promise<void> {
 
   // Broadcast whenever the snapshot changed (new messages OR pruning)
   if (newMsgs.length > 0 || pruned) {
-    // Broadcast
-    io.emit('ticker:messages', tickerMessages);
+    io.emit("ticker:messages", tickerMessages);
   }
 }
 
 // ---- Polling loop ----
 
+/**
+ * Guard against overlapping poll cycles: if a previous invocation is still
+ * awaiting the CLI or transcript reads, skip the next tick rather than
+ * running concurrently and racing on shared state.
+ */
+let isPolling = false;
+
 async function pollAndBroadcast(): Promise<void> {
-  const { sessions } = await pollSessions();
-  const agentList = mapToAgentStates(sessions);
+  if (isPolling) return;
+  isPolling = true;
+  try {
+    const { sessions } = await pollSessions();
+    const agentList = mapToAgentStates(sessions);
 
-  // Broadcast to all connected WebSocket clients
-  io.emit("agents:update", agentList);
+    // Broadcast to all connected WebSocket clients
+    io.emit("agents:update", agentList);
 
-  // Poll messages from transcripts
-  await pollMessages();
+    // Poll messages from transcripts
+    await pollMessages();
+  } finally {
+    isPolling = false;
+  }
 }
 
 // ---- REST API ----

--- a/server/index.ts
+++ b/server/index.ts
@@ -422,7 +422,8 @@ async function pollMessages(): Promise<void> {
   const cutoff = Date.now() - TICKER_MAX_AGE;
   let i = 0;
   while (i < tickerMessages.length && tickerMessages[i].timestamp < cutoff) i++;
-  if (i > 0) tickerMessages.splice(0, i);
+  const pruned = i > 0;
+  if (pruned) tickerMessages.splice(0, i);
 
   if (newMsgs.length > 0) {
     // Add new messages and sort by timestamp
@@ -433,7 +434,10 @@ async function pollMessages(): Promise<void> {
     while (tickerMessages.length > TICKER_BUFFER_SIZE) {
       tickerMessages.shift();
     }
+  }
 
+  // Broadcast whenever the snapshot changed (new messages OR pruning)
+  if (newMsgs.length > 0 || pruned) {
     // Broadcast
     io.emit('ticker:messages', tickerMessages);
   }

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -95,3 +95,20 @@ export interface GatewayStatus {
   uptime: number;
   version: string;
 }
+
+// ── Message Ticker ─────────────────────────────────────
+
+export interface TickerMessage {
+  /** Unique message ID (from __openclaw.id or synthetic) */
+  id: string;
+  /** Agent ID that sent/received this message */
+  agentId: string;
+  /** Agent display name */
+  agentName: string;
+  /** 'user' or 'assistant' */
+  role: 'user' | 'assistant';
+  /** Truncated text content (max ~150 chars) */
+  text: string;
+  /** Timestamp (ms epoch) */
+  timestamp: number;
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { AgentSidebar } from './components/AgentSidebar';
 import { AgentDetailPanel } from './components/AgentDetailPanel';
 import { LayoutEditor } from './components/LayoutEditor';
 import { SoundControls } from './components/SoundControls';
+import MessageTicker from './components/MessageTicker';
 import { useAgentStore } from './hooks/useAgentStore';
 import { useLayoutStore } from './hooks/useLayoutStore';
 import type { PlacedFurniture } from '../shared/types';
@@ -136,6 +137,7 @@ export const App: React.FC = () => {
         agent={selectedAgentId ? agents.find(a => a.id === selectedAgentId) ?? null : null}
         onClose={() => setSelectedAgentId(null)}
       />
+      <MessageTicker />
     </div>
   );
 };

--- a/src/components/MessageTicker.css
+++ b/src/components/MessageTicker.css
@@ -113,3 +113,12 @@
   right: 0;
   z-index: 10;
 }
+
+/* ── Accessibility: reduced motion ───────────────────── */
+
+@media (prefers-reduced-motion: reduce) {
+  .ticker-messages {
+    animation: none;
+    padding-left: 0;
+  }
+}

--- a/src/components/MessageTicker.css
+++ b/src/components/MessageTicker.css
@@ -1,0 +1,115 @@
+/* ── Message Ticker ──────────────────────────────────── */
+
+.ticker-container {
+  position: relative;
+  width: 100%;
+  height: 36px;
+  background: rgba(15, 15, 35, 0.85);
+  border-top: 1px solid rgba(78, 204, 163, 0.2);
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  font-size: 13px;
+  color: #c8d6e5;
+}
+
+.ticker-label {
+  flex-shrink: 0;
+  padding: 0 12px;
+  font-size: 11px;
+  font-weight: 600;
+  color: #4ecca3;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  border-right: 1px solid rgba(78, 204, 163, 0.15);
+  height: 100%;
+  display: flex;
+  align-items: center;
+  background: rgba(78, 204, 163, 0.05);
+}
+
+.ticker-track {
+  flex: 1;
+  overflow: hidden;
+  position: relative;
+  height: 100%;
+  display: flex;
+  align-items: center;
+}
+
+.ticker-messages {
+  display: flex;
+  gap: 32px;
+  white-space: nowrap;
+  animation: ticker-scroll var(--ticker-duration, 30s) linear infinite;
+  padding-left: 100%;
+}
+
+.ticker-messages:hover {
+  animation-play-state: paused;
+}
+
+.ticker-msg {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  opacity: 0;
+  transition: opacity 0.5s ease;
+}
+
+.ticker-msg.visible {
+  opacity: 1;
+}
+
+.ticker-msg.fading {
+  opacity: 0.3;
+}
+
+.ticker-msg-name {
+  font-weight: 600;
+  color: #4ecca3;
+  font-size: 12px;
+}
+
+.ticker-msg-name.user-msg {
+  color: #f0a500;
+}
+
+.ticker-msg-text {
+  color: #a0b4c8;
+}
+
+.ticker-msg-text.user-msg {
+  color: #e8d5b7;
+}
+
+.ticker-msg-time {
+  font-size: 10px;
+  color: rgba(200, 214, 229, 0.35);
+  margin-left: 4px;
+}
+
+.ticker-empty {
+  color: rgba(200, 214, 229, 0.3);
+  font-style: italic;
+  padding: 0 12px;
+}
+
+@keyframes ticker-scroll {
+  0% {
+    transform: translateX(0);
+  }
+  100% {
+    transform: translateX(var(--ticker-width, -2000px));
+  }
+}
+
+/* ── Compact mode (below canvas) ─────────────────────── */
+
+.ticker-compact {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: 10;
+}

--- a/src/components/MessageTicker.tsx
+++ b/src/components/MessageTicker.tsx
@@ -6,7 +6,7 @@
  */
 
 import { useEffect, useRef, useState, useCallback } from 'react';
-import { io as socketIO, Socket } from 'socket.io-client';
+import { io as socketIO } from 'socket.io-client';
 import type { TickerMessage } from '../../shared/types';
 import './MessageTicker.css';
 
@@ -27,32 +27,43 @@ function truncate(text: string, maxLen: number): string {
 export default function MessageTicker() {
   const [messages, setMessages] = useState<TickerMessage[]>([]);
   const [connected, setConnected] = useState(false);
-  const socketRef = useRef<Socket | null>(null);
+  const [now, setNow] = useState(Date.now());
   const trackRef = useRef<HTMLDivElement>(null);
+
+  // Tick every 30s so age-based opacity updates even when no new messages arrive
+  useEffect(() => {
+    const timer = setInterval(() => setNow(Date.now()), 30_000);
+    return () => clearInterval(timer);
+  }, []);
 
   // Connect to WebSocket
   useEffect(() => {
+    let isCancelled = false;
     const socket = socketIO(API_BASE, { transports: ['websocket', 'polling'] });
-    socketRef.current = socket;
 
-    socket.on('connect', () => setConnected(true));
-    socket.on('disconnect', () => setConnected(false));
+    const handleConnect = () => { if (!isCancelled) setConnected(true); };
+    const handleDisconnect = () => { if (!isCancelled) setConnected(false); };
+    const handleMessages = (msgs: TickerMessage[]) => { if (!isCancelled) setMessages(msgs); };
 
-    socket.on('ticker:messages', (msgs: TickerMessage[]) => {
-      setMessages(msgs);
-    });
+    socket.on('connect', handleConnect);
+    socket.on('disconnect', handleDisconnect);
+    socket.on('ticker:messages', handleMessages);
 
     // Fetch initial state; abort if this effect is cleaned up before it resolves
     const controller = new AbortController();
     fetch(`${API_BASE}/api/messages`, { signal: controller.signal })
       .then(r => r.json())
       .then(data => {
-        if (data.messages) setMessages(data.messages);
+        if (!isCancelled && data.messages) setMessages(data.messages);
       })
       .catch(() => {});
 
     return () => {
+      isCancelled = true;
       controller.abort();
+      socket.off('connect', handleConnect);
+      socket.off('disconnect', handleDisconnect);
+      socket.off('ticker:messages', handleMessages);
       socket.disconnect();
     };
   }, []);
@@ -77,9 +88,10 @@ export default function MessageTicker() {
     return () => clearTimeout(timer);
   }, [messages, updateScrollParams]);
 
-  // Age-based opacity class
+  // Age-based opacity class — uses `now` state so it re-evaluates every 30s
+  // even when no new messages arrive, ensuring old messages actually fade
   const getAgeClass = (msg: TickerMessage) => {
-    const age = Date.now() - msg.timestamp;
+    const age = now - msg.timestamp;
     if (age < 180000) return 'visible'; // < 3 min: full opacity
     return 'fading'; // > 3 min: fading
   };

--- a/src/components/MessageTicker.tsx
+++ b/src/components/MessageTicker.tsx
@@ -1,0 +1,115 @@
+/**
+ * MessageTicker — horizontal scrolling feed of recent agent messages
+ *
+ * Displays a news-ticker style bar at the bottom of the pixel office
+ * showing the latest messages from all active agents. Pauses on hover.
+ */
+
+import { useEffect, useRef, useState, useCallback } from 'react';
+import { io as socketIO, Socket } from 'socket.io-client';
+import type { TickerMessage } from '../../shared/types';
+import './MessageTicker.css';
+
+const SOCKET_URL = import.meta.env.VITE_SOCKET_URL || 'http://localhost:3001';
+
+/** Format timestamp to HH:MM */
+function fmtTime(ts: number): string {
+  const d = new Date(ts);
+  return `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}`;
+}
+
+/** Truncate text with ellipsis */
+function truncate(text: string, maxLen: number): string {
+  if (text.length <= maxLen) return text;
+  return text.slice(0, maxLen - 1) + '…';
+}
+
+export default function MessageTicker() {
+  const [messages, setMessages] = useState<TickerMessage[]>([]);
+  const [connected, setConnected] = useState(false);
+  const socketRef = useRef<Socket | null>(null);
+  const trackRef = useRef<HTMLDivElement>(null);
+
+  // Connect to WebSocket
+  useEffect(() => {
+    const socket = socketIO(SOCKET_URL, { transports: ['websocket', 'polling'] });
+    socketRef.current = socket;
+
+    socket.on('connect', () => setConnected(true));
+    socket.on('disconnect', () => setConnected(false));
+
+    socket.on('ticker:messages', (msgs: TickerMessage[]) => {
+      setMessages(msgs);
+    });
+
+    // Fetch initial state
+    fetch(`${SOCKET_URL}/api/messages`)
+      .then(r => r.json())
+      .then(data => {
+        if (data.messages) setMessages(data.messages);
+      })
+      .catch(() => {});
+
+    return () => {
+      socket.disconnect();
+    };
+  }, []);
+
+  // Calculate scroll duration and width based on content
+  const updateScrollParams = useCallback(() => {
+    if (!trackRef.current) return;
+    const track = trackRef.current;
+
+    // Measure total content width
+    const contentWidth = track.scrollWidth;
+    const containerWidth = track.parentElement?.clientWidth || 800;
+
+    // Total distance = content width (starts off-screen right) + container width
+    const totalDistance = contentWidth;
+    const duration = Math.max(20, totalDistance / 40); // ~40px per second
+
+    track.style.setProperty('--ticker-width', `-${totalDistance}px`);
+    track.style.setProperty('--ticker-duration', `${duration}s`);
+  }, [messages]);
+
+  useEffect(() => {
+    // Delay to let DOM update
+    const timer = setTimeout(updateScrollParams, 100);
+    return () => clearTimeout(timer);
+  }, [messages, updateScrollParams]);
+
+  // Age-based opacity class
+  const getAgeClass = (msg: TickerMessage) => {
+    const age = Date.now() - msg.timestamp;
+    if (age < 60000) return 'visible'; // < 1 min: full
+    if (age < 180000) return 'visible'; // < 3 min: full
+    return 'fading'; // > 3 min: fading
+  };
+
+  return (
+    <div className="ticker-container">
+      <div className="ticker-label">
+        {connected ? '📡 Live' : '⏳'}
+      </div>
+      <div className="ticker-track">
+        {messages.length === 0 ? (
+          <span className="ticker-empty">Waiting for agent activity…</span>
+        ) : (
+          <div className="ticker-messages" ref={trackRef}>
+            {messages.map((msg) => (
+              <span key={msg.id} className={`ticker-msg ${getAgeClass(msg)}`}>
+                <span className={`ticker-msg-name ${msg.role === 'user' ? 'user-msg' : ''}`}>
+                  {msg.role === 'user' ? '👤' : '🤖'} {msg.agentName}
+                </span>
+                <span className={`ticker-msg-text ${msg.role === 'user' ? 'user-msg' : ''}`}>
+                  {truncate(msg.text, 120)}
+                </span>
+                <span className="ticker-msg-time">{fmtTime(msg.timestamp)}</span>
+              </span>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/MessageTicker.tsx
+++ b/src/components/MessageTicker.tsx
@@ -28,6 +28,7 @@ export default function MessageTicker() {
   const [messages, setMessages] = useState<TickerMessage[]>([]);
   const [connected, setConnected] = useState(false);
   const [now, setNow] = useState(Date.now());
+
   const trackRef = useRef<HTMLDivElement>(null);
 
   // Tick every 30s so age-based opacity updates even when no new messages arrive

--- a/src/components/MessageTicker.tsx
+++ b/src/components/MessageTicker.tsx
@@ -42,8 +42,9 @@ export default function MessageTicker() {
       setMessages(msgs);
     });
 
-    // Fetch initial state
-    fetch(`${SOCKET_URL}/api/messages`)
+    // Fetch initial state; abort if this effect is cleaned up before it resolves
+    const controller = new AbortController();
+    fetch(`${SOCKET_URL}/api/messages`, { signal: controller.signal })
       .then(r => r.json())
       .then(data => {
         if (data.messages) setMessages(data.messages);
@@ -51,6 +52,7 @@ export default function MessageTicker() {
       .catch(() => {});
 
     return () => {
+      controller.abort();
       socket.disconnect();
     };
   }, []);
@@ -60,12 +62,9 @@ export default function MessageTicker() {
     if (!trackRef.current) return;
     const track = trackRef.current;
 
-    // Measure total content width
-    const contentWidth = track.scrollWidth;
-    const containerWidth = track.parentElement?.clientWidth || 800;
-
-    // Total distance = content width (starts off-screen right) + container width
-    const totalDistance = contentWidth;
+    // Total distance the track must travel (content width + viewport width so
+    // items fully exit on the left before looping)
+    const totalDistance = track.scrollWidth + (track.parentElement?.clientWidth ?? 0);
     const duration = Math.max(20, totalDistance / 40); // ~40px per second
 
     track.style.setProperty('--ticker-width', `-${totalDistance}px`);
@@ -81,8 +80,7 @@ export default function MessageTicker() {
   // Age-based opacity class
   const getAgeClass = (msg: TickerMessage) => {
     const age = Date.now() - msg.timestamp;
-    if (age < 60000) return 'visible'; // < 1 min: full
-    if (age < 180000) return 'visible'; // < 3 min: full
+    if (age < 180000) return 'visible'; // < 3 min: full opacity
     return 'fading'; // > 3 min: fading
   };
 

--- a/src/components/MessageTicker.tsx
+++ b/src/components/MessageTicker.tsx
@@ -10,8 +10,6 @@ import { io as socketIO } from 'socket.io-client';
 import type { TickerMessage } from '../../shared/types';
 import './MessageTicker.css';
 
-const API_BASE = import.meta.env.VITE_API_BASE || window.location.origin;
-
 /** Format timestamp to HH:MM */
 function fmtTime(ts: number): string {
   const d = new Date(ts);
@@ -40,7 +38,7 @@ export default function MessageTicker() {
   // Connect to WebSocket
   useEffect(() => {
     let isCancelled = false;
-    const socket = socketIO(API_BASE, { transports: ['websocket', 'polling'] });
+    const socket = socketIO({ transports: ['websocket', 'polling'] });
 
     const handleConnect = () => { if (!isCancelled) setConnected(true); };
     const handleDisconnect = () => { if (!isCancelled) setConnected(false); };
@@ -52,7 +50,7 @@ export default function MessageTicker() {
 
     // Fetch initial state; abort if this effect is cleaned up before it resolves
     const controller = new AbortController();
-    fetch(`${API_BASE}/api/messages`, { signal: controller.signal })
+    fetch("/api/messages", { signal: controller.signal })
       .then(r => r.json())
       .then(data => {
         if (!isCancelled && data.messages) setMessages(data.messages);

--- a/src/components/MessageTicker.tsx
+++ b/src/components/MessageTicker.tsx
@@ -10,7 +10,7 @@ import { io as socketIO, Socket } from 'socket.io-client';
 import type { TickerMessage } from '../../shared/types';
 import './MessageTicker.css';
 
-const SOCKET_URL = import.meta.env.VITE_SOCKET_URL || 'http://localhost:3001';
+const API_BASE = import.meta.env.VITE_API_BASE || window.location.origin;
 
 /** Format timestamp to HH:MM */
 function fmtTime(ts: number): string {
@@ -32,7 +32,7 @@ export default function MessageTicker() {
 
   // Connect to WebSocket
   useEffect(() => {
-    const socket = socketIO(SOCKET_URL, { transports: ['websocket', 'polling'] });
+    const socket = socketIO(API_BASE, { transports: ['websocket', 'polling'] });
     socketRef.current = socket;
 
     socket.on('connect', () => setConnected(true));
@@ -44,7 +44,7 @@ export default function MessageTicker() {
 
     // Fetch initial state; abort if this effect is cleaned up before it resolves
     const controller = new AbortController();
-    fetch(`${SOCKET_URL}/api/messages`, { signal: controller.signal })
+    fetch(`${API_BASE}/api/messages`, { signal: controller.signal })
       .then(r => r.json())
       .then(data => {
         if (data.messages) setMessages(data.messages);

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />


### PR DESCRIPTION
- [x] Fix `extractText` dead code (thinking/tool_use checks inside a `type==='text'` guard — always false)
- [x] Fix `getAgeClass` duplicate `return 'visible'` (second branch was dead code)
- [x] Fix `updateScrollParams`: `containerWidth` was unused; now added to `totalDistance` so content scrolls fully off-screen
- [x] Add `AbortController` to initial `fetch` in `MessageTicker` `useEffect` (React StrictMode safety)
- [x] Move `agentTranscriptPaths` declaration before first usage (`mapToAgentStates`)
- [x] Replace sequence-number scan with byte-offset file reading in `tailTranscript` (reads only new bytes each poll instead of the whole file; switch `statSync` → async `fs/promises.stat` to avoid blocking the event loop)
- [x] Prune expired messages from the rolling buffer in `pollMessages`
- [x] Fix `getAgeClass`: add periodic `now` state (30s interval) so messages actually fade after 3 min with no new data
- [x] Fully harden StrictMode: add `isCancelled` flag + named handlers + `socket.off` in cleanup
- [x] Remove dead `socketRef` (assigned but never read)
- [x] Fix `tailTranscript`: remove redundant `existsSync` (rely on `statAsync` try/catch)
- [x] Fix `tailTranscript`: move error handling from `rl.on('error')` to `stream.on('error')` with proper `rl.close()` + `stream.destroy()`
- [x] Add `isPolling` in-flight guard to `pollAndBroadcast` to prevent overlapping concurrent poll cycles
- [x] Normalize single-quote strings in ticker section to match file's double-quote style
- [x] Fix `tailTranscript` double-resolve race: `stream.on("error")` calls `rl.close()` which triggers `rl.on("close")` — added `errored` guard so the close handler skips offset update and doesn't resolve with partial data
- [x] Switch `MessageTicker` to relative URLs (`/api/messages` + no-arg `socketIO()`) matching other hooks — avoids CORS issues, works with Vite proxy
- [x] Add `@media (prefers-reduced-motion: reduce)` to disable ticker scroll animation for accessibility
- [x] Typecheck clean, CodeQL: 0 alerts