### PR TITLE
fix(P0.1): eliminate canvas memory leak in getSpriteFrame

### DIFF
--- a/src/game/SpriteLoader.ts
+++ b/src/game/SpriteLoader.ts
@@ -43,6 +43,7 @@ export interface LoadedCharacter {
   down: SpriteFrame[];
   up: SpriteFrame[];
   right: SpriteFrame[];
+  left: SpriteFrame[]; // Pre-flipped for performance
 }
 
 export interface LoadedFurnitureItem {
@@ -105,7 +106,14 @@ function flipHorizontal(source: HTMLCanvasElement): HTMLCanvasElement {
   return canvas;
 }
 
-// ── Public loaders ─────────────────────────────────────────
+/** Create left-facing frames by flipping right frames */
+function createLeftFrames(rightFrames: SpriteFrame[]): SpriteFrame[] {
+  return rightFrames.map(frame => ({
+    canvas: flipHorizontal(frame.canvas),
+    width: frame.width,
+    height: frame.height,
+  }));
+}
 
 /**
  * Load all 6 character sprite sheets from /assets/characters/char_0..5.png
@@ -122,7 +130,7 @@ export async function loadCharacters(
     const path = `${basePath}char_${i}.png`;
     const bitmap = await loadPng(path, signal);
 
-    const byDir: LoadedCharacter = { down: [], up: [], right: [] };
+    const byDir: LoadedCharacter = { down: [], up: [], right: [], left: [] };
 
     for (let dirIdx = 0; dirIdx < CHARACTER_DIRS.length; dirIdx++) {
       const dir = CHARACTER_DIRS[dirIdx];
@@ -142,6 +150,9 @@ export async function loadCharacters(
 
       byDir[dir] = frames;
     }
+
+    // Pre-generate left frames from right frames
+    byDir.left = createLeftFrames(byDir.right);
 
     characters.push(byDir);
   }
@@ -339,11 +350,14 @@ function composedToLoaded(composed: ComposedCharacter): LoadedCharacter {
   const toFrames = (canvases: HTMLCanvasElement[]): SpriteFrame[] =>
     canvases.map(canvas => ({ canvas, width: OUT_FRAME_W, height: OUT_FRAME_H }));
 
+  const rightFrames = toFrames(composed.right);
+
   // The compositor outputs are already in the correct format (3 dirs × 7 frames)
   return {
     down: toFrames(composed.down),
     up: toFrames(composed.up),
-    right: toFrames(composed.right),
+    right: rightFrames,
+    left: createLeftFrames(rightFrames), // Pre-flip left frames
   };
 }
 
@@ -375,13 +389,8 @@ export function getSpriteFrame(
   const [startIdx, count] = FRAME_RANGES[state];
   const frameIdx = startIdx + (frameTick % count);
 
-  // "left" is "right" flipped horizontally
-  if (dir === 'left') {
-    const rightFrame = character.right[frameIdx];
-    return flipHorizontal(rightFrame.canvas);
-  }
-
-  const dirFrames = character[dir as 'down' | 'up' | 'right'];
+  // All directions now have pre-cached frames
+  const dirFrames = character[dir];
   return dirFrames[frameIdx].canvas;
 }
 


### PR DESCRIPTION
Pre-flip left-facing character frames during asset loading instead of creating new canvases every frame. This fixes a critical memory leak where hundreds of canvas elements were created per second when characters faced left.

Changes:
- Add `left: SpriteFrame[]` to LoadedCharacter interface
- Add createLeftFrames() helper to pre-flip right frames
- Update loadCharacters() to populate left frames
- Update composedToLoaded() to pre-flip left frames
- Simplify getSpriteFrame() to use cached left frames


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Performance Improvements**
  * Optimized character sprite rendering by pre-generating left-facing animation frames during asset loading, reducing computational overhead during gameplay for smoother character animations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->