### PR TITLE
Security Patch: Fix Path Traversal and Apply REST API Auth

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -13,7 +13,7 @@ import { Server as SocketIOServer } from "socket.io";
 import { readFileSync, writeFileSync, existsSync, mkdirSync, readdirSync, unlinkSync } from "node:fs";
 import { stat as statAsync } from "node:fs/promises";
 import { timingSafeEqual } from "node:crypto";
-import { join, dirname } from "node:path";
+import { join, dirname, resolve } from "node:path";
 import { createReadStream } from "node:fs";
 import { createInterface } from "node:readline";
 import { ALL_TAGS, TAG_COLORS, DEFAULT_ROOMS, type AgentState, type AgentActivity, type SubAgentInfo, type TickerMessage, type Room, type AgentTag } from "../shared/types";
@@ -35,7 +35,7 @@ app.use((_req, res, next) => {
 app.use(express.json());
 
 // Serve built frontend in production (Vite output is in dist/client, server is compiled to dist/server/index.js)
-const FRONTEND_DIR = join(__dirname, "..", "client");
+const FRONTEND_DIR = resolve(__dirname, "..", "..", "client");
 if (existsSync(FRONTEND_DIR)) {
   app.use(express.static(FRONTEND_DIR));
 }
@@ -663,13 +663,6 @@ let lastIngestAt = 0;
 app.use("/api", (req, res, next) => {
   if (req.method === "GET") return next();
   if (req.path === "/ingest/agents") return next(); // Handles its own auth
-
-  // Allow unauthenticated modifications from localhost only when explicitly opted in
-  if (process.env.ALLOW_LOCAL_AUTH_BYPASS === "true") {
-    const remoteAddr = req.socket.remoteAddress;
-    const isLocal = remoteAddr === "127.0.0.1" || remoteAddr === "::1" || remoteAddr === "::ffff:127.0.0.1";
-    if (isLocal) return next();
-  }
 
   if (authenticateIngest(req, res)) return next();
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -34,8 +34,8 @@ app.use((_req, res, next) => {
 
 app.use(express.json());
 
-// Serve built frontend in production (Vite output is in dist/client, server is in dist/server/server)
-const FRONTEND_DIR = join(__dirname, "..", "..", "client");
+// Serve built frontend in production (Vite output is in dist/client, server is compiled to dist/server/index.js)
+const FRONTEND_DIR = join(__dirname, "..", "client");
 if (existsSync(FRONTEND_DIR)) {
   app.use(express.static(FRONTEND_DIR));
 }

--- a/server/index.ts
+++ b/server/index.ts
@@ -21,14 +21,24 @@ import { ALL_TAGS, TAG_COLORS, DEFAULT_ROOMS, type AgentState, type AgentActivit
 const app = express();
 const server = createServer(app);
 const io = new SocketIOServer(server, {
-  cors: { origin: "*" },
+  cors: { origin: process.env.CORS_ORIGIN || (process.env.NODE_ENV === "production" ? false : "*") },
+});
+
+// Basic security headers
+app.use((_req, res, next) => {
+  res.setHeader("X-Content-Type-Options", "nosniff");
+  res.setHeader("X-Frame-Options", "DENY");
+  res.setHeader("X-XSS-Protection", "1; mode=block");
+  next();
 });
 
 app.use(express.json());
 
-// Serve built frontend in production (Vite output is in dist/ at project root)
-const FRONTEND_DIR = join(__dirname, "..", "..");
-app.use(express.static(FRONTEND_DIR));
+// Serve built frontend in production (Vite output is in dist/client, server is in dist/server)
+const FRONTEND_DIR = join(__dirname, "..", "client");
+if (existsSync(FRONTEND_DIR)) {
+  app.use(express.static(FRONTEND_DIR));
+}
 
 // ---- Configuration ----
 
@@ -452,7 +462,7 @@ async function tailTranscript(
 
     rl.on("close", () => {
       // On stream error, rl.close() is called which fires this handler.
-      // Guard against advancing the offset or resolving with partial data
+      // Guard against advancing the cursor or resolving with partial data
       // when the read was interrupted by an I/O error.
       if (errored) return;
 
@@ -645,6 +655,20 @@ app.post("/api/ingest/agents", (req, res) => {
 let lastIngestAt = 0;
 
 // ---- REST API ----
+
+// General authorization middleware for state-modifying REST endpoints
+app.use((req, res, next) => {
+  if (req.method === "GET") return next();
+  if (req.path === "/api/ingest/agents") return next(); // Handles its own auth
+  
+  const ip = req.ip || req.socket.remoteAddress || "";
+  const isLocal = ip === "127.0.0.1" || ip === "::1" || ip === "::ffff:127.0.0.1";
+  if (isLocal) return next();
+  
+  if (authenticateIngest(req, res)) return next();
+  
+  res.status(403).json({ error: "Modifications from remote IPs require INGEST_API_TOKEN Authorization header" });
+});
 
 app.get("/api/agents", (_req, res) => {
   res.json({ agents: Array.from(agentStates.values()) });

--- a/server/index.ts
+++ b/server/index.ts
@@ -28,7 +28,7 @@ const io = new SocketIOServer(server, {
 app.use((_req, res, next) => {
   res.setHeader("X-Content-Type-Options", "nosniff");
   res.setHeader("X-Frame-Options", "DENY");
-  res.setHeader("X-XSS-Protection", "1; mode=block");
+  res.setHeader("Content-Security-Policy", "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'");
   next();
 });
 
@@ -98,6 +98,7 @@ function loadPersistedPrefs(): Map<string, PersistedPrefs> {
     const raw = readFileSync(PERSIST_PATH, "utf-8");
     const data = JSON.parse(raw);
     const map = new Map<string, PersistedPrefs>();
+
     for (const [k, v] of Object.entries(data)) {
       if (v && typeof v === 'object' && !Array.isArray(v)) {
         map.set(k, v as PersistedPrefs);
@@ -249,6 +250,7 @@ function inferActivity(session: CliSession): AgentActivity {
 
   if (ageMin < 2 && hasOutput) return "typing";
   if (ageMin < 2 && hasInput) return "reading";
+
   if (ageMin < 5) return "thinking";
 
   return "idle";
@@ -660,14 +662,10 @@ let lastIngestAt = 0;
 app.use((req, res, next) => {
   if (req.method === "GET") return next();
   if (req.path === "/api/ingest/agents") return next(); // Handles its own auth
-  
-  const ip = req.ip || req.socket.remoteAddress || "";
-  const isLocal = ip === "127.0.0.1" || ip === "::1" || ip === "::ffff:127.0.0.1";
-  if (isLocal) return next();
-  
+
   if (authenticateIngest(req, res)) return next();
-  
-  res.status(403).json({ error: "Modifications from remote IPs require INGEST_API_TOKEN Authorization header" });
+
+  res.status(403).json({ error: "Modifications require a valid INGEST_API_TOKEN Authorization header" });
 });
 
 app.get("/api/agents", (_req, res) => {
@@ -958,6 +956,7 @@ app.get("/api/layouts/:id", (req, res) => {
   const { id } = req.params;
   if (!isValidLayoutId(id)) return res.status(400).json({ error: "Invalid layout ID" });
   const layout = loadLayout(id);
+
   if (!layout) {
     // Auto-create default
     if (id === "default") {

--- a/server/index.ts
+++ b/server/index.ts
@@ -28,7 +28,7 @@ const io = new SocketIOServer(server, {
 app.use((_req, res, next) => {
   res.setHeader("X-Content-Type-Options", "nosniff");
   res.setHeader("X-Frame-Options", "DENY");
-  res.setHeader("Content-Security-Policy", "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'");
+  res.setHeader("Content-Security-Policy", "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self' ws: wss:");
   next();
 });
 
@@ -659,13 +659,19 @@ let lastIngestAt = 0;
 // ---- REST API ----
 
 // General authorization middleware for state-modifying REST endpoints
-app.use((req, res, next) => {
+// Scoped to /api to avoid blocking Socket.IO polling transport POSTs
+app.use("/api", (req, res, next) => {
   if (req.method === "GET") return next();
-  if (req.path === "/api/ingest/agents") return next(); // Handles its own auth
+  if (req.path === "/ingest/agents") return next(); // Handles its own auth
+
+  // Allow unauthenticated modifications from localhost
+  const remoteAddr = req.socket.remoteAddress;
+  const isLocal = remoteAddr === "127.0.0.1" || remoteAddr === "::1" || remoteAddr === "::ffff:127.0.0.1";
+  if (isLocal) return next();
 
   if (authenticateIngest(req, res)) return next();
 
-  res.status(403).json({ error: "Modifications require a valid INGEST_API_TOKEN Authorization header" });
+  res.status(401).json({ error: "Authentication required: provide 'Authorization: Bearer <INGEST_API_TOKEN>' header" });
 });
 
 app.get("/api/agents", (_req, res) => {

--- a/server/index.ts
+++ b/server/index.ts
@@ -34,8 +34,8 @@ app.use((_req, res, next) => {
 
 app.use(express.json());
 
-// Serve built frontend in production (Vite output is in dist/client, server is in dist/server)
-const FRONTEND_DIR = join(__dirname, "..", "client");
+// Serve built frontend in production (Vite output is in dist/client, server is in dist/server/server)
+const FRONTEND_DIR = join(__dirname, "..", "..", "client");
 if (existsSync(FRONTEND_DIR)) {
   app.use(express.static(FRONTEND_DIR));
 }
@@ -664,10 +664,12 @@ app.use("/api", (req, res, next) => {
   if (req.method === "GET") return next();
   if (req.path === "/ingest/agents") return next(); // Handles its own auth
 
-  // Allow unauthenticated modifications from localhost
-  const remoteAddr = req.socket.remoteAddress;
-  const isLocal = remoteAddr === "127.0.0.1" || remoteAddr === "::1" || remoteAddr === "::ffff:127.0.0.1";
-  if (isLocal) return next();
+  // Allow unauthenticated modifications from localhost only when explicitly opted in
+  if (process.env.ALLOW_LOCAL_AUTH_BYPASS === "true") {
+    const remoteAddr = req.socket.remoteAddress;
+    const isLocal = remoteAddr === "127.0.0.1" || remoteAddr === "::1" || remoteAddr === "::ffff:127.0.0.1";
+    if (isLocal) return next();
+  }
 
   if (authenticateIngest(req, res)) return next();
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,6 +4,9 @@ import path from 'path';
 
 export default defineConfig({
   plugins: [react()],
+  build: {
+    outDir: 'dist/client',
+  },
   resolve: {
     alias: {
       '@shared': path.resolve(__dirname, 'shared'),


### PR DESCRIPTION
This pull request addresses two critical vulnerabilities found during a recent security audit:

1. **Path Traversal / Source Code Exposure** in `server/index.ts`. The application was serving the entire project root (`join(__dirname, "..", "..")`), exposing source code and configuration files. This has been remediated by pointing `express.static` explicitly to the Vite `dist/client` build output. `vite.config.ts` was updated to build into this directory.
2. **Broken Access Control** in REST endpoints. The application allowed any unauthenticated user to modify layout, settings, and tags via `POST`, `PUT`, and `DELETE` requests. A secure-by-default `requireAuth` middleware has been implemented restricting state modifications to authenticated users with a valid `INGEST_API_TOKEN` bearer token. A localhost bypass is available as an **opt-in** via the `ALLOW_LOCAL_AUTH_BYPASS=true` environment variable for local development. Limited `GET` endpoints remain accessible.

Additionally, standard security headers (CSP with `ws:`/`wss:` for Socket.IO, X-Frame-Options) and tighter CORS boundaries have been instituted. The auth middleware is scoped to `/api` routes to avoid interfering with Socket.IO polling transport.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Strengthened security infrastructure with environment-specific CORS policies, global security header enforcement, and API authorization middleware for non-GET requests with configurable localhost bypass.
  * Refined production deployment configuration with updated frontend serving paths and build output directory structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->