### PR TITLE
fix: prune stale transcript read offsets for inactive agents

### DIFF
--- a/MERGE_CHECKLIST.md
+++ b/MERGE_CHECKLIST.md
@@ -1,14 +1,22 @@
 # PR Merge Checklist
 
-## Step 1: Merge new PRs into target branches
+## Step 1a: Merge follow-up fix PRs into their targets
+
+| Fix PR | Target | Contains |
+|--------|--------|----------|
+| **#21** | → `main` | `useLayoutStore` DELETE response.ok + CharacterCustomizer TS18047 fix |
+| **#22** | → PR #17 (`fix/p0-2-debounce-obstacle-rebuild`) | `previewCtx.imageSmoothingEnabled` + `useLayoutStore` response.ok |
+| **#23** | → PR #19 (`fix/character-customizer-null-check`) | `previewCtx.imageSmoothingEnabled` consistency |
+
+## Step 1b: Merge new PRs into target branches
 
 | New PR | Target | Contains |
 |--------|--------|----------|
-| #16 | → #11 (`fix/p0-1-canvas-memory-leak`) | SpriteLoader memory leak + CodeRabbit defensive fix |
-| #17 | → #14 (`fix/p0-2-debounce-obstacle-rebuild`) | Deferred obstacle rebuild |
-| #18 | → #13 (`fix/p0-3-state-race-condition`) | Snapshot + atomic update + `mapToAgentStates` pure + TS18047 fix |
-| #19 | → #9 (`fix/character-customizer-null-check`) | TS18047 fix + removed aliases |
-| #20 | → #15 (`fix/p0-4-prune-read-offsets`) | Prune offsets + snapshot + pure `mapToAgentStates` + aliases |
+| #16 | → PR #11 (`fix/p0-1-canvas-memory-leak`) | SpriteLoader memory leak + CodeRabbit defensive fix |
+| #17 | → PR #14 (`fix/p0-2-debounce-obstacle-rebuild`) | Deferred obstacle rebuild |
+| #18 | → PR #13 (`fix/p0-3-state-race-condition`) | Snapshot + atomic update + `mapToAgentStates` pure + TS18047 fix |
+| #19 | → PR #9 (`fix/character-customizer-null-check`) | TS18047 fix + aliases |
+| #20 | → PR #15 (`fix/p0-4-prune-read-offsets`) | Prune offsets + snapshot + pure `mapToAgentStates` + aliases |
 
 ## Step 2: Merge original PRs into main
 
@@ -26,7 +34,7 @@
 
 ## Notes
 
+- Step 1a fix PRs (21-23) should be merged first so their fixes are included when Step 1b PRs are reviewed
 - New PRs (16-20) add review fixes on top of original PRs
-- After merging #16→#11, PR #11 includes the memory leak fix + defensive null checks
-- After merging #18→#13, PR #13 includes the snapshot fix + CodeRabbit `mapToAgentStates` pure fix
-- Merging order within each step doesn't matter
+- PR #18 already has `mapToAgentStates` pure fix (CodeRabbit comment is stale)
+- PR #20 already removed aliases (CodeRabbit comment is stale)

--- a/MERGE_CHECKLIST.md
+++ b/MERGE_CHECKLIST.md
@@ -1,0 +1,32 @@
+# PR Merge Checklist
+
+## Step 1: Merge new PRs into target branches
+
+| New PR | Target | Contains |
+|--------|--------|----------|
+| #16 | → #11 (`fix/p0-1-canvas-memory-leak`) | SpriteLoader memory leak + CodeRabbit defensive fix |
+| #17 | → #14 (`fix/p0-2-debounce-obstacle-rebuild`) | Deferred obstacle rebuild |
+| #18 | → #13 (`fix/p0-3-state-race-condition`) | Snapshot + atomic update + `mapToAgentStates` pure + TS18047 fix |
+| #19 | → #9 (`fix/character-customizer-null-check`) | TS18047 fix + removed aliases |
+| #20 | → #15 (`fix/p0-4-prune-read-offsets`) | Prune offsets + snapshot + pure `mapToAgentStates` + aliases |
+
+## Step 2: Merge original PRs into main
+
+| PR | Title |
+|----|-------|
+| #9 | CharacterCustomizer TS18047 fix |
+| #11 | Canvas memory leak |
+| #13 | Race condition fix |
+| #14 | Deferred obstacle rebuild |
+| #15 | Prune read offsets |
+
+## Rejected PRs
+
+- **#12** — Broken: deletes all server imports/config. Do NOT merge.
+
+## Notes
+
+- New PRs (16-20) add review fixes on top of original PRs
+- After merging #16→#11, PR #11 includes the memory leak fix + defensive null checks
+- After merging #18→#13, PR #13 includes the snapshot fix + CodeRabbit `mapToAgentStates` pure fix
+- Merging order within each step doesn't matter

--- a/server/index.ts
+++ b/server/index.ts
@@ -239,7 +239,7 @@ function inferActivity(session: CliSession): AgentActivity {
  * Aggregates sessions by agentId — picks the most recently updated session
  * to determine the agent's current activity.
  */
-function mapToAgentStates(cliSessions: CliSession[]): AgentState[] {
+function mapToAgentStates(cliSessions: CliSession[]): Map<string, AgentState> {
   // Group sessions by agentId
   const byAgent = new Map<string, CliSession[]>();
   for (const s of cliSessions) {
@@ -250,7 +250,7 @@ function mapToAgentStates(cliSessions: CliSession[]): AgentState[] {
     byAgent.set(agentId, list);
   }
 
-  const results: AgentState[] = [];
+  const results = new Map<string, AgentState>();
 
   // Process all registered agents (including those without active sessions)
   for (const [agentId, known] of AGENT_REGISTRY) {
@@ -269,7 +269,7 @@ function mapToAgentStates(cliSessions: CliSession[]): AgentState[] {
         agentTranscriptPaths.set(agentId, transcriptPath);
       }
 
-      const state: AgentState = {
+      results.set(agentId, {
         id: agentId,
         name: known.name,
         activity,
@@ -299,12 +299,10 @@ function mapToAgentStates(cliSessions: CliSession[]): AgentState[] {
             status: s.status === "completed" ? "completed" as const : s.abortedLastRun ? "failed" as const : "running" as const,
           })),
         sessionUptime: latestSession.updatedAt ? (Date.now() - latestSession.updatedAt) / 1000 : undefined,
-      };
-      agentStates.set(agentId, state);
-      results.push(state);
+      });
     } else {
       // No active session — agent is sleeping
-      const state: AgentState = {
+      results.set(agentId, {
         id: agentId,
         name: known.name,
         activity: "sleeping",
@@ -316,9 +314,7 @@ function mapToAgentStates(cliSessions: CliSession[]): AgentState[] {
         pixelEnabled: known.pixelEnabled,
         tags: known.tags,
         roomId: resolveRoom(known.tags),
-      };
-      agentStates.set(agentId, state);
-      results.push(state);
+      });
     }
   }
 
@@ -466,13 +462,29 @@ async function tailTranscript(
 }
 
 /**
+ * Prune read offsets for agents that are no longer active
+ */
+function pruneReadOffsets(activeAgentIds: Set<string>): void {
+  for (const key of lastReadOffset.keys()) {
+    const agentId = key.split(':')[0];
+    if (!activeAgentIds.has(agentId)) {
+      lastReadOffset.delete(key);
+    }
+  }
+}
+
+/**
  * Poll messages from all active agent transcripts.
  */
 async function pollMessages(): Promise<void> {
   const promises: Promise<TickerMessage[]>[] = [];
 
+  // Collect active agent IDs for pruning
+  const activeAgentIds = new Set<string>();
+
   for (const [agentId, state] of agentStates) {
     if (!state.active) continue;
+    activeAgentIds.add(agentId);
 
     const known = AGENT_REGISTRY.get(agentId);
     if (!known) continue;
@@ -482,6 +494,9 @@ async function pollMessages(): Promise<void> {
       promises.push(tailTranscript(agentId, known.name, transcriptPath));
     }
   }
+
+  // Prune read offsets for inactive agents
+  pruneReadOffsets(activeAgentIds);
 
   const results = await Promise.all(promises);
   const newMsgs = results.flat();
@@ -524,10 +539,20 @@ async function pollAndBroadcast(): Promise<void> {
   isPolling = true;
   try {
     const { sessions } = await pollSessions();
-    const agentList = mapToAgentStates(sessions);
+    const agentMap = mapToAgentStates(sessions);
+    const agentList = Array.from(agentMap.values());
 
-    // Broadcast to all connected WebSocket clients
-    io.emit("agents:update", agentList);
+    // Create immutable snapshot before any async operations
+    const snapshot = agentList.map(a => ({ ...a }));
+
+    // Update global state atomically
+    agentStates.clear();
+    for (const agent of agentMap.values()) {
+      agentStates.set(agent.id, agent);
+    }
+
+    // Broadcast the snapshot (not the mutable global state)
+    io.emit("agents:update", snapshot);
 
     // Poll messages from transcripts
     await pollMessages();
@@ -572,7 +597,15 @@ app.post("/api/ingest/agents", (req, res) => {
   }
 
   // Map and broadcast
-  const agentList = mapToAgentStates(sessions as CliSession[]);
+  const agentMap = mapToAgentStates(sessions as CliSession[]);
+  const agentList = Array.from(agentMap.values());
+
+  // Update global state
+  agentStates.clear();
+  for (const agent of agentMap.values()) {
+    agentStates.set(agent.id, agent);
+  }
+
   lastIngestAt = Date.now();
   console.log(`[ingest] ${agentList.length} agents updated (${sessions.length} sessions)`);
   io.emit("agents:update", agentList);

--- a/src/components/CharacterCustomizer.tsx
+++ b/src/components/CharacterCustomizer.tsx
@@ -46,12 +46,15 @@ export const CharacterCustomizer: React.FC<Props> = ({
     const ctx = canvas.getContext('2d');
     if (!ctx) return;
 
+    const previewCanvas = canvas;
+    const previewCtx = ctx;
+
     ctx.imageSmoothingEnabled = false;
 
     // Load source sheets and composite a preview
     let cancelled = false;
 
-    async function renderPreview() {
+    async function renderPreview(c: HTMLCanvasElement, context: CanvasRenderingContext2D) {
       if (cancelled) return;
 
       const BASE = '/assets/source/MetroCity/';
@@ -69,14 +72,14 @@ export const CharacterCustomizer: React.FC<Props> = ({
         if (cancelled) return;
 
         // Clear
-        ctx.clearRect(0, 0, canvas.width, canvas.height);
+        context.clearRect(0, 0, c.width, c.height);
 
         // Draw checkerboard background for transparency
         const CHECK = 6;
-        for (let y = 0; y < canvas.height; y += CHECK) {
-          for (let x = 0; x < canvas.width; x += CHECK) {
-            ctx.fillStyle = ((x / CHECK + y / CHECK) % 2 === 0) ? '#1a1a2e' : '#16213e';
-            ctx.fillRect(x, y, CHECK, CHECK);
+        for (let y = 0; y < c.height; y += CHECK) {
+          for (let x = 0; x < c.width; x += CHECK) {
+            context.fillStyle = ((x / CHECK + y / CHECK) % 2 === 0) ? '#1a1a2e' : '#16213e';
+            context.fillRect(x, y, CHECK, CHECK);
           }
         }
 
@@ -87,25 +90,28 @@ export const CharacterCustomizer: React.FC<Props> = ({
         const cropH = 32;
 
         // Layer: body
-        ctx.drawImage(bodyImg, srcX + cropX, recipe.bodyIndex * SRC, cropW, cropH, 16, 8, DST, DST * 2);
+        context.drawImage(bodyImg, srcX + cropX, recipe.bodyIndex * SRC, cropW, cropH, 16, 8, DST, DST * 2);
         // Layer: outfit
-        ctx.drawImage(outfitImg, srcX + cropX, 0, cropW, cropH, 16, 8, DST, DST * 2);
+        context.drawImage(outfitImg, srcX + cropX, 0, cropW, cropH, 16, 8, DST, DST * 2);
         // Layer: hair
-        ctx.drawImage(hairImg, srcX + cropX, recipe.hairIndex * SRC, cropW, cropH, 16, 8, DST, DST * 2);
+        context.drawImage(hairImg, srcX + cropX, recipe.hairIndex * SRC, cropW, cropH, 16, 8, DST, DST * 2);
 
       } catch (err) {
+        // Skip drawing if effect was cancelled or unmounted — a newer render may be in flight
+        if (cancelled) return;
+
         // Preview failed — draw fallback
-        ctx.clearRect(0, 0, canvas.width, canvas.height);
-        ctx.fillStyle = '#1a1a2e';
-        ctx.fillRect(0, 0, canvas.width, canvas.height);
-        ctx.fillStyle = '#4ecca3';
-        ctx.font = '12px monospace';
-        ctx.textAlign = 'center';
-        ctx.fillText('Preview', canvas.width / 2, canvas.height / 2);
+        context.clearRect(0, 0, c.width, c.height);
+        context.fillStyle = '#1a1a2e';
+        context.fillRect(0, 0, c.width, c.height);
+        context.fillStyle = '#4ecca3';
+        context.font = '12px monospace';
+        context.textAlign = 'center';
+        context.fillText('Preview', c.width / 2, c.height / 2);
       }
     }
 
-    renderPreview();
+    renderPreview(previewCanvas, previewCtx);
     return () => { cancelled = true; };
   }, [recipe.bodyIndex, recipe.hairIndex, recipe.outfitIndex]);
 

--- a/src/components/CharacterCustomizer.tsx
+++ b/src/components/CharacterCustomizer.tsx
@@ -46,9 +46,6 @@ export const CharacterCustomizer: React.FC<Props> = ({
     const ctx = canvas.getContext('2d');
     if (!ctx) return;
 
-    const previewCanvas = canvas;
-    const previewCtx = ctx;
-
     ctx.imageSmoothingEnabled = false;
 
     // Load source sheets and composite a preview
@@ -111,7 +108,7 @@ export const CharacterCustomizer: React.FC<Props> = ({
       }
     }
 
-    renderPreview(previewCanvas, previewCtx);
+    renderPreview(canvas, ctx);
     return () => { cancelled = true; };
   }, [recipe.bodyIndex, recipe.hairIndex, recipe.outfitIndex]);
 


### PR DESCRIPTION
## Summary

Applies the PR #15 fix to clean up stale `lastReadOffset` entries for agents that are no longer active.

## Changes

- Collect active agent IDs during `pollMessages()` in a `Set<string>`
- Call `pruneReadOffsets()` after all promises are collected but before `await` to clean up stale offsets
- Prevents unbounded growth of read offsets map for inactive agents

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the character preview could render unexpectedly after being closed or cancelled.

* **Improvements**
  * Enhanced the stability and reliability of the character preview rendering system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->