### PR TITLE
fix: create immutable snapshot before async pollMessages in pollAndBroadcast

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -239,7 +239,7 @@ function inferActivity(session: CliSession): AgentActivity {
  * Aggregates sessions by agentId — picks the most recently updated session
  * to determine the agent's current activity.
  */
-function mapToAgentStates(cliSessions: CliSession[]): AgentState[] {
+function mapToAgentStates(cliSessions: CliSession[]): Map<string, AgentState> {
   // Group sessions by agentId
   const byAgent = new Map<string, CliSession[]>();
   for (const s of cliSessions) {
@@ -250,7 +250,7 @@ function mapToAgentStates(cliSessions: CliSession[]): AgentState[] {
     byAgent.set(agentId, list);
   }
 
-  const results: AgentState[] = [];
+  const results = new Map<string, AgentState>();
 
   // Process all registered agents (including those without active sessions)
   for (const [agentId, known] of AGENT_REGISTRY) {
@@ -269,7 +269,7 @@ function mapToAgentStates(cliSessions: CliSession[]): AgentState[] {
         agentTranscriptPaths.set(agentId, transcriptPath);
       }
 
-      const state: AgentState = {
+      results.set(agentId, {
         id: agentId,
         name: known.name,
         activity,
@@ -299,12 +299,10 @@ function mapToAgentStates(cliSessions: CliSession[]): AgentState[] {
             status: s.status === "completed" ? "completed" as const : s.abortedLastRun ? "failed" as const : "running" as const,
           })),
         sessionUptime: latestSession.updatedAt ? (Date.now() - latestSession.updatedAt) / 1000 : undefined,
-      };
-      agentStates.set(agentId, state);
-      results.push(state);
+      });
     } else {
       // No active session — agent is sleeping
-      const state: AgentState = {
+      results.set(agentId, {
         id: agentId,
         name: known.name,
         activity: "sleeping",
@@ -316,9 +314,7 @@ function mapToAgentStates(cliSessions: CliSession[]): AgentState[] {
         pixelEnabled: known.pixelEnabled,
         tags: known.tags,
         roomId: resolveRoom(known.tags),
-      };
-      agentStates.set(agentId, state);
-      results.push(state);
+      });
     }
   }
 
@@ -466,13 +462,29 @@ async function tailTranscript(
 }
 
 /**
+ * Prune read offsets for agents that are no longer active
+ */
+function pruneReadOffsets(activeAgentIds: Set<string>): void {
+  for (const key of lastReadOffset.keys()) {
+    const agentId = key.split(':')[0];
+    if (!activeAgentIds.has(agentId)) {
+      lastReadOffset.delete(key);
+    }
+  }
+}
+
+/**
  * Poll messages from all active agent transcripts.
  */
 async function pollMessages(): Promise<void> {
   const promises: Promise<TickerMessage[]>[] = [];
 
+  // Collect active agent IDs for pruning
+  const activeAgentIds = new Set<string>();
+
   for (const [agentId, state] of agentStates) {
     if (!state.active) continue;
+    activeAgentIds.add(agentId);
 
     const known = AGENT_REGISTRY.get(agentId);
     if (!known) continue;
@@ -482,6 +494,9 @@ async function pollMessages(): Promise<void> {
       promises.push(tailTranscript(agentId, known.name, transcriptPath));
     }
   }
+
+  // Prune read offsets for inactive agents
+  pruneReadOffsets(activeAgentIds);
 
   const results = await Promise.all(promises);
   const newMsgs = results.flat();
@@ -524,14 +539,15 @@ async function pollAndBroadcast(): Promise<void> {
   isPolling = true;
   try {
     const { sessions } = await pollSessions();
-    const agentList = mapToAgentStates(sessions);
+    const agentMap = mapToAgentStates(sessions);
+    const agentList = Array.from(agentMap.values());
 
     // Create immutable snapshot before any async operations
     const snapshot = agentList.map(a => ({ ...a }));
 
     // Update global state atomically
     agentStates.clear();
-    for (const agent of agentList) {
+    for (const agent of agentMap.values()) {
       agentStates.set(agent.id, agent);
     }
 
@@ -581,7 +597,15 @@ app.post("/api/ingest/agents", (req, res) => {
   }
 
   // Map and broadcast
-  const agentList = mapToAgentStates(sessions as CliSession[]);
+  const agentMap = mapToAgentStates(sessions as CliSession[]);
+  const agentList = Array.from(agentMap.values());
+
+  // Update global state
+  agentStates.clear();
+  for (const agent of agentMap.values()) {
+    agentStates.set(agent.id, agent);
+  }
+
   lastIngestAt = Date.now();
   console.log(`[ingest] ${agentList.length} agents updated (${sessions.length} sessions)`);
   io.emit("agents:update", agentList);

--- a/server/index.ts
+++ b/server/index.ts
@@ -526,8 +526,17 @@ async function pollAndBroadcast(): Promise<void> {
     const { sessions } = await pollSessions();
     const agentList = mapToAgentStates(sessions);
 
-    // Broadcast to all connected WebSocket clients
-    io.emit("agents:update", agentList);
+    // Create immutable snapshot before any async operations
+    const snapshot = agentList.map(a => ({ ...a }));
+
+    // Update global state atomically
+    agentStates.clear();
+    for (const agent of agentList) {
+      agentStates.set(agent.id, agent);
+    }
+
+    // Broadcast the snapshot (not the mutable global state)
+    io.emit("agents:update", snapshot);
 
     // Poll messages from transcripts
     await pollMessages();

--- a/src/components/CharacterCustomizer.tsx
+++ b/src/components/CharacterCustomizer.tsx
@@ -46,12 +46,15 @@ export const CharacterCustomizer: React.FC<Props> = ({
     const ctx = canvas.getContext('2d');
     if (!ctx) return;
 
+    const previewCanvas = canvas;
+    const previewCtx = ctx;
+
     ctx.imageSmoothingEnabled = false;
 
     // Load source sheets and composite a preview
     let cancelled = false;
 
-    async function renderPreview() {
+    async function renderPreview(c: HTMLCanvasElement, context: CanvasRenderingContext2D) {
       if (cancelled) return;
 
       const BASE = '/assets/source/MetroCity/';
@@ -69,14 +72,14 @@ export const CharacterCustomizer: React.FC<Props> = ({
         if (cancelled) return;
 
         // Clear
-        ctx.clearRect(0, 0, canvas.width, canvas.height);
+        context.clearRect(0, 0, c.width, c.height);
 
         // Draw checkerboard background for transparency
         const CHECK = 6;
-        for (let y = 0; y < canvas.height; y += CHECK) {
-          for (let x = 0; x < canvas.width; x += CHECK) {
-            ctx.fillStyle = ((x / CHECK + y / CHECK) % 2 === 0) ? '#1a1a2e' : '#16213e';
-            ctx.fillRect(x, y, CHECK, CHECK);
+        for (let y = 0; y < c.height; y += CHECK) {
+          for (let x = 0; x < c.width; x += CHECK) {
+            context.fillStyle = ((x / CHECK + y / CHECK) % 2 === 0) ? '#1a1a2e' : '#16213e';
+            context.fillRect(x, y, CHECK, CHECK);
           }
         }
 
@@ -87,25 +90,28 @@ export const CharacterCustomizer: React.FC<Props> = ({
         const cropH = 32;
 
         // Layer: body
-        ctx.drawImage(bodyImg, srcX + cropX, recipe.bodyIndex * SRC, cropW, cropH, 16, 8, DST, DST * 2);
+        context.drawImage(bodyImg, srcX + cropX, recipe.bodyIndex * SRC, cropW, cropH, 16, 8, DST, DST * 2);
         // Layer: outfit
-        ctx.drawImage(outfitImg, srcX + cropX, 0, cropW, cropH, 16, 8, DST, DST * 2);
+        context.drawImage(outfitImg, srcX + cropX, 0, cropW, cropH, 16, 8, DST, DST * 2);
         // Layer: hair
-        ctx.drawImage(hairImg, srcX + cropX, recipe.hairIndex * SRC, cropW, cropH, 16, 8, DST, DST * 2);
+        context.drawImage(hairImg, srcX + cropX, recipe.hairIndex * SRC, cropW, cropH, 16, 8, DST, DST * 2);
 
       } catch (err) {
+        // Skip drawing if effect was cancelled or unmounted — a newer render may be in flight
+        if (cancelled) return;
+
         // Preview failed — draw fallback
-        ctx.clearRect(0, 0, canvas.width, canvas.height);
-        ctx.fillStyle = '#1a1a2e';
-        ctx.fillRect(0, 0, canvas.width, canvas.height);
-        ctx.fillStyle = '#4ecca3';
-        ctx.font = '12px monospace';
-        ctx.textAlign = 'center';
-        ctx.fillText('Preview', canvas.width / 2, canvas.height / 2);
+        context.clearRect(0, 0, c.width, c.height);
+        context.fillStyle = '#1a1a2e';
+        context.fillRect(0, 0, c.width, c.height);
+        context.fillStyle = '#4ecca3';
+        context.font = '12px monospace';
+        context.textAlign = 'center';
+        context.fillText('Preview', c.width / 2, c.height / 2);
       }
     }
 
-    renderPreview();
+    renderPreview(previewCanvas, previewCtx);
     return () => { cancelled = true; };
   }, [recipe.bodyIndex, recipe.hairIndex, recipe.outfitIndex]);
 


### PR DESCRIPTION
## Summary

Applies the PR #13 fix to prevent race conditions in `pollAndBroadcast()` by creating an immutable snapshot of agent state before any async operations.

## Changes

- Create snapshot of `agentList` before `await pollMessages()`
- Update `agentStates` atomically (clear + re-populate)
- Broadcast snapshot instead of mutable list
- Prevents inconsistent `agents:update` payloads when `pollMessages` modifies global state

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved data consistency in agent state updates.
  * Enhanced stability of character preview rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->