### PR TITLE
Fix/p0 4 prune read offsets

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -525,9 +525,18 @@ async function pollAndBroadcast(): Promise<void> {
   try {
     const { sessions } = await pollSessions();
     const agentList = mapToAgentStates(sessions);
-
-    // Broadcast to all connected WebSocket clients
-    io.emit("agents:update", agentList);
+    
+    // Create immutable snapshot before any async operations
+    const snapshot = agentList.map(a => ({ ...a }));
+    
+    // Update global state atomically
+    agentStates.clear();
+    for (const agent of agentList) {
+      agentStates.set(agent.id, agent);
+    }
+    
+    // Broadcast the snapshot (not the mutable global state)
+    io.emit("agents:update", snapshot);
 
     // Poll messages from transcripts
     await pollMessages();

--- a/server/index.ts
+++ b/server/index.ts
@@ -471,8 +471,12 @@ async function tailTranscript(
 async function pollMessages(): Promise<void> {
   const promises: Promise<TickerMessage[]>[] = [];
 
+  // Collect active agent IDs for pruning
+  const activeAgentIds = new Set<string>();
+
   for (const [agentId, state] of agentStates) {
     if (!state.active) continue;
+    activeAgentIds.add(agentId);
 
     const known = AGENT_REGISTRY.get(agentId);
     if (!known) continue;
@@ -482,6 +486,9 @@ async function pollMessages(): Promise<void> {
       promises.push(tailTranscript(agentId, known.name, transcriptPath));
     }
   }
+
+  // Prune read offsets for inactive agents
+  pruneReadOffsets(activeAgentIds);
 
   const results = await Promise.all(promises);
   const newMsgs = results.flat();
@@ -507,6 +514,16 @@ async function pollMessages(): Promise<void> {
   // Broadcast whenever the snapshot changed (new messages OR pruning)
   if (newMsgs.length > 0 || pruned) {
     io.emit("ticker:messages", tickerMessages);
+  }
+}
+
+/** Prune read offsets for agents that are no longer active */
+function pruneReadOffsets(activeAgentIds: Set<string>): void {
+  for (const key of lastReadOffset.keys()) {
+    const agentId = key.split(':')[0];
+    if (!activeAgentIds.has(agentId)) {
+      lastReadOffset.delete(key);
+    }
   }
 }
 


### PR DESCRIPTION
This pull request improves the management of agent state and resource cleanup in the `server/index.ts` file. The main changes focus on ensuring that read offsets are properly pruned for inactive agents, and that agent state updates and broadcasts are handled more safely and efficiently.

**Agent lifecycle and resource management:**

* Added logic to collect active agent IDs during polling and prune read offsets for agents that are no longer active, preventing stale data from accumulating (`pollMessages`, `pruneReadOffsets`) [[1]](diffhunk://#diff-786114c6ebf98e577ec30dac884800bb7c9ce800b5323710ed03b916e1d33b68R474-R479) [[2]](diffhunk://#diff-786114c6ebf98e577ec30dac884800bb7c9ce800b5323710ed03b916e1d33b68R490-R492) [[3]](diffhunk://#diff-786114c6ebf98e577ec30dac884800bb7c9ce800b5323710ed03b916e1d33b68R520-R529).

**State update and broadcasting improvements:**

* In `pollAndBroadcast`, refactored the update process to create an immutable snapshot of agent state before broadcasting to WebSocket clients and updating the global state atomically. This prevents clients from seeing partially updated or inconsistent state (`pollAndBroadcast`).