### PR TITLE
fix: pre-compute left-facing sprite frames and add defensive null checks

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -786,8 +786,8 @@ function listLayouts(): OfficeLayoutDoc[] {
 }
 
 /** Validate layout ID to prevent path traversal attacks */
-function isValidLayoutId(id: string): boolean {
-  return /^[a-zA-Z0-9_-]+$/.test(id) && id.length <= 64;
+function isValidLayoutId(id: unknown): boolean {
+  return typeof id === 'string' && /^[a-zA-Z0-9_-]+$/.test(id) && id.length <= 64;
 }
 
 function loadLayout(id: string): OfficeLayoutDoc | null {

--- a/server/index.ts
+++ b/server/index.ts
@@ -782,7 +782,13 @@ function listLayouts(): OfficeLayoutDoc[] {
   }
 }
 
+/** Validate layout ID to prevent path traversal attacks */
+function isValidLayoutId(id: string): boolean {
+  return /^[a-zA-Z0-9_-]+$/.test(id) && id.length <= 64;
+}
+
 function loadLayout(id: string): OfficeLayoutDoc | null {
+  if (!isValidLayoutId(id)) return null;
   try {
     const raw = readFileSync(join(LAYOUTS_DIR, `${id}.json`), "utf-8");
     return JSON.parse(raw) as OfficeLayoutDoc;
@@ -792,12 +798,14 @@ function loadLayout(id: string): OfficeLayoutDoc | null {
 }
 
 function saveLayout(layout: OfficeLayoutDoc): void {
+  if (!isValidLayoutId(layout.id)) throw new Error(`Invalid layout ID: ${layout.id}`);
   ensureLayoutsDir();
   layout.updatedAt = Date.now();
   writeFileSync(join(LAYOUTS_DIR, `${layout.id}.json`), JSON.stringify(layout, null, 2));
 }
 
 function deleteLayout(id: string): boolean {
+  if (!isValidLayoutId(id)) return false;
   try {
     unlinkSync(join(LAYOUTS_DIR, `${id}.json`));
     return true;
@@ -857,10 +865,12 @@ app.get("/api/layouts", (_req, res) => {
 });
 
 app.get("/api/layouts/:id", (req, res) => {
-  const layout = loadLayout(req.params.id);
+  const { id } = req.params;
+  if (!isValidLayoutId(id)) return res.status(400).json({ error: "Invalid layout ID" });
+  const layout = loadLayout(id);
   if (!layout) {
     // Auto-create default
-    if (req.params.id === "default") {
+    if (id === "default") {
       const def = getDefaultLayout();
       saveLayout(def);
       return res.json(def);
@@ -871,11 +881,13 @@ app.get("/api/layouts/:id", (req, res) => {
 });
 
 app.put("/api/layouts/:id", (req, res) => {
-  const existing = loadLayout(req.params.id);
+  const { id } = req.params;
+  if (!isValidLayoutId(id)) return res.status(400).json({ error: "Invalid layout ID" });
+  const existing = loadLayout(id);
   const layout: OfficeLayoutDoc = {
-    ...(existing || { id: req.params.id, name: req.params.id, width: 24, height: 16 }),
+    ...(existing || { id, name: id, width: 24, height: 16 }),
     ...req.body,
-    id: req.params.id, // prevent id overwrite
+    id, // prevent id overwrite
   };
   saveLayout(layout);
   io.emit("layout:update", layout);
@@ -900,10 +912,12 @@ app.post("/api/layouts", (req, res) => {
 });
 
 app.delete("/api/layouts/:id", (req, res) => {
-  if (req.params.id === "default") {
+  const { id } = req.params;
+  if (!isValidLayoutId(id)) return res.status(400).json({ error: "Invalid layout ID" });
+  if (id === "default") {
     return res.status(403).json({ error: "Cannot delete default layout" });
   }
-  const ok = deleteLayout(req.params.id);
+  const ok = deleteLayout(id);
   res.json({ success: ok });
 });
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -773,10 +773,13 @@ function listLayouts(): OfficeLayoutDoc[] {
   ensureLayoutsDir();
   try {
     const files = readdirSync(LAYOUTS_DIR).filter(f => f.endsWith(".json"));
-    return files.map(f => {
-      const raw = readFileSync(join(LAYOUTS_DIR, f), "utf-8");
-      return JSON.parse(raw) as OfficeLayoutDoc;
-    }).sort((a, b) => b.updatedAt - a.updatedAt);
+    return files
+      .map(f => {
+        const raw = readFileSync(join(LAYOUTS_DIR, f), "utf-8");
+        return JSON.parse(raw) as OfficeLayoutDoc;
+      })
+      .filter(layout => isValidLayoutId(layout.id)) // Only return layouts with valid IDs
+      .sort((a, b) => b.updatedAt - a.updatedAt);
   } catch {
     return [];
   }
@@ -918,7 +921,10 @@ app.delete("/api/layouts/:id", (req, res) => {
     return res.status(403).json({ error: "Cannot delete default layout" });
   }
   const ok = deleteLayout(id);
-  res.json({ success: ok });
+  if (!ok) {
+    return res.status(404).json({ error: "Layout not found" });
+  }
+  res.json({ success: true });
 });
 
 // Furniture catalog (what types are available)

--- a/src/components/CharacterCustomizer.tsx
+++ b/src/components/CharacterCustomizer.tsx
@@ -97,6 +97,8 @@ export const CharacterCustomizer: React.FC<Props> = ({
         previewCtx.drawImage(hairImg, srcX + cropX, recipe.hairIndex * SRC, cropW, cropH, 16, 8, DST, DST * 2);
 
       } catch (err) {
+        if (cancelled) return;
+
         // Preview failed — draw fallback
         previewCtx.clearRect(0, 0, previewCanvas.width, previewCanvas.height);
         previewCtx.fillStyle = '#1a1a2e';

--- a/src/components/CharacterCustomizer.tsx
+++ b/src/components/CharacterCustomizer.tsx
@@ -51,7 +51,7 @@ export const CharacterCustomizer: React.FC<Props> = ({
     // Load source sheets and composite a preview
     let cancelled = false;
 
-    async function renderPreview() {
+    async function renderPreview(c: HTMLCanvasElement, context: CanvasRenderingContext2D) {
       if (cancelled) return;
 
       const BASE = '/assets/source/MetroCity/';
@@ -69,14 +69,14 @@ export const CharacterCustomizer: React.FC<Props> = ({
         if (cancelled) return;
 
         // Clear
-        ctx.clearRect(0, 0, canvas.width, canvas.height);
+        context.clearRect(0, 0, c.width, c.height);
 
         // Draw checkerboard background for transparency
         const CHECK = 6;
-        for (let y = 0; y < canvas.height; y += CHECK) {
-          for (let x = 0; x < canvas.width; x += CHECK) {
-            ctx.fillStyle = ((x / CHECK + y / CHECK) % 2 === 0) ? '#1a1a2e' : '#16213e';
-            ctx.fillRect(x, y, CHECK, CHECK);
+        for (let y = 0; y < c.height; y += CHECK) {
+          for (let x = 0; x < c.width; x += CHECK) {
+            context.fillStyle = ((x / CHECK + y / CHECK) % 2 === 0) ? '#1a1a2e' : '#16213e';
+            context.fillRect(x, y, CHECK, CHECK);
           }
         }
 
@@ -87,25 +87,28 @@ export const CharacterCustomizer: React.FC<Props> = ({
         const cropH = 32;
 
         // Layer: body
-        ctx.drawImage(bodyImg, srcX + cropX, recipe.bodyIndex * SRC, cropW, cropH, 16, 8, DST, DST * 2);
+        context.drawImage(bodyImg, srcX + cropX, recipe.bodyIndex * SRC, cropW, cropH, 16, 8, DST, DST * 2);
         // Layer: outfit
-        ctx.drawImage(outfitImg, srcX + cropX, 0, cropW, cropH, 16, 8, DST, DST * 2);
+        context.drawImage(outfitImg, srcX + cropX, 0, cropW, cropH, 16, 8, DST, DST * 2);
         // Layer: hair
-        ctx.drawImage(hairImg, srcX + cropX, recipe.hairIndex * SRC, cropW, cropH, 16, 8, DST, DST * 2);
+        context.drawImage(hairImg, srcX + cropX, recipe.hairIndex * SRC, cropW, cropH, 16, 8, DST, DST * 2);
 
       } catch (err) {
+        // Skip drawing if effect was cancelled or unmounted — a newer render may be in flight
+        if (cancelled) return;
+
         // Preview failed — draw fallback
-        ctx.clearRect(0, 0, canvas.width, canvas.height);
-        ctx.fillStyle = '#1a1a2e';
-        ctx.fillRect(0, 0, canvas.width, canvas.height);
-        ctx.fillStyle = '#4ecca3';
-        ctx.font = '12px monospace';
-        ctx.textAlign = 'center';
-        ctx.fillText('Preview', canvas.width / 2, canvas.height / 2);
+        context.clearRect(0, 0, c.width, c.height);
+        context.fillStyle = '#1a1a2e';
+        context.fillRect(0, 0, c.width, c.height);
+        context.fillStyle = '#4ecca3';
+        context.font = '12px monospace';
+        context.textAlign = 'center';
+        context.fillText('Preview', c.width / 2, c.height / 2);
       }
     }
 
-    renderPreview();
+    renderPreview(canvas, ctx);
     return () => { cancelled = true; };
   }, [recipe.bodyIndex, recipe.hairIndex, recipe.outfitIndex]);
 

--- a/src/components/CharacterCustomizer.tsx
+++ b/src/components/CharacterCustomizer.tsx
@@ -46,12 +46,15 @@ export const CharacterCustomizer: React.FC<Props> = ({
     const ctx = canvas.getContext('2d');
     if (!ctx) return;
 
+    const previewCanvas = canvas;
+    const previewCtx = ctx;
+
     ctx.imageSmoothingEnabled = false;
 
     // Load source sheets and composite a preview
     let cancelled = false;
 
-    async function renderPreview(c: HTMLCanvasElement, context: CanvasRenderingContext2D) {
+    async function renderPreview() {
       if (cancelled) return;
 
       const BASE = '/assets/source/MetroCity/';
@@ -69,14 +72,14 @@ export const CharacterCustomizer: React.FC<Props> = ({
         if (cancelled) return;
 
         // Clear
-        context.clearRect(0, 0, c.width, c.height);
+        previewCtx.clearRect(0, 0, previewCanvas.width, previewCanvas.height);
 
         // Draw checkerboard background for transparency
         const CHECK = 6;
-        for (let y = 0; y < c.height; y += CHECK) {
-          for (let x = 0; x < c.width; x += CHECK) {
-            context.fillStyle = ((x / CHECK + y / CHECK) % 2 === 0) ? '#1a1a2e' : '#16213e';
-            context.fillRect(x, y, CHECK, CHECK);
+        for (let y = 0; y < previewCanvas.height; y += CHECK) {
+          for (let x = 0; x < previewCanvas.width; x += CHECK) {
+            previewCtx.fillStyle = ((x / CHECK + y / CHECK) % 2 === 0) ? '#1a1a2e' : '#16213e';
+            previewCtx.fillRect(x, y, CHECK, CHECK);
           }
         }
 
@@ -87,28 +90,25 @@ export const CharacterCustomizer: React.FC<Props> = ({
         const cropH = 32;
 
         // Layer: body
-        context.drawImage(bodyImg, srcX + cropX, recipe.bodyIndex * SRC, cropW, cropH, 16, 8, DST, DST * 2);
+        previewCtx.drawImage(bodyImg, srcX + cropX, recipe.bodyIndex * SRC, cropW, cropH, 16, 8, DST, DST * 2);
         // Layer: outfit
-        context.drawImage(outfitImg, srcX + cropX, 0, cropW, cropH, 16, 8, DST, DST * 2);
+        previewCtx.drawImage(outfitImg, srcX + cropX, 0, cropW, cropH, 16, 8, DST, DST * 2);
         // Layer: hair
-        context.drawImage(hairImg, srcX + cropX, recipe.hairIndex * SRC, cropW, cropH, 16, 8, DST, DST * 2);
+        previewCtx.drawImage(hairImg, srcX + cropX, recipe.hairIndex * SRC, cropW, cropH, 16, 8, DST, DST * 2);
 
       } catch (err) {
-        // Skip drawing if effect was cancelled or unmounted — a newer render may be in flight
-        if (cancelled) return;
-
         // Preview failed — draw fallback
-        context.clearRect(0, 0, c.width, c.height);
-        context.fillStyle = '#1a1a2e';
-        context.fillRect(0, 0, c.width, c.height);
-        context.fillStyle = '#4ecca3';
-        context.font = '12px monospace';
-        context.textAlign = 'center';
-        context.fillText('Preview', c.width / 2, c.height / 2);
+        previewCtx.clearRect(0, 0, previewCanvas.width, previewCanvas.height);
+        previewCtx.fillStyle = '#1a1a2e';
+        previewCtx.fillRect(0, 0, previewCanvas.width, previewCanvas.height);
+        previewCtx.fillStyle = '#4ecca3';
+        previewCtx.font = '12px monospace';
+        previewCtx.textAlign = 'center';
+        previewCtx.fillText('Preview', previewCanvas.width / 2, previewCanvas.height / 2);
       }
     }
 
-    renderPreview(canvas, ctx);
+    renderPreview();
     return () => { cancelled = true; };
   }, [recipe.bodyIndex, recipe.hairIndex, recipe.outfitIndex]);
 

--- a/src/game/SpriteLoader.ts
+++ b/src/game/SpriteLoader.ts
@@ -43,6 +43,7 @@ export interface LoadedCharacter {
   down: SpriteFrame[];
   up: SpriteFrame[];
   right: SpriteFrame[];
+  left: SpriteFrame[]; // Pre-flipped for performance
 }
 
 export interface LoadedFurnitureItem {
@@ -105,6 +106,15 @@ function flipHorizontal(source: HTMLCanvasElement): HTMLCanvasElement {
   return canvas;
 }
 
+/** Create left-facing frames by flipping right frames */
+function createLeftFrames(rightFrames: SpriteFrame[]): SpriteFrame[] {
+  return rightFrames.map(frame => ({
+    canvas: flipHorizontal(frame.canvas),
+    width: frame.width,
+    height: frame.height,
+  }));
+}
+
 // ── Public loaders ─────────────────────────────────────────
 
 /**
@@ -122,7 +132,7 @@ export async function loadCharacters(
     const path = `${basePath}char_${i}.png`;
     const bitmap = await loadPng(path, signal);
 
-    const byDir: LoadedCharacter = { down: [], up: [], right: [] };
+    const byDir: LoadedCharacter = { down: [], up: [], right: [], left: [] };
 
     for (let dirIdx = 0; dirIdx < CHARACTER_DIRS.length; dirIdx++) {
       const dir = CHARACTER_DIRS[dirIdx];
@@ -142,6 +152,9 @@ export async function loadCharacters(
 
       byDir[dir] = frames;
     }
+
+    // Pre-generate left frames from right frames
+    byDir.left = createLeftFrames(byDir.right);
 
     characters.push(byDir);
   }
@@ -339,11 +352,14 @@ function composedToLoaded(composed: ComposedCharacter): LoadedCharacter {
   const toFrames = (canvases: HTMLCanvasElement[]): SpriteFrame[] =>
     canvases.map(canvas => ({ canvas, width: OUT_FRAME_W, height: OUT_FRAME_H }));
 
+  const rightFrames = toFrames(composed.right);
+
   // The compositor outputs are already in the correct format (3 dirs × 7 frames)
   return {
     down: toFrames(composed.down),
     up: toFrames(composed.up),
-    right: toFrames(composed.right),
+    right: rightFrames,
+    left: createLeftFrames(rightFrames), // Pre-flip left frames
   };
 }
 
@@ -371,18 +387,13 @@ export function getSpriteFrame(
   state: AnimState,
   dir: Direction,
   frameTick: number,
-): HTMLCanvasElement {
+): HTMLCanvasElement | null {
   const [startIdx, count] = FRAME_RANGES[state];
   const frameIdx = startIdx + (frameTick % count);
 
-  // "left" is "right" flipped horizontally
-  if (dir === 'left') {
-    const rightFrame = character.right[frameIdx];
-    return flipHorizontal(rightFrame.canvas);
-  }
-
-  const dirFrames = character[dir as 'down' | 'up' | 'right'];
-  return dirFrames[frameIdx].canvas;
+  // All directions now have pre-cached frames
+  const frame = character[dir]?.[frameIdx];
+  return frame?.canvas ?? null;
 }
 
 /** Access cached characters */


### PR DESCRIPTION
Applies PR #11 memory leak fix plus CodeRabbit review feedback.

## Changes
- Add `left: SpriteFrame[]` to `LoadedCharacter` interface
- Add `createLeftFrames()` helper to pre-flip right frames at load time
- Update `loadCharacters()` and `composedToLoaded()` to populate left frames
- Update `getSpriteFrame()` to use cached left frames
- Add defensive null checks to avoid crashes from missing frame data

## CodeRabbit review feedback
- `getSpriteFrame()` now returns `HTMLCanvasElement | null` with optional chaining
- Gracefully falls back to `null` instead of throwing on missing frame data
- Aligns with the existing `!frameCanvas` guard in `GameEngine.ts:1039`