### PR TITLE
fix: backend hardening — timing-safe auth, type safety, canvas disposal

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -120,6 +120,7 @@ for (const [id, prefs] of savedPrefs) {
     if (prefs.pixelEnabled !== undefined) agent.pixelEnabled = prefs.pixelEnabled;
     if (prefs.characterSpriteId !== undefined) agent.characterSpriteId = prefs.characterSpriteId;
     if (prefs.tags !== undefined) agent.tags = prefs.tags;
+    if (prefs.recipe !== undefined) agent.recipe = prefs.recipe;
   }
 }
 
@@ -581,7 +582,12 @@ function authenticateIngest(req: express.Request, _res: express.Response): boole
   const token = auth.slice(7);
   const expected = Buffer.from(INGEST_TOKEN, "utf-8");
   const provided = Buffer.from(token, "utf-8");
-  if (expected.length !== provided.length) return false;
+  if (expected.length !== provided.length) {
+    const padded = Buffer.alloc(expected.length);
+    provided.copy(padded, 0, 0, expected.length);
+    timingSafeEqual(expected, padded);
+    return false;
+  }
   return timingSafeEqual(expected, provided);
 }
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -12,6 +12,7 @@ import { createServer } from "http";
 import { Server as SocketIOServer } from "socket.io";
 import { readFileSync, writeFileSync, existsSync, mkdirSync, readdirSync, unlinkSync } from "node:fs";
 import { stat as statAsync } from "node:fs/promises";
+import { timingSafeEqual } from "node:crypto";
 import { join, dirname } from "node:path";
 import { createReadStream } from "node:fs";
 import { createInterface } from "node:readline";
@@ -73,15 +74,22 @@ function defaultRegistry(): Map<string, KnownAgent> {
   ]);
 }
 
+interface PersistedPrefs {
+  pixelEnabled?: boolean;
+  characterSpriteId?: string;
+  tags?: AgentTag[];
+  recipe?: { bodyIndex: number; hairIndex: number; outfitIndex: number };
+}
+
 /** Load persisted agent preferences (pixelEnabled, spriteId, tags, recipe) from disk */
-function loadPersistedPrefs(): Map<string, { pixelEnabled?: boolean; characterSpriteId?: string; tags?: AgentTag[]; recipe?: { bodyIndex: number; hairIndex: number; outfitIndex: number } }> {
+function loadPersistedPrefs(): Map<string, PersistedPrefs> {
   try {
     if (!existsSync(PERSIST_PATH)) return new Map();
     const raw = readFileSync(PERSIST_PATH, "utf-8");
     const data = JSON.parse(raw);
-    const map = new Map<string, { pixelEnabled?: boolean; characterSpriteId?: string; tags?: AgentTag[]; recipe?: { bodyIndex: number; hairIndex: number; outfitIndex: number } }>();
+    const map = new Map<string, PersistedPrefs>();
     for (const [k, v] of Object.entries(data)) {
-      map.set(k, v as any);
+      map.set(k, v as PersistedPrefs);
     }
     return map;
   } catch {
@@ -255,7 +263,8 @@ function mapToAgentStates(cliSessions: CliSession[]): Map<string, AgentState> {
   // Process all registered agents (including those without active sessions)
   for (const [agentId, known] of AGENT_REGISTRY) {
     const sessions = byAgent.get(agentId);
-    const latestSession = sessions?.sort((a, b) => (b.updatedAt ?? 0) - (a.updatedAt ?? 0))[0];
+    const sorted = sessions ? [...sessions].sort((a, b) => (b.updatedAt ?? 0) - (a.updatedAt ?? 0)) : [];
+    const latestSession = sorted[0];
 
     if (latestSession) {
       const activity = inferActivity(latestSession);
@@ -565,11 +574,15 @@ async function pollAndBroadcast(): Promise<void> {
 
 const INGEST_TOKEN = process.env.INGEST_API_TOKEN || "";
 
-function authenticateIngest(req: express.Request, res: express.Response): boolean {
-  if (!INGEST_TOKEN) return false; // no token configured = ingest disabled
+function authenticateIngest(req: express.Request, _res: express.Response): boolean {
+  if (!INGEST_TOKEN) return false;
   const auth = req.headers.authorization;
   if (!auth || !auth.startsWith("Bearer ")) return false;
-  return auth.slice(7) === INGEST_TOKEN;
+  const token = auth.slice(7);
+  const expected = Buffer.from(INGEST_TOKEN, "utf-8");
+  const provided = Buffer.from(token, "utf-8");
+  if (expected.length !== provided.length) return false;
+  return timingSafeEqual(expected, provided);
 }
 
 /**

--- a/server/index.ts
+++ b/server/index.ts
@@ -89,7 +89,9 @@ function loadPersistedPrefs(): Map<string, PersistedPrefs> {
     const data = JSON.parse(raw);
     const map = new Map<string, PersistedPrefs>();
     for (const [k, v] of Object.entries(data)) {
-      map.set(k, v as PersistedPrefs);
+      if (v && typeof v === 'object' && !Array.isArray(v)) {
+        map.set(k, v as PersistedPrefs);
+      }
     }
     return map;
   } catch {

--- a/server/index.ts
+++ b/server/index.ts
@@ -576,21 +576,19 @@ async function pollAndBroadcast(): Promise<void> {
 // ---- Ingest API (receives data from OpenClaw host collector) ----
 
 const INGEST_TOKEN = process.env.INGEST_API_TOKEN || "";
+const INGEST_TOKEN_BUF = INGEST_TOKEN ? Buffer.from(INGEST_TOKEN, "utf-8") : Buffer.alloc(0);
 
 function authenticateIngest(req: express.Request, _res: express.Response): boolean {
-  if (!INGEST_TOKEN) return false;
+  if (!INGEST_TOKEN_BUF.length) return false;
   const auth = req.headers.authorization;
   if (!auth || !auth.startsWith("Bearer ")) return false;
   const token = auth.slice(7);
-  const expected = Buffer.from(INGEST_TOKEN, "utf-8");
   const provided = Buffer.from(token, "utf-8");
-  if (expected.length !== provided.length) {
-    const padded = Buffer.alloc(expected.length);
-    provided.copy(padded, 0, 0, expected.length);
-    timingSafeEqual(expected, padded);
+  if (INGEST_TOKEN_BUF.length !== provided.length) {
+    timingSafeEqual(INGEST_TOKEN_BUF, Buffer.alloc(INGEST_TOKEN_BUF.length));
     return false;
   }
-  return timingSafeEqual(expected, provided);
+  return timingSafeEqual(INGEST_TOKEN_BUF, provided);
 }
 
 /**

--- a/src/game/SpriteLoader.ts
+++ b/src/game/SpriteLoader.ts
@@ -191,12 +191,22 @@ export async function loadFloors(
   return floors;
 }
 
+interface ManifestNode {
+  file?: string;
+  width?: number;
+  height?: number;
+  footprintW?: number;
+  footprintH?: number;
+  orientation?: string;
+  members?: ManifestNode[];
+}
+
 /**
  * Recursively find the first leaf asset node (one with a `file` field)
  * inside a potentially nested manifest member tree (e.g. PC has
  * rotation → state → animation → asset).
  */
-function findLeafAsset(node: any): { file: string; width: number; height: number; footprintW?: number; footprintH?: number } | null {
+function findLeafAsset(node: ManifestNode): ManifestNode | null {
   if (node.file) return node;
   if (node.members && node.members.length > 0) {
     for (const child of node.members) {
@@ -240,16 +250,16 @@ export async function loadFurniture(
       if (manifest.members && manifest.members.length > 0) {
         // Prefer the "front" orientation, fall back to first member
         const front = manifest.members.find(
-          (m: any) => m.orientation === 'front' || m.orientation === 'front_left',
+          (m: ManifestNode) => m.orientation === 'front' || m.orientation === 'front_left',
         );
         const member = front || manifest.members[0];
         // For nested groups (e.g. PC with state/animation sub-groups),
         // recursively dig to find the first leaf asset with a file
         const leaf = findLeafAsset(member);
         if (leaf) {
-          primaryFile = leaf.file;
-          fw = leaf.width;
-          fh = leaf.height;
+          primaryFile = leaf.file ?? '';
+          fw = leaf.width ?? 0;
+          fh = leaf.height ?? 0;
           footprintW = leaf.footprintW || 1;
           footprintH = leaf.footprintH || 1;
         }
@@ -417,11 +427,24 @@ export function getComposedCharacter(agentId: string): ComposedCharacter | null 
 }
 
 /**
+ * Dispose a composed character's canvases to free backing store.
+ */
+function disposeComposed(composed: ComposedCharacter): void {
+  for (const frames of [composed.down, composed.up, composed.right]) {
+    for (const c of frames) { c.width = 0; c.height = 0; }
+  }
+  composed.portrait.width = 0;
+  composed.portrait.height = 0;
+}
+
+/**
  * Recompose a single agent's character (e.g. after recipe change).
  * Returns the new LoadedCharacter for engine update.
  */
 export function recomposeAgent(agentId: string, recipe: CharacterRecipe): LoadedCharacter | null {
   try {
+    const old = cachedComposed.get(agentId);
+    if (old) disposeComposed(old);
     const composed = composeCharacter(recipe);
     cachedComposed.set(agentId, composed);
     return composedToLoaded(composed);

--- a/src/game/SpriteLoader.ts
+++ b/src/game/SpriteLoader.ts
@@ -191,6 +191,8 @@ export async function loadFloors(
   return floors;
 }
 
+type LeafAsset = ManifestNode & { file: string };
+
 interface ManifestNode {
   file?: string;
   width?: number;
@@ -206,8 +208,8 @@ interface ManifestNode {
  * inside a potentially nested manifest member tree (e.g. PC has
  * rotation → state → animation → asset).
  */
-function findLeafAsset(node: ManifestNode): ManifestNode | null {
-  if (node.file) return node;
+function findLeafAsset(node: ManifestNode): LeafAsset | null {
+  if (node.file) return node as LeafAsset;
   if (node.members && node.members.length > 0) {
     for (const child of node.members) {
       const leaf = findLeafAsset(child);
@@ -238,7 +240,7 @@ export async function loadFurniture(
       const manifestRes = await fetch(`${basePath}${type}/manifest.json`, { signal });
       if (!manifestRes.ok) continue;
 
-      const manifest = await manifestRes.json();
+      const manifest = (await manifestRes.json()) as ManifestNode;
 
       // Find the primary (front-facing) sprite from manifest members
       let primaryFile = '';
@@ -257,7 +259,7 @@ export async function loadFurniture(
         // recursively dig to find the first leaf asset with a file
         const leaf = findLeafAsset(member);
         if (leaf) {
-          primaryFile = leaf.file ?? '';
+          primaryFile = leaf.file;
           fw = leaf.width ?? 0;
           fh = leaf.height ?? 0;
           footprintW = leaf.footprintW || 1;
@@ -266,8 +268,8 @@ export async function loadFurniture(
       } else {
         // Simple asset — use explicit file or default to {ID}.png
         primaryFile = manifest.file || `${type}.png`;
-        fw = manifest.width;
-        fh = manifest.height;
+        fw = manifest.width ?? 0;
+        fh = manifest.height ?? 0;
         footprintW = manifest.footprintW || 1;
         footprintH = manifest.footprintH || 1;
       }
@@ -321,6 +323,7 @@ export async function loadAllAssets(signal?: AbortSignal): Promise<{
   let characters: LoadedCharacter[] = [];
   try {
     await loadSourceSheets();
+    for (const prev of cachedComposed.values()) disposeComposed(prev);
     cachedComposed.clear();
 
     // Compose characters for known agents

--- a/src/game/SpriteLoader.ts
+++ b/src/game/SpriteLoader.ts
@@ -443,10 +443,10 @@ function disposeComposed(composed: ComposedCharacter): void {
  */
 export function recomposeAgent(agentId: string, recipe: CharacterRecipe): LoadedCharacter | null {
   try {
-    const old = cachedComposed.get(agentId);
-    if (old) disposeComposed(old);
     const composed = composeCharacter(recipe);
+    const old = cachedComposed.get(agentId);
     cachedComposed.set(agentId, composed);
+    if (old) disposeComposed(old);
     return composedToLoaded(composed);
   } catch (err) {
     console.error(`[SpriteLoader] Failed to recompose ${agentId}:`, err);

--- a/src/hooks/useLayoutStore.ts
+++ b/src/hooks/useLayoutStore.ts
@@ -124,9 +124,8 @@ export function useLayoutStore() {
   useEffect(() => {
     fetchLayouts();
     fetchCatalog();
-    // Load default layout on mount
     loadLayoutById('default');
-  }, []);
+  }, [fetchLayouts, fetchCatalog, loadLayoutById]);
 
   return {
     layouts,


### PR DESCRIPTION
## Summary

Backend and type-safety improvements from the code audit (`AUDIT.md`):

- **Timing-safe token comparison** — `authenticateIngest` used `===` for bearer token check, vulnerable to timing attacks. Now uses `crypto.timingSafeEqual`.
- **Fix sessions sort mutation** — `sessions?.sort()` mutated the input array from `mapToAgentStates`. Now sorts a copy: `[...sessions].sort()`.
- **Remove `as any` cast** — `loadPersistedPrefs` used `v as any`. Extracted `PersistedPrefs` interface and cast to that instead.
- **Type `findLeafAsset`** — Replaced `any` parameter with `ManifestNode` interface for manifest member traversal.
- **Canvas disposal in `recomposeAgent`** — Old composited canvases (43 per agent) were never released. Now `disposeComposed` sets `width=0` on old canvases before replacing.
- **Fix `useLayoutStore` effect deps** — Empty `[]` dep array caused React to not track `fetchLayouts`/`fetchCatalog`/`loadLayoutById` stability.

## Test plan

- [x] `npm run typecheck` passes clean
- [x] `npm run build` passes clean
- [ ] Verify ingest auth still works with `INGEST_API_TOKEN` set
- [ ] Verify manifest-based furniture still loads (PC, etc.)
- [ ] Verify CharacterCustomizer Apply → old sprites freed (no canvas pool growth in DevTools)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced authentication security with improved token validation.
  * Fixed memory management by properly disposing cached character assets.
  * Improved data validation for saved preferences to prevent corruption.
  * Fixed session selection logic to prevent unintended data mutations.

* **Performance**
  * Optimized asset loading with better handling of missing asset dimensions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->