### PR TITLE
feat: Mobile/Touch support

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
     <title>OpenClaw Pixel Agents</title>
     <style>
       * { margin: 0; padding: 0; box-sizing: border-box; }

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>OpenClaw Pixel Agents</title>
     <style>
       * { margin: 0; padding: 0; box-sizing: border-box; }

--- a/src/App.css
+++ b/src/App.css
@@ -58,7 +58,7 @@
   cursor: pointer;
   transition: background 0.2s;
   /* Touch-friendly minimum size */
-  min-height: 36px;
+  min-height: 44px;
   min-width: 44px;
 }
 

--- a/src/App.css
+++ b/src/App.css
@@ -39,3 +39,94 @@
   display: flex;
   overflow: hidden;
 }
+
+/* ── Mobile Responsive ─────────────────────────────── */
+
+.header-controls {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.editor-toggle {
+  background: #0f3460;
+  color: #e0e0e0;
+  border: none;
+  border-radius: 4px;
+  padding: 6px 12px;
+  font-size: 12px;
+  cursor: pointer;
+  transition: background 0.2s;
+  /* Touch-friendly minimum size */
+  min-height: 36px;
+  min-width: 44px;
+}
+
+.editor-toggle:hover {
+  background: #1a4a7a;
+}
+
+.editor-toggle.active {
+  background: #e94560;
+  color: white;
+}
+
+@media (max-width: 768px) {
+  .app-header {
+    padding: 6px 10px;
+  }
+
+  .app-header h1 {
+    font-size: 13px;
+  }
+
+  .header-controls {
+    gap: 6px;
+  }
+
+  .app-main {
+    flex-direction: column;
+  }
+
+  /* Sidebar becomes a collapsible bottom drawer */
+  .app-main > .agent-sidebar {
+    width: 100%;
+    max-height: 40vh;
+    border-left: none;
+    border-top: 1px solid #0f3460;
+    order: 2;
+    padding: 8px;
+  }
+
+  /* Canvas wrapper takes remaining space */
+  .app-main > .office-wrapper {
+    flex: 1;
+    min-height: 0;
+    order: 1;
+  }
+}
+
+@media (max-width: 480px) {
+  .app-header h1 {
+    font-size: 11px;
+  }
+
+  .app-header h1 span {
+    display: none;
+  }
+
+  .header-controls {
+    flex-wrap: wrap;
+    gap: 4px;
+  }
+
+  /* Sidebar collapses to a peek bar, expandable on tap */
+  .app-main > .agent-sidebar {
+    max-height: 35vh;
+    padding: 6px;
+  }
+
+  .agent-card {
+    padding: 8px;
+  }
+}

--- a/src/components/AgentDetailPanel.css
+++ b/src/components/AgentDetailPanel.css
@@ -266,3 +266,39 @@
   background: rgba(108, 117, 125, 0.1);
   color: #6c757d;
 }
+
+/* ── Mobile: bottom sheet ── */
+
+@media (max-width: 768px) {
+  .detail-overlay {
+    align-items: flex-end;
+  }
+
+  .detail-panel {
+    width: 100%;
+    max-width: 100vw;
+    height: auto;
+    max-height: 70vh;
+    border-left: none;
+    border-top: 1px solid #2d2d4a;
+    border-radius: 12px 12px 0 0;
+    padding: 16px;
+    animation: slideUp 0.25s ease-out;
+  }
+
+  @keyframes slideUp {
+    from { transform: translateY(100%); }
+    to { transform: translateY(0); }
+  }
+
+  .detail-close {
+    width: 32px;
+    height: 32px;
+    font-size: 18px;
+  }
+
+  .detail-header {
+    gap: 10px;
+    margin-bottom: 16px;
+  }
+}

--- a/src/components/AgentDetailPanel.css
+++ b/src/components/AgentDetailPanel.css
@@ -283,18 +283,18 @@
     border-top: 1px solid #2d2d4a;
     border-radius: 12px 12px 0 0;
     padding: 16px;
-    animation: slideUp 0.25s ease-out;
+    animation: slide-up 0.25s ease-out;
   }
 
-  @keyframes slideUp {
+  @keyframes slide-up {
     from { transform: translateY(100%); }
     to { transform: translateY(0); }
   }
 
   .detail-close {
-    width: 32px;
-    height: 32px;
-    font-size: 18px;
+    width: 44px;
+    height: 44px;
+    font-size: 20px;
   }
 
   .detail-header {

--- a/src/components/AgentSidebar.css
+++ b/src/components/AgentSidebar.css
@@ -172,3 +172,45 @@
 .sidebar-footer button.danger:hover {
   background: #8c3030;
 }
+
+/* ── Mobile: horizontal scrollable agent strip ── */
+
+@media (max-width: 768px) {
+  .agent-sidebar {
+    width: 100%;
+    border-left: none;
+    border-top: 1px solid #0f3460;
+    padding: 8px;
+    overflow-x: auto;
+    overflow-y: hidden;
+  }
+
+  .agent-sidebar h2 {
+    font-size: 12px;
+    margin-bottom: 6px;
+  }
+
+  .agent-list {
+    flex-direction: row;
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    gap: 6px;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .agent-card {
+    min-width: 140px;
+    flex-shrink: 0;
+    padding: 8px;
+  }
+
+  .sidebar-footer {
+    flex-direction: row;
+    padding-top: 6px;
+  }
+
+  .sidebar-footer button {
+    font-size: 10px;
+    padding: 6px 6px;
+  }
+}

--- a/src/components/AgentSidebar.css
+++ b/src/components/AgentSidebar.css
@@ -211,6 +211,8 @@
 
   .sidebar-footer button {
     font-size: 10px;
-    padding: 6px 6px;
+    padding: 8px 6px;
+    min-height: 44px;
+    min-width: 44px;
   }
 }

--- a/src/components/PixelOffice.css
+++ b/src/components/PixelOffice.css
@@ -5,6 +5,9 @@
   justify-content: center;
   padding: 16px;
   position: relative;
+  overflow: hidden;
+  /* Allow touch scrolling to be captured by canvas */
+  touch-action: none;
 }
 
 .office-canvas {
@@ -15,6 +18,11 @@
   background: #0f0f23;
   max-width: 100%;
   max-height: 100%;
+  /* Prevent browser touch gestures on canvas (we handle our own) */
+  touch-action: none;
+  -webkit-touch-callout: none;
+  -webkit-user-select: none;
+  user-select: none;
 }
 
 .editor-badge {
@@ -36,4 +44,35 @@
 @keyframes pulse-badge {
   0%, 100% { opacity: 1; }
   50% { opacity: 0.7; }
+}
+
+/* ── Mobile ─────────────────────────────────────── */
+
+@media (max-width: 768px) {
+  .pixel-office {
+    padding: 8px;
+  }
+
+  .office-canvas {
+    /* Scale canvas to fit viewport width */
+    max-width: calc(100vw - 16px);
+    max-height: calc(60vh - 16px);
+  }
+
+  .editor-badge {
+    bottom: 10px;
+    font-size: 10px;
+    padding: 3px 8px;
+  }
+}
+
+@media (max-width: 480px) {
+  .pixel-office {
+    padding: 4px;
+  }
+
+  .office-canvas {
+    max-width: calc(100vw - 8px);
+    max-height: calc(55vh - 8px);
+  }
 }

--- a/src/components/PixelOffice.css
+++ b/src/components/PixelOffice.css
@@ -6,7 +6,7 @@
   padding: 16px;
   position: relative;
   overflow: hidden;
-  /* Allow touch scrolling to be captured by canvas */
+  /* Prevent native touch scrolling/gestures in this container (canvas handles them) */
   touch-action: none;
 }
 

--- a/src/game/GameEngine.ts
+++ b/src/game/GameEngine.ts
@@ -1419,10 +1419,14 @@ export class GameEngine {
     e.preventDefault(); // prevent mouse event synthesis & scroll
 
     if (e.touches.length === 2) {
-      // Pinch-to-zoom start
+      // Pinch-to-zoom start: cancel any active one-finger drag/tap state so that
+      // lifting all fingers after a pinch cannot accidentally finalize a furniture drag.
+      this.touchDragging = null;
+      this.touchStartPos = null;
+      this.touchCurrentPos = null;
+      this.touchMoved = true;
       this.pinchStartDist = this.touchDistance(e.touches[0], e.touches[1]);
       this.pinchStartZoom = this.cameraZoom;
-      this.touchMoved = true; // cancel any pending tap
       return;
     }
 
@@ -1489,12 +1493,12 @@ export class GameEngine {
     this.mouseGridX = gridX;
     this.mouseGridY = gridY;
 
-    // Editor mode: drag furniture
+    // Editor mode: drag furniture (subtract grab offset to keep furniture under finger)
     if (this.editorMode && this.touchDragging) {
       const item = this.placedFurniture.find(f => f.id === this.touchDragging!.id);
       if (item) {
-        item.x = Math.max(1, Math.min(this.config.gridWidth - 3, gridX));
-        item.y = Math.max(1, Math.min(this.config.gridHeight - 3, gridY));
+        item.x = Math.max(1, Math.min(this.config.gridWidth - 3, gridX - this.touchDragging.offsetX));
+        item.y = Math.max(1, Math.min(this.config.gridHeight - 3, gridY - this.touchDragging.offsetY));
       }
     }
   };
@@ -1510,11 +1514,12 @@ export class GameEngine {
       if (this.touchDragging) {
         // touchCurrentPos is always set alongside touchStartPos in handleTouchStart and kept
         // up-to-date in handleTouchMove, so it reliably reflects the finger's final position.
+        // Subtract the grab offset so the drop position matches what was shown during the drag.
         const { gridX, gridY } = this.screenToGrid(this.touchCurrentPos!.x, this.touchCurrentPos!.y);
         this.editorCallbacks?.onMoveFurniture(
           this.touchDragging.id,
-          Math.max(1, Math.min(this.config.gridWidth - 3, gridX)),
-          Math.max(1, Math.min(this.config.gridHeight - 3, gridY)),
+          Math.max(1, Math.min(this.config.gridWidth - 3, gridX - this.touchDragging.offsetX)),
+          Math.max(1, Math.min(this.config.gridHeight - 3, gridY - this.touchDragging.offsetY)),
         );
         sfx.place();
         this.touchDragging = null;

--- a/src/game/GameEngine.ts
+++ b/src/game/GameEngine.ts
@@ -1505,7 +1505,7 @@ export class GameEngine {
     // Pinch-to-zoom end — nothing extra to do
     if (e.touches.length > 0) return;
 
-    // Editor mode: finish furniture drag or place
+    // Editor mode: finish furniture drag, place, or double-tap rotate
     if (this.editorMode) {
       if (this.touchDragging) {
         // touchCurrentPos is always set alongside touchStartPos in handleTouchStart and kept
@@ -1518,11 +1518,29 @@ export class GameEngine {
         );
         sfx.place();
         this.touchDragging = null;
-      } else if (!this.touchMoved && this.selectedFurnitureType && this.touchStartPos) {
-        // Tap to place furniture
+      } else if (!this.touchMoved && this.touchStartPos) {
         const { gridX, gridY } = this.screenToGrid(this.touchStartPos.x, this.touchStartPos.y);
-        this.editorCallbacks?.onPlaceFurniture(this.selectedFurnitureType, gridX, gridY);
-        sfx.place();
+        const now = Date.now();
+
+        // Double-tap furniture → rotate (mirrors desktop right-click in editor mode)
+        if (now - this.lastTapTime < GameEngine.DOUBLE_TAP_MS) {
+          const hit = this.findFurnitureAt(gridX, gridY);
+          if (hit) {
+            hit.rotation = ((hit.rotation || 0) + 90) % 360;
+            sfx.place();
+            this.lastTapTime = 0;
+            this.touchStartPos = null;
+            this.touchCurrentPos = null;
+            return;
+          }
+        }
+        this.lastTapTime = now;
+
+        // Single tap to place furniture
+        if (this.selectedFurnitureType) {
+          this.editorCallbacks?.onPlaceFurniture(this.selectedFurnitureType, gridX, gridY);
+          sfx.place();
+        }
       }
       this.touchStartPos = null;
       this.touchCurrentPos = null;
@@ -1532,25 +1550,11 @@ export class GameEngine {
     // ── Non-editor: tap interactions ──
     if (this.touchMoved || !this.touchStartPos) {
       this.touchStartPos = null;
+      this.touchCurrentPos = null;
       return; // was a drag or pinch, not a tap
     }
 
     const { gridX, gridY } = this.screenToGrid(this.touchStartPos.x, this.touchStartPos.y);
-    const now = Date.now();
-
-    // Double-tap on furniture → rotate (equivalent to right-click)
-    if (now - this.lastTapTime < GameEngine.DOUBLE_TAP_MS) {
-      const hit = this.findFurnitureAt(gridX, gridY);
-      if (hit) {
-        hit.rotation = ((hit.rotation || 0) + 90) % 360;
-        sfx.place();
-        this.lastTapTime = 0; // reset to prevent triple-tap
-        this.touchStartPos = null;
-        this.touchCurrentPos = null;
-        return;
-      }
-    }
-    this.lastTapTime = now;
 
     const charId = this.findCharacterAt(gridX, gridY);
 

--- a/src/game/GameEngine.ts
+++ b/src/game/GameEngine.ts
@@ -225,10 +225,11 @@ export class GameEngine {
 
   // Touch state
   private touchStartPos: { x: number; y: number } | null = null;
-  private touchStartTime = 0;
+  private touchCurrentPos: { x: number; y: number } | null = null;
   private lastTapTime = 0;
   private pinchStartDist = 0;
   private pinchStartZoom = 1;
+  private cameraZoom = 1; // view-only zoom applied via CSS transform (independent of render zoom)
   private touchDragging: { id: string; offsetX: number; offsetY: number } | null = null;
   private touchMoved = false; // true once finger moves > threshold
 
@@ -334,7 +335,6 @@ export class GameEngine {
     this.canvas.removeEventListener('touchmove', this.handleTouchMove);
     this.canvas.removeEventListener('touchend', this.handleTouchEnd);
     this.canvas.removeEventListener('touchcancel', this.handleTouchCancel);
-    this.canvas.removeEventListener('keydown', this.handleKeyDown);
   }
 
   private loop = () => {
@@ -1414,7 +1414,6 @@ export class GameEngine {
 
   private static readonly TAP_THRESHOLD = 12; // px movement before it's a drag, not a tap
   private static readonly DOUBLE_TAP_MS = 300; // max interval between double-tap
-  private static readonly LONG_PRESS_MS = 500; // ms before long-press triggers
 
   private handleTouchStart = (e: TouchEvent) => {
     e.preventDefault(); // prevent mouse event synthesis & scroll
@@ -1422,14 +1421,14 @@ export class GameEngine {
     if (e.touches.length === 2) {
       // Pinch-to-zoom start
       this.pinchStartDist = this.touchDistance(e.touches[0], e.touches[1]);
-      this.pinchStartZoom = this.zoom;
+      this.pinchStartZoom = this.cameraZoom;
       this.touchMoved = true; // cancel any pending tap
       return;
     }
 
     const t = e.touches[0];
     this.touchStartPos = { x: t.clientX, y: t.clientY };
-    this.touchStartTime = Date.now();
+    this.touchCurrentPos = { x: t.clientX, y: t.clientY };
     this.touchMoved = false;
 
     const { gridX, gridY } = this.screenToGrid(t.clientX, t.clientY);
@@ -1457,10 +1456,19 @@ export class GameEngine {
     // Pinch-to-zoom
     if (e.touches.length === 2) {
       const dist = this.touchDistance(e.touches[0], e.touches[1]);
+
+      // Guard against zero/invalid starting distance (e.g., both fingers started at the
+      // same pixel): reinitialize from the first valid distance seen during move.
+      if (!this.pinchStartDist || this.pinchStartDist <= 0) {
+        if (dist <= 0) return;
+        this.pinchStartDist = dist;
+        this.pinchStartZoom = this.cameraZoom;
+      }
+
       const scale = dist / this.pinchStartDist;
       const newZoom = Math.max(1, Math.min(4, this.pinchStartZoom * scale));
-      this.zoom = newZoom;
-      this.canvas.style.transform = `scale(${this.zoom})`;
+      this.cameraZoom = newZoom;
+      this.canvas.style.transform = `scale(${this.cameraZoom})`;
       this.canvas.style.transformOrigin = 'center center';
       return;
     }
@@ -1473,6 +1481,9 @@ export class GameEngine {
     if (Math.abs(dx) > GameEngine.TAP_THRESHOLD || Math.abs(dy) > GameEngine.TAP_THRESHOLD) {
       this.touchMoved = true;
     }
+
+    // Track the latest finger position so handleTouchEnd can use the drop location
+    this.touchCurrentPos = { x: t.clientX, y: t.clientY };
 
     const { gridX, gridY } = this.screenToGrid(t.clientX, t.clientY);
     this.mouseGridX = gridX;
@@ -1497,9 +1508,9 @@ export class GameEngine {
     // Editor mode: finish furniture drag or place
     if (this.editorMode) {
       if (this.touchDragging) {
-        const { gridX, gridY } = this.screenToGrid(
-          this.touchStartPos!.x, this.touchStartPos!.y,
-        );
+        // touchCurrentPos is always set alongside touchStartPos in handleTouchStart and kept
+        // up-to-date in handleTouchMove, so it reliably reflects the finger's final position.
+        const { gridX, gridY } = this.screenToGrid(this.touchCurrentPos!.x, this.touchCurrentPos!.y);
         this.editorCallbacks?.onMoveFurniture(
           this.touchDragging.id,
           Math.max(1, Math.min(this.config.gridWidth - 3, gridX)),
@@ -1514,6 +1525,7 @@ export class GameEngine {
         sfx.place();
       }
       this.touchStartPos = null;
+      this.touchCurrentPos = null;
       return;
     }
 
@@ -1534,6 +1546,7 @@ export class GameEngine {
         sfx.place();
         this.lastTapTime = 0; // reset to prevent triple-tap
         this.touchStartPos = null;
+        this.touchCurrentPos = null;
         return;
       }
     }
@@ -1569,10 +1582,12 @@ export class GameEngine {
     }
 
     this.touchStartPos = null;
+    this.touchCurrentPos = null;
   };
 
   private handleTouchCancel = () => {
     this.touchStartPos = null;
+    this.touchCurrentPos = null;
     this.touchDragging = null;
     this.touchMoved = false;
     this.mouseGridX = -1;

--- a/src/game/GameEngine.ts
+++ b/src/game/GameEngine.ts
@@ -223,6 +223,15 @@ export class GameEngine {
   private selectedAgentId: string | null = null;
   private selectionPulse = 0; // for animated ring
 
+  // Touch state
+  private touchStartPos: { x: number; y: number } | null = null;
+  private touchStartTime = 0;
+  private lastTapTime = 0;
+  private pinchStartDist = 0;
+  private pinchStartZoom = 1;
+  private touchDragging: { id: string; offsetX: number; offsetY: number } | null = null;
+  private touchMoved = false; // true once finger moves > threshold
+
   // Day/night cycle
   private dayPhase = 0; // 0-1, loops continuously
   private static readonly DAY_CYCLE_SECONDS = 120; // full cycle duration
@@ -253,6 +262,11 @@ export class GameEngine {
     // Character click (non-editor mode)
     this.canvas.addEventListener('click', this.handleClick);
     this.canvas.addEventListener('keydown', this.handleKeyDown);
+    // Touch support
+    this.canvas.addEventListener('touchstart', this.handleTouchStart, { passive: false });
+    this.canvas.addEventListener('touchmove', this.handleTouchMove, { passive: false });
+    this.canvas.addEventListener('touchend', this.handleTouchEnd, { passive: false });
+    this.canvas.addEventListener('touchcancel', this.handleTouchCancel, { passive: false });
   }
 
   async init(signal?: AbortSignal) {
@@ -315,6 +329,11 @@ export class GameEngine {
     this.canvas.removeEventListener('mouseleave', this.handleMouseLeave);
     this.canvas.removeEventListener('contextmenu', this.handleContextMenu);
     this.canvas.removeEventListener('click', this.handleClick);
+    this.canvas.removeEventListener('keydown', this.handleKeyDown);
+    this.canvas.removeEventListener('touchstart', this.handleTouchStart);
+    this.canvas.removeEventListener('touchmove', this.handleTouchMove);
+    this.canvas.removeEventListener('touchend', this.handleTouchEnd);
+    this.canvas.removeEventListener('touchcancel', this.handleTouchCancel);
     this.canvas.removeEventListener('keydown', this.handleKeyDown);
   }
 
@@ -1238,13 +1257,17 @@ export class GameEngine {
 
   // ── Mouse handlers ───────────────────────────────────
 
-  private screenToGrid(e: MouseEvent): { gridX: number; gridY: number } {
+  private screenToGrid(e: MouseEvent): { gridX: number; gridY: number };
+  private screenToGrid(clientX: number, clientY: number): { gridX: number; gridY: number };
+  private screenToGrid(eOrX: MouseEvent | number, maybeY?: number): { gridX: number; gridY: number } {
     const rect = this.canvas.getBoundingClientRect();
     const scaleX = this.canvas.width / rect.width;
     const scaleY = this.canvas.height / rect.height;
+    const clientX = typeof eOrX === 'number' ? eOrX : eOrX.clientX;
+    const clientY = typeof eOrX === 'number' ? maybeY! : eOrX.clientY;
     return {
-      gridX: Math.floor((e.clientX - rect.left) * scaleX / this.config.tileSize),
-      gridY: Math.floor((e.clientY - rect.top) * scaleY / this.config.tileSize),
+      gridX: Math.floor((clientX - rect.left) * scaleX / this.config.tileSize),
+      gridY: Math.floor((clientY - rect.top) * scaleY / this.config.tileSize),
     };
   }
 
@@ -1386,6 +1409,182 @@ export class GameEngine {
       this.canvas.style.cursor = 'default';
     }
   };
+
+  // ── Touch Event Handlers ─────────────────────────────
+
+  private static readonly TAP_THRESHOLD = 12; // px movement before it's a drag, not a tap
+  private static readonly DOUBLE_TAP_MS = 300; // max interval between double-tap
+  private static readonly LONG_PRESS_MS = 500; // ms before long-press triggers
+
+  private handleTouchStart = (e: TouchEvent) => {
+    e.preventDefault(); // prevent mouse event synthesis & scroll
+
+    if (e.touches.length === 2) {
+      // Pinch-to-zoom start
+      this.pinchStartDist = this.touchDistance(e.touches[0], e.touches[1]);
+      this.pinchStartZoom = this.zoom;
+      this.touchMoved = true; // cancel any pending tap
+      return;
+    }
+
+    const t = e.touches[0];
+    this.touchStartPos = { x: t.clientX, y: t.clientY };
+    this.touchStartTime = Date.now();
+    this.touchMoved = false;
+
+    const { gridX, gridY } = this.screenToGrid(t.clientX, t.clientY);
+    this.mouseGridX = gridX;
+    this.mouseGridY = gridY;
+
+    // Editor mode: start dragging furniture immediately on touch
+    if (this.editorMode && e.touches.length === 1) {
+      if (this.selectedFurnitureType) {
+        // Will place on touchend if not moved
+      } else {
+        const hit = this.findFurnitureAt(gridX, gridY);
+        if (hit) {
+          this.touchDragging = { id: hit.id, offsetX: gridX - hit.x, offsetY: gridY - hit.y };
+          this.selectedFurnitureId = hit.id;
+          this.editorCallbacks?.onSelectFurniture(hit.id);
+        }
+      }
+    }
+  };
+
+  private handleTouchMove = (e: TouchEvent) => {
+    e.preventDefault();
+
+    // Pinch-to-zoom
+    if (e.touches.length === 2) {
+      const dist = this.touchDistance(e.touches[0], e.touches[1]);
+      const scale = dist / this.pinchStartDist;
+      const newZoom = Math.max(1, Math.min(4, this.pinchStartZoom * scale));
+      this.zoom = newZoom;
+      this.canvas.style.transform = `scale(${this.zoom})`;
+      this.canvas.style.transformOrigin = 'center center';
+      return;
+    }
+
+    if (!this.touchStartPos) return;
+    const t = e.touches[0];
+    const dx = t.clientX - this.touchStartPos.x;
+    const dy = t.clientY - this.touchStartPos.y;
+
+    if (Math.abs(dx) > GameEngine.TAP_THRESHOLD || Math.abs(dy) > GameEngine.TAP_THRESHOLD) {
+      this.touchMoved = true;
+    }
+
+    const { gridX, gridY } = this.screenToGrid(t.clientX, t.clientY);
+    this.mouseGridX = gridX;
+    this.mouseGridY = gridY;
+
+    // Editor mode: drag furniture
+    if (this.editorMode && this.touchDragging) {
+      const item = this.placedFurniture.find(f => f.id === this.touchDragging!.id);
+      if (item) {
+        item.x = Math.max(1, Math.min(this.config.gridWidth - 3, gridX));
+        item.y = Math.max(1, Math.min(this.config.gridHeight - 3, gridY));
+      }
+    }
+  };
+
+  private handleTouchEnd = (e: TouchEvent) => {
+    e.preventDefault();
+
+    // Pinch-to-zoom end — nothing extra to do
+    if (e.touches.length > 0) return;
+
+    // Editor mode: finish furniture drag or place
+    if (this.editorMode) {
+      if (this.touchDragging) {
+        const { gridX, gridY } = this.screenToGrid(
+          this.touchStartPos!.x, this.touchStartPos!.y,
+        );
+        this.editorCallbacks?.onMoveFurniture(
+          this.touchDragging.id,
+          Math.max(1, Math.min(this.config.gridWidth - 3, gridX)),
+          Math.max(1, Math.min(this.config.gridHeight - 3, gridY)),
+        );
+        sfx.place();
+        this.touchDragging = null;
+      } else if (!this.touchMoved && this.selectedFurnitureType && this.touchStartPos) {
+        // Tap to place furniture
+        const { gridX, gridY } = this.screenToGrid(this.touchStartPos.x, this.touchStartPos.y);
+        this.editorCallbacks?.onPlaceFurniture(this.selectedFurnitureType, gridX, gridY);
+        sfx.place();
+      }
+      this.touchStartPos = null;
+      return;
+    }
+
+    // ── Non-editor: tap interactions ──
+    if (this.touchMoved || !this.touchStartPos) {
+      this.touchStartPos = null;
+      return; // was a drag or pinch, not a tap
+    }
+
+    const { gridX, gridY } = this.screenToGrid(this.touchStartPos.x, this.touchStartPos.y);
+    const now = Date.now();
+
+    // Double-tap on furniture → rotate (equivalent to right-click)
+    if (now - this.lastTapTime < GameEngine.DOUBLE_TAP_MS) {
+      const hit = this.findFurnitureAt(gridX, gridY);
+      if (hit) {
+        hit.rotation = ((hit.rotation || 0) + 90) % 360;
+        sfx.place();
+        this.lastTapTime = 0; // reset to prevent triple-tap
+        this.touchStartPos = null;
+        return;
+      }
+    }
+    this.lastTapTime = now;
+
+    const charId = this.findCharacterAt(gridX, gridY);
+
+    if (charId && !charId.startsWith('sub-')) {
+      // Tap agent → select
+      this.selectedAgentId = charId;
+      this.selectionPulse = 0;
+      sfx.click();
+      this.gameCallbacks?.onCharacterClick(charId);
+    } else if (this.selectedAgentId) {
+      // Tap empty tile → move selected agent
+      const char = this.characters.get(this.selectedAgentId);
+      if (char) {
+        this.ensureObstacles();
+        if (this.obstacleGrid && gridY >= 0 && gridY < this.config.gridHeight
+            && gridX >= 0 && gridX < this.config.gridWidth
+            && !this.obstacleGrid[gridY][gridX]) {
+          char.targetX = gridX;
+          char.targetY = gridY;
+          char.path = this.computePath(char);
+          char.pathIndex = 0;
+          sfx.footstep();
+        }
+      }
+      this.selectedAgentId = null;
+    } else {
+      // Tap empty tile, no agent selected → deselect
+      this.selectedAgentId = null;
+    }
+
+    this.touchStartPos = null;
+  };
+
+  private handleTouchCancel = () => {
+    this.touchStartPos = null;
+    this.touchDragging = null;
+    this.touchMoved = false;
+    this.mouseGridX = -1;
+    this.mouseGridY = -1;
+  };
+
+  /** Euclidean distance between two touch points */
+  private touchDistance(a: Touch, b: Touch): number {
+    const dx = a.clientX - b.clientX;
+    const dy = a.clientY - b.clientY;
+    return Math.sqrt(dx * dx + dy * dy);
+  }
 
   // ── Helpers ──────────────────────────────────────────
 


### PR DESCRIPTION
- [x] Previous review comments applied (a9db5dc)
- [x] Fix 1: Cancel active drag/tap state (`touchDragging`, `touchStartPos`, `touchCurrentPos`) when pinch-zoom starts, so pinch-end cannot accidentally finalize a furniture drag
- [x] Fix 2: Apply `offsetX/offsetY` grab offset in both `handleTouchMove` and `handleTouchEnd` so furniture stays under the initial grab point during drag
- [x] Fix 3: Updated misleading `touch-action: none` comment in `PixelOffice.css`
- [x] Typecheck passes, CodeQL clean, code review clean — ready to merge