### PR TITLE
fix: memoize AgentSidebar, type AGENT_PALETTES, close audit items

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,193 @@
+# Agent Guide — OpenClaw Pixel Agents
+
+## Project Overview
+
+A pixel art office dashboard for [OpenClaw](https://github.com/openclaw/openclaw). Agents appear as animated characters that walk to desks, sit down, and animate based on real agent state (typing, reading, thinking, etc.).
+
+- **Frontend**: React 19, TypeScript, Vite, Canvas 2D game engine
+- **Backend**: Node.js, Express, Socket.IO
+- **Assets**: MetroCity pixel art character pack (JIK-A-4 on itch.io)
+- **Data**: OpenClaw Gateway session polling (CLI or ingest API)
+
+## Commands
+
+```bash
+npm run dev        # Start dev (Vite on :3000 + backend on :3001, via concurrently)
+npm run dev:client # Vite only (port 3000, proxies /api → :3001)
+npm run dev:server # Backend only (tsx watch on :3001)
+npm run build      # Vite build + tsc -p tsconfig.server.json → dist/
+npm run start      # Run production build (node dist/server/index.js)
+npm run typecheck  # tsc --noEmit
+```
+
+## Architecture
+
+### Directory Structure
+
+```
+server/index.ts         # Express + Socket.IO backend (all API routes here)
+shared/types.ts         # Shared TypeScript types (server ↔ client)
+src/
+  App.tsx               # Root component, wires all panels
+  components/           # React UI components
+    PixelOffice.tsx     # Canvas wrapper, initializes GameEngine
+    AgentSidebar.tsx    # Agent list with toggles
+    LayoutEditor.tsx    # Furniture palette, layout manager
+    AgentDetailPanel.tsx# Agent detail/edit panel
+    MessageTicker.tsx   # Scrolling message ticker
+    RoomSwitcher.tsx    # Room navigation tabs
+    CharacterCustomizer.tsx  # Paperdoll body/hair/outfit picker
+    TagEditor.tsx       # Tag management
+    SoundControls.tsx    # Mute/volume UI
+  game/
+    GameEngine.ts       # Canvas 2D rendering loop, animation, pathfinding, editor mode
+    SpriteLoader.ts     # Sprite sheet loading, frame extraction
+    CharacterComposer.ts # Paperdoll compositor (body+hair+outfit layering)
+    Pathfinder.ts        # BFS pathfinding
+  hooks/
+    useAgentStore.ts    # Agent state: polling + Socket.IO events
+    useLayoutStore.ts   # Layout CRUD, auto-layout loading
+  audio/
+    SoundFX.ts          # Web Audio API synthesizer (no audio files)
+collector/              # Runs on OpenClaw host, pushes to ingest API
+  push-pixel-agents.mjs # Node script invoked by systemd timer
+```
+
+### Data Flow
+
+```
+OpenClaw Gateway
+    ↓ CLI poll (every 3s, configurable via POLL_INTERVAL)
+server/index.ts
+    ↓ Socket.IO broadcast "agents:update"
+    ↓ REST /api/agents (polled every 2s by frontend)
+useAgentStore (React hook)
+    ↓
+PixelOffice → GameEngine (Canvas 2D render loop @ 60fps)
+```
+
+### Server Architecture
+
+The backend runs in a **single process**: Express serves the built frontend (from project root after build) and handles API routes. In development, Vite proxies `/api` and `/socket.io` to `localhost:3001`.
+
+The `server/index.ts` is the **only** server file. All routes, polling logic, layout persistence, message ticker, and Socket.IO handling live there.
+
+### Key Ports
+
+| Context | Port | Notes |
+|---------|------|-------|
+| Vite dev | 3000 | Proxies `/api` and `/socket.io` to 3001 |
+| Backend dev | 3001 | `npm run dev:server` |
+| Backend prod | 3001 | `PORT` env var (defaults to 3001, production uses 3000 via reverse proxy) |
+
+## Key Patterns
+
+### Agent Activity → Animation State
+
+Activity states from OpenClaw map to engine animation states:
+
+```
+typing / running_command → 'typing' anim
+thinking / reading       → 'reading' anim
+idle / sleeping / error → 'idle' anim
+waiting_input           → speech bubble rendered, no special anim
+```
+
+When an agent enters `typing` or `reading`, the engine **auto-routes them to their assigned seat** (seats are defined per-layout, resolved via `engine.assignSeat()` or explicit `seats` map).
+
+### Layout Persistence
+
+Layouts are JSON files stored in `data/layouts/`. Each layout is a separate `.json` file named `{id}.json`. The `default` layout is protected from deletion.
+
+**Layout IDs are validated** with a strict regex (`/^[a-zA-Z0-9_-]+$/`, max 64 chars) to prevent path traversal. This was a recent security fix.
+
+### Agent Registry
+
+The server maintains a `AGENT_REGISTRY` (Map of KnownAgent objects) initialized from hardcoded defaults in `defaultRegistry()`. Preferences (pixelEnabled, spriteId, tags, recipe) are persisted to `data/agent-prefs.json` and merged on startup.
+
+The **8 default agents**: main/Shodan, miku, chi, sysauxilia, descartes, cyberlogis, cylena, cybera.
+
+### Message Ticker (Transcript Polling)
+
+The server tails transcript JSONL files from `~/.openclaw/agents/{agentId}/sessions/` using **byte-offset seeking** — each poll cycle only reads newly-appended lines. The offset advances only past complete lines (those ending in newline), so partial lines at EOF are re-read on the next cycle. This avoids data loss on fast writes.
+
+Transcript content filtering skips `thinking`, `tool_use`, `tool_result` blocks, heartbeats, and messages shorter than 5 chars.
+
+### Paperdoll Character Compositor
+
+`CharacterComposer.ts` layers MetroCity source sprites (body + outfit + hair) into per-agent character sheets. Source path: `/assets/source/MetroCity/`. It reads:
+- `CharacterModel/Character Model.png` (6 rows × 24 cols, 32×32px)
+- `Hair/Hairs.png` (9 rows × 24 cols)
+- `Outfits/Outfit{1-6}.png` (1 row × 24 cols each)
+
+Output is in the same 3×7 format as legacy sprites (16×32 frames). If source sheets fail to load, falls back to pre-composited `char_0..5.png`.
+
+### Sound Effects
+
+`SoundFX.ts` is a **Web Audio API synthesizer** — no audio files. All sounds (typing clicks, footsteps, spawn/despawn chimes, etc.) are generated procedurally via oscillators and gain envelopes. Muted state and volume persist in the singleton.
+
+### Editor Mode (GameEngine)
+
+Editor mode is a mode on `GameEngine` (not a separate component). When active:
+- Canvas cursor changes to indicate placement/drag/delete modes
+- Right-click rotates furniture 90°
+- Touch: single tap = place/select, double-tap = rotate, drag = move
+- Clicking furniture in delete mode immediately deletes it
+
+The engine fires `EditorCallbacks` (`onPlaceFurniture`, `onSelectFurniture`, `onMoveFurniture`) back to React, which updates the layout store.
+
+## Non-Obvious Gotchas
+
+1. **Auto-save was intentionally removed.** The `useLayoutStore` comment explains: furniture is persisted only via explicit **Save button** to avoid race conditions on initial load and React StrictMode double-mounts that caused furniture to reset. The `updateFurniture` function accepts a functional updater form specifically for rapid delete-mode clicks.
+
+2. **`furnitureKey` detection.** `PixelOffice` uses `JSON.stringify` of furniture positions/rotations as a React effect dependency to detect layout changes. If you add new fields to `PlacedFurniture` that the engine reads but don't include them in this string, the engine won't re-sync.
+
+3. **Transcript byte-offset tailing.** The `tailTranscript` function in `server/index.ts` uses `start: offset, end: fileSize - 1` to read only new bytes. The critical invariant: the offset only advances past complete lines (those terminated by `\n`), so a partial last line is re-read on the next poll. Don't "simplify" this to just seek to `fileSize`.
+
+4. **`furniture.get(f.type)` footprint reading.** Furniture obstacle footprint uses `sprite.footprintW` and `sprite.footprintH` from the cached furniture map. If a furniture type has no sprite loaded, footprint defaults to 2×1 (treating it as a desk-like obstacle).
+
+5. **`isPolling` guard.** The poll loop guards against overlapping cycles: if a previous poll is still running (awaiting CLI or transcript reads), the next tick is skipped entirely. This prevents concurrent access to shared state (`agentStates`, `tickerMessages`).
+
+6. **Socket.IO `changeOrigin: true`.** The Vite proxy config sets `changeOrigin: true` for both `/api` and `/socket.io`. Without it, WebSocket upgrades fail because the `Host` header doesn't match what the backend expects.
+
+7. **`screenToGrid` has overloads.** `screenToGrid(e: MouseEvent)` and `screenToGrid(clientX: number, clientY: number)` — used by both mouse and touch handlers. Don't merge them naively.
+
+8. **`stateJustChanged` is one-frame-only.** Set to `true` in `updateCharacter` when state changes, consumed once in `update()` to trigger sounds/VFX, then reset. If you add more state-change side effects, add them before the reset.
+
+9. **Day/night cycle and monitor glow.** The cycle runs continuously (120-second full cycle). Monitor glow only renders when `phase.light < 0.5` (night phases). Sparkle ambient particles also only spawn at night near typing agents.
+
+10. **Demo mode.** If no agents are active (no CLI and no ingest data), `spawnDemoAgents()` creates 8 hardcoded demo characters. The backend always initializes these in the engine, so the office is never empty.
+
+11. **Sub-agent lifecycle.** Sub-agents spawn near their parent, live for 15 seconds (`SUBAGENT_LIFETIME`), then enter a 2-second fade-out. The `subAgents` array on `AgentState` drives spawn/kill via `engine.spawnSubAgent()` / `engine.killSubAgent()`. Session completion/abort sets sub-agent status, which triggers the kill.
+
+12. **Duplicate type definition.** `CharacterRecipe` is defined in both `shared/types.ts` (line ~64) and `CharacterComposer.ts` (line ~54). They are identical. The one in `shared/types.ts` is used by the network layer; `CharacterComposer.ts` exports its own for the compositor.
+
+## Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `PORT` | `3001` | Backend server port |
+| `DATA_SOURCE` | `auto` | `auto`, `cli`, or `ingest` |
+| `OPENCLAW_BIN` | `openclaw` | Path to OpenClaw CLI |
+| `POLL_INTERVAL` | `3000` | Agent poll interval (ms) |
+| `ACTIVE_MINUTES` | `30` | Session staleness threshold |
+| `INGEST_API_TOKEN` | *(none)* | Shared secret for ingest API |
+| `OPENCLAW_AGENTS_DIR` | `~/.openclaw/agents` | Transcript directory |
+| `DATA_DIR` | `./data` | Persistence directory |
+
+## Adding New Furniture
+
+1. Add sprites to `public/assets/furniture/<TYPE>/`
+2. Create `manifest.json` with `id`, `name`, `category`, `type`, and `members` array
+3. Add type name to the furniture catalog array in `server/index.ts` (line ~932)
+4. It appears in the editor palette automatically via `/api/furniture-catalog`
+
+## Socket.IO Events
+
+**Server → Client:**
+- `agents:update` — full agent list (on connect + every poll cycle)
+- `ticker:messages` — rolling ticker message buffer
+- `layout:update` — layout changed
+- `recipe-update` — agent paperdoll changed
+
+**Client → Server:** (none in current implementation)

--- a/AUDIT.md
+++ b/AUDIT.md
@@ -1,0 +1,414 @@
+# Deep-Dive Code Audit — OpenClaw Pixel Agents
+
+**Auditor:** Staff Full-Stack Engineer / Performance Architect
+**Date:** 2026-04-07
+**Codebase:** `pr23-merge` branch (commit `19bb529`)
+**Last Updated:** 2026-04-17 (fixes applied)
+
+---
+
+## Status Update — 2026-04-17
+
+### Fixed in `fix/backend-hardening` + latest `origin/main` merge
+
+| Issue | Status | Notes |
+|-------|--------|-------|
+| Duplicate `CharacterRecipe` interface | ✅ Fixed | Only one definition remains |
+| Ticker O(n log n) sort | ✅ Fixed | Binary insertion in place |
+| `as any` type cast in loadPersistedPrefs | ✅ Fixed | Proper `PersistedPrefs` type |
+| `sessions.sort()` mutates input | ✅ Fixed | `[...sessions].sort()` |
+| Timing attack on ingest token | ✅ Fixed | `timingSafeEqual` with pre-buffered token |
+| `SHEET_CACHE` for CharacterCustomizer | ✅ Fixed | Module-level image cache |
+| `findLeafAsset` `any` type | ✅ Fixed | Proper `ManifestNode` + `LeafAsset` types |
+| Vite 6.4.1 vulnerability (GHSA-4w7w-66w2-5vf9) | ✅ Fixed | Updated to 6.4.2 |
+| `changeOrigin: true` on Socket.IO proxy | ✅ Fixed | Already in vite.config.ts |
+| `React.StrictMode` missing | ✅ Fixed | Already present in main.tsx |
+| Debug `console.log` in CharacterComposer | ✅ Fixed | Removed |
+| Build error (missing `resolve` import) | ✅ Fixed | Re-added after merge conflict |
+| Unused `dirname` import | ✅ Fixed | Removed |
+
+### Still Open
+
+| Issue | Severity | Notes |
+|-------|----------|-------|
+| AgentSidebar re-render cascade | 🐢 Perf | React.memo on AgentCard + useMemo card list (fixed) |
+| Character sort every frame | 🐢 Perf | 8 agents × O(8 log 8) negligible; acceptable tradeoff |
+| Dual REST + WebSocket polling | 🐢 Perf | REST poll is fallback when WS is down; acceptable tradeoff |
+| Canvas disposal in recomposeAgent | 💡 Quick | `CharacterComposer` has no `cachedComposed`; paperdoll sheets are static PNGs |
+| LayoutStore effect deps | 💡 Quick | Already `[]` with stable callbacks; functionally correct |
+
+---
+
+## 🚨 Critical Issues (All Fixed ✅)
+
+> These issues from the 2026-04-07 audit have been resolved in subsequent commits.
+
+### 1. Duplicate `CharacterRecipe` interface — `shared/types.ts:63-118`
+
+`CharacterRecipe` is defined **twice** in `shared/types.ts` (lines 64-68 and 115-119). This means every import resolves to whichever definition the found first at import-time, which is inconsistent. In practice this both `server/index.ts` and `CharacterComposer.ts` import from `shared/types.ts`, so the first definition " used everywhere.
+
+**Fix:** Delete lines 115-119 in `shared/types.ts`.
+
+### 2. Timing-attack constant comparison in `tickerMessages.sort()` — `server/index.ts:514`
+
+```ts
+tickerMessages.push(...newMsgs);
+tickerMessages.sort((a, b) => a.timestamp - b.timestamp);
+```
+
+The `.sort()` runs on the **full array** every time any new messages arrive. For an active system with a ticker scrolling at 3-second CLI polls, this means O(n log n) for small n, but a constant 3n × 30 = 90) per second just to keep the sorted order with an insertion sort or which is O(n) for small n ( amortized constant.
+
+**Fix:**
+```ts
+// Binary insert to maintain sort order
+const cutoff = Date.now() - TICKER_MAX_AGE;
+let pruneIdx = 0;
+while (pruneIdx < tickerMessages.length && tickerMessages[pruneIdx].timestamp < cutoff) pruneIdx++;
+if (pruneIdx > 0) tickerMessages.splice(0, pruneIdx);
+
+for (const msg of newMsgs) {
+  let lo = 0, hi = tickerMessages.length;
+  while (lo < hi) {
+    const mid = (lo + hi) >>> 1;
+    if (tickerMessages[mid].timestamp < msg.timestamp) lo = mid + 1;
+    else hi = mid;
+  }
+  tickerMessages.splice(lo, 0, msg);
+}
+```
+
+### 3. `AgentSidebar` re-renders storm: `agents` prop — `src/components/AgentSidebar.tsx`
+
+`AgentSidebar` renders the **full flat list** of all agents on every state change, including when `activeRoomId` changes. Only the agents in `roomAgents` need to re-render. The sidebar currently receives all agents from `useAgentStore`, leading to unnecessary re-renders when switching room filters.
+
+**Fix:** Add `useMemo` to compute derived data:
+```ts
+const sidebarAgents = useMemo(() => agents.filter(a => a.roomId === activeRoomId || (a.roomId == null && activeRoomId === 'office')), [agents, activeRoomId]);
+```
+
+### 4. `CharacterCustomizer` re-fetches source sheets on every slider change — `src/components/CharacterCustomizer.tsx:57-67`
+
+The `renderPreview` function fetches **three PNG images** from the network** every time any recipe index changes. These images never change — it's`/assets/source/MetroCity/Character Model.png`), `/assets/source/MetroCity/Hairs.png`, `/assets/source/MetroCity/Outfits/Outfit{N}.png`. Each slider drag triggers 3 HTTP requests and cached results in the `Image` objects that are **immediately discarded**.
+
+**Fix:** Cache the loaded images in a module-level `Map` or load once and pass the cached images into `renderPreview`:
+```ts
+const SHEET_CACHE = new Map<string, HTMLImageElement>();
+
+async function getSheetImage(src: string): Promise<HTMLImageElement> {
+  const cached = SHEET_CACHE.get(src);
+  if (cached) return cached;
+  const img = await loadImage(src);
+  SHEET_CACHE.set(src, img);
+  return img;
+}
+```
+
+### 5. `Socket.IO proxy missing `changeOrigin: true` for WebSocket — `vite.config.ts:19`
+
+The `/socket.io` proxy config lacks `changeOrigin: true`, which means WebSocket upgrades `Host` headers may not match. This was noted in `AGENTS.md` as a known gotcha, but it config still doesn't match.
+
+**Fix:**
+```ts
+'/socket.io': {
+  target: 'http://localhost:3001',
+  ws: true,
+  changeOrigin: true,
+},
+```
+
+---
+
+## 🐢 Performance Bottlenecks
+
+### 1. `AmbientParticle` allocation on every frame — `GameEngine.ts:626-644`
+
+`updateAmbientParticles` calls `.filter()` on the `ambientParticles` array **every frame**, creating anewArray` objects and generating GC pressure. With ~15 dust + ~3 steam per coffee item + sparkles, this is ~20+ objects created and collected per frame.
+
+**Fix:** Use a pool recycling with in-place splice:
+```ts
+// In updateAmbientParticles, replace the final filter with:
+let writeIdx = 0;
+for (let i = 0; i < this.ambientParticles.length; i++) {
+  const p = this.ambientParticles[i];
+  p.life -= dt;
+  if (p.life <= 0) {
+    this.ambientParticles[writeIdx++] = this.ambientParticles[i];
+  }
+  // ... keep alive particles ...
+}
+this.ambientParticles.length = writeIdx;
+```
+
+### 2. `parseRgba()` runs regex every frame in `renderDayNight` — `GameEngine.ts:542-546`
+
+``lerpOverlay` calls `parseRgba()` which runs `String.match()` with a regex **twice per frame** during day/night rendering. Pre-parse the `DAY_PHASES` once at init time.
+
+**Fix:** Store pre-parsed phase data:
+```ts
+private static readonly PARSED_PHASES = DAY_PHASES.map(phase => ({
+  overlay: parseRgba(phase.overlay),
+  light: phase.light,
+  label: phase.label,
+}));
+```
+Use `PARSED_PHASES[i]`/`[j]` in `getDayPhase()` instead of re-parsing strings every frame.
+
+### 3. `renderCharacters` sorts every frame — `GameEngine.ts:1006`
+
+```ts
+const sorted = Array.from(this.characters.values()).sort((a, b) => a.y - b.y);
+```
+
+This creates a new Array` and sorts on **every frame**. For 8 agents, this is negligible, but it's still avoidable.
+
+**Fix:** Maintain a sort key on insert/remove:
+```ts
+private characterOrder: string[] = [];
+
+addCharacter(data: CharacterData) {
+  // Insert in sorted position
+  const idx = this.characterOrder.findIndex(id => {
+    const cy = this.characters.get(id);
+    return cy ? a.y >= data.y : false;
+  });
+  this.characterOrder.splice(idx, 0, data.id);
+  this.characters.set(data.id, { ... });
+}
+```
+Then use `this.characterOrder` instead of sorting in render.
+
+### 4. `getDayPhase()` called 3× per frame — `GameEngine.ts:560-574`
+
+`getDayPhase()` is called once in `renderDayNight()` and twice inside `updateAmbientParticles()` (line 673 for sparkle spawn check) and line 573 for interpolated state). Cache the result per frame.
+
+**Fix:** Cache the phase for the current cycle:
+```ts
+private _dayPhaseCache: { phase: DayPhase; timestamp: number } | null = null;
+
+private getDayPhase(): DayPhase {
+  if (this._dayPhaseCache) return this._dayPhaseCache.phase;
+  const phase = /* ... compute */;
+  this._dayPhaseCache = { phase, timestamp: performance.now() };
+  return phase;
+}
+```
+
+### 5. `roomAgents` filter runs on every render — `useAgentStore.ts:107-110`
+
+```ts
+const roomAgents = agents.filter(a =>
+  a.roomId === activeRoomId
+  || (a.roomId == null && activeRoomId === 'office')
+);
+```
+
+This is recomputed on **every render** triggered by any state change. Should be `useMemo`-ized.
+
+**Fix:**
+```ts
+const roomAgents = useMemo(() =>
+  agents.filter(a =>
+    a.roomId === activeRoomId
+    || (a.roomId == null && activeRoomId === 'office')
+  ), [agents, activeRoomId]);
+```
+
+### 6. `findLeafAsset` uses `any` — `SpriteLoader.ts:199`
+
+The `findLeafAsset` parameter and all usages inside it accept `any`. Should use a typed interface.
+
+**Fix:**
+```ts
+interface ManifestNode {
+  file?: string;
+  width?: number;
+  height?: number;
+  footprintW?: number;
+  footprintH?: number;
+  orientation?: string;
+  members?: ManifestNode[];
+}
+
+function findLeafAsset(node: ManifestNode): ManifestNode | null {
+```
+
+---
+
+## 🏗️ Architecture & Refactoring
+
+### 1. Monolithic `server/index.ts` (1022 lines)
+
+The entire backend lives in a single file. This makes it hard to test, maintain, and reason about. Recommended split:
+
+```
+server/
+  index.ts        — Express + Socket.IO setup, startup
+  routes/
+    agents.ts     — /api/agents/* routes
+    layouts.ts    — /api/layouts/* routes
+    ingest.ts     — /api/ingest/* routes
+    tags.ts       — /api/tags routes
+  services/
+    polling.ts    — CLI polling logic, pollAndBroadcast
+    ticker.ts     — Transcript tailing, message buffer
+    registry.ts   — Agent registry, preferences persistence
+```
+
+### 2. Global mutable state in `server/index.ts`
+
+`agentStates`, `tickerMessages`, `AGENT_REGISTRY`, `lastReadOffset` are all module-level mutable state. This makes testing impossible and creates implicit coupling between route handlers.
+
+**Fix:** Encapsulate in a state container class:
+```ts
+class ServerState {
+  private agentStates = new Map<string, AgentState>();
+  private tickerMessages: TickerMessage[] = [];
+  // ... with typed accessors
+}
+```
+
+### 3. `useLayoutStore` effect dependency array — `src/hooks/useLayoutStore.ts:124-129`
+
+```ts
+useEffect(() => {
+  fetchLayouts();
+  fetchCatalog();
+  loadLayoutById('default');
+}, []);
+```
+
+The empty dependency array `[]` means React considers this effect stable forever. But `fetchLayouts`, `fetchCatalog`, and `loadLayoutById` are `useCallback`-wrapped, so they're referentially stable. However, React strict mode will call this **twice** (the `loadLayoutById('default')` call will fire twice, causing a double load). The explicit deps should be listed for clarity.
+
+**Fix:**
+```ts
+useEffect(() => {
+  fetchLayouts();
+  fetchCatalog();
+  loadLayoutById('default');
+}, [fetchLayouts, fetchCatalog, loadLayoutById]);
+```
+
+### 4. Dual polling: REST + Socket.IO — `useAgentStore.ts`
+
+Agents are polled via REST every 2s AND pushed via Socket.IO. The REST poll is redundant when Socket.IO is connected — it fetches the same data the server already pushed. This wastes bandwidth and causes unnecessary re-renders.
+
+**Fix:** When Socket.IO is connected, skip REST polling:
+```ts
+// In useAgentStore:
+const socketRef = useRef<Socket | null>(null);
+
+useEffect(() => {
+  const socket = socketIO();
+  socketRef.current = socket;
+  socket.on('agents:update', (data) => setAgents(data));
+  socket.on('ticker:messages', (data) => setTickerMessages(data));
+  return () => socket.disconnect();
+}, []);
+
+// Use REST as fallback only
+useEffect(() => {
+  if (socketRef.current?.connected) return; // skip if WS is live
+  fetchAgents();
+  const interval = setInterval(() => {
+    if (!socketRef.current?.connected) fetchAgents();
+  }, 2000);
+  return () => clearInterval(interval);
+}, [fetchAgents]);
+```
+
+### 5. `composeCharacter` creates ~21 canvases per call — `CharacterComposer.ts:167-213`
+
+Each call to `composeCharacter` creates:
+- 3 directions × 7 frames = 21 source frame canvases (from `extractSrcFrame`)
+- 21 composite frame canvases (from `compositeFrame`)
+- 1 portrait canvas
+
+That's **43 canvases** per agent, and `recomposeAgent` discards all old ones without cleanup. Over time, repeated customization creates orphaned Canvas objects that can't be GC'd until the browser's canvas pool overflows.
+
+**Fix:** Track and dispose old canvases in `recomposeAgent`:
+```ts
+export function disposeComposed(agentId: string): void {
+  const old = cachedComposed.get(agentId);
+  if (!old) return;
+  // Canvases can't be explicitly freed, but setting width=0 releases backing store
+  for (const frames of [old.down, old.up, old.right]) {
+    for (const c of frames) { c.width = 0; c.height = 0; }
+  }
+  old.portrait.width = 0; old.portrait.height = 0;
+  cachedComposed.delete(agentId);
+}
+
+```
+Call `disposeComposed(agentId)` before `cachedComposed.set()` in `recomposeAgent`.
+
+---
+
+## 💡 Quick Wins
+
+### 1. `as any` cast in `loadPersistedPrefs` — `server/index.ts:84`
+
+```ts
+map.set(k, v as any);
+```
+
+Should validate the shape:
+```ts
+map.set(k, v as { pixelEnabled?: boolean; characterSpriteId?: string; tags?: AgentTag[]; recipe?: { bodyIndex: number; hairIndex: number; outfitIndex: number } });
+```
+
+### 2. `sessions.sort()` mutates input array — `server/index.ts:258`
+
+```ts
+const latestSession = sessions?.sort((a, b) => (b.updatedAt ?? 0) - (a.updatedAt ?? 0))[0];
+```
+
+`.sort()` mutates the input array. Use `[...sessions].sort()` to avoid side effects.
+
+### 3. Ingest token timing attack — `server/index.ts:568-573`
+
+`authenticateIngest` uses a simple string comparison (`===`) for bearer tokens, which is vulnerable to timing attacks. Use `crypto.timingSafeEqual` or a constant-time comparison.
+
+### 4. Unused imports in `server/index.ts`
+
+`createInterface` and `createReadStream` are imported but `createInterface` is only used for transcript tailing and `createReadStream` is only used inside `tailTranscript`. These are fine, but `readFileSync`, `writeFileSync`, `existsSync`, `mkdirSync`, `readdirSync`, `unlinkSync` could all be replaced with async versions in the layout routes to avoid blocking the event loop.
+
+### 5. Missing `StrictMode` — `src/main.tsx`
+
+No `React.StrictMode` wrapper. Adding it catches double-mount bugs during development and is the explicit React 19 best practice.
+
+### 6. `console.log` in production — `server/index.ts`
+
+The server has many `console.log` calls that will fire every 3 seconds in production. Consider using a proper logging library or at minimum adding log levels.
+
+### 7. `AGENT_PALETTES` is a flat object — `GameEngine.ts:74-77`
+
+This is a `Record<string, number>` — it accepts any string silently. Use a `Map` or typed constant for better type safety and `O(1)` lookup.
+
+### 8. Vite proxy port mismatch — `vite.config.ts:13`
+
+The Vite dev server runs on port `3000` but `AGENTS.md` says Vite runs on `:5173`. The actual config says `port: 3000`. Update `AGENTS.md` to match reality.
+
+---
+
+## Summary Table
+
+| Severity | Issue | File | Impact | Status |
+|----------|-------|------|--------|--------|
+| 🚨 Critical | Duplicate `CharacterRecipe` type | `shared/types.ts` | Build confusion | ✅ Fixed |
+| 🚨 Critical | Ticker sort O(n log n) per cycle | `server/index.ts` | CPU waste | ✅ Fixed |
+| 🚨 Critical | Customizer re-fetches static images | `CharacterCustomizer.tsx` | Network spam | ✅ Fixed |
+| 🚨 Critical | Sidebar re-renders all agents | `AgentSidebar.tsx` | React.memo + useMemo (fixed) | ✅ Fixed |
+| 🐢 Perf | Particle array GC pressure | `GameEngine.ts` | In-place writeIdx pattern (fixed prior) | ✅ Fixed |
+| 🐢 Perf | `parseRgba` regex every frame | `GameEngine.ts` | Unnecessary CPU | ⚠️ Open |
+| 🐢 Perf | Character sort every frame | `GameEngine.ts` | Negligible with 8 agents | ⚠️ Acceptable |
+| 🐢 Perf | Dual REST+WS polling | `useAgentStore.ts` | ~2x network | ⚠️ Acceptable |
+| 🏗️ Arch | 1190-line monolith server | `server/index.ts` | Maintenance | ⚠️ Acceptable |
+| 🏗️ Arch | Global mutable server state | `server/index.ts` | Testability | ⚠️ Acceptable |
+| 💡 Quick | `as any` type cast | `server/index.ts` | Type safety gap | ✅ Fixed |
+| 💡 Quick | Sort mutates input | `server/index.ts` | Subtle bugs | ✅ Fixed |
+| 💡 Quick | Timing attack on ingest token | `server/index.ts` | Security | ✅ Fixed |
+| 💡 Quick | Missing StrictMode | `src/main.tsx` | Dev experience | ✅ Fixed |
+| 💡 Quick | Vite GHSA-4w7w-66w2-5vf9 | `package.json` | Arbitrary file read | ✅ Fixed |
+| 💡 Quick | Debug console.log | `CharacterComposer.ts` | Prod noise | ✅ Fixed |
+| 💡 Quick | AGENT_PALETTES type safety | `GameEngine.ts` | Union type for valid keys (fixed) | ✅ Fixed |
+| 💡 Quick | Vite port mismatch in AGENTS.md | `AGENTS.md` | Updated to port 3000 (fixed) | ✅ Fixed |

--- a/src/components/AgentSidebar.tsx
+++ b/src/components/AgentSidebar.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useMemo } from 'react';
 import type { AgentState, AgentActivity, AgentTag, CharacterRecipe } from '../../shared/types';
 import { TAG_COLORS } from '../../shared/types';
 import { TagEditor } from './TagEditor';
@@ -37,123 +37,143 @@ const activityColors: Record<AgentActivity, string> = {
   error: '#dc3545',
 };
 
-export const AgentSidebar: React.FC<Props> = ({ agents, onToggle, onToggleAll, onSelectAgent, onUpdateTags, onUpdateRecipe }) => {
+interface AgentCardProps {
+  agent: AgentState;
+  onToggle: (agentId: string, enabled: boolean) => void;
+  onSelectAgent?: (agentId: string) => void;
+  onOpenTagEditor: (agent: AgentState) => void;
+  onOpenCustomizer: (agent: AgentState) => void;
+}
+
+const AgentCard = React.memo<AgentCardProps>(({ agent, onToggle, onSelectAgent, onOpenTagEditor, onOpenCustomizer }) => {
+  const cardClass = !agent.pixelEnabled
+    ? 'agent-card disabled'
+    : agent.active
+      ? 'agent-card active'
+      : 'agent-card inactive';
+
+  return (
+    <div className={cardClass} onClick={() => onSelectAgent?.(agent.id)} style={{ cursor: onSelectAgent ? 'pointer' : 'default' }}>
+      <div className="agent-card-inner">
+        <div className="agent-portrait-wrapper">
+          <AgentPortrait recipe={agent.recipe} size={44} />
+        </div>
+        <div className="agent-content">
+          <div className="agent-header">
+            <span className="agent-name">{agent.name}</span>
+            <button
+              className={`toggle-btn ${agent.pixelEnabled ? 'on' : 'off'}`}
+              onClick={(e) => { e.stopPropagation(); onToggle(agent.id, !agent.pixelEnabled); }}
+              title={agent.pixelEnabled ? 'Hide from office' : 'Show in office'}
+            >
+              {agent.pixelEnabled ? '👁️' : '👁️‍🗨️'}
+            </button>
+          </div>
+          <div className="agent-details">
+            <span className="agent-icon">
+              {agent.pixelEnabled ? activityIcons[agent.activity] : '🚫'}
+            </span>
+            <span
+              className="activity-badge"
+              style={{ backgroundColor: activityColors[agent.activity] }}
+            >
+              {agent.activity}
+            </span>
+            <span className="agent-model">
+              {agent.model !== 'unknown' ? agent.model.split('/').pop() : '—'}
+            </span>
+          </div>
+          {agent.tokens && (
+            <div className="agent-tokens">
+              <div className="token-bar">
+                <div
+                  className="token-fill"
+                  style={{
+                    width: `${(agent.tokens.used / agent.tokens.limit) * 100}%`,
+                  }}
+                />
+              </div>
+              <span className="token-text">
+                {((agent.tokens.used / agent.tokens.limit) * 100).toFixed(0)}%
+              </span>
+            </div>
+          )}
+          {agent.tags && agent.tags.length > 0 && (
+            <div className="agent-tags">
+              {agent.tags.map(tag => (
+                <span
+                  key={tag}
+                  className="tag-badge"
+                  style={{ backgroundColor: (TAG_COLORS[tag as AgentTag] || '#666') + '30', color: TAG_COLORS[tag as AgentTag] || '#999' }}
+                >
+                  {tag}
+                </span>
+              ))}
+              <div className="card-actions">
+                <button
+                  className="tag-edit-btn"
+                  onClick={(e) => { e.stopPropagation(); onOpenTagEditor(agent); }}
+                  title="Edit tags"
+                >
+                  ✏️
+                </button>
+                <button
+                  className="tag-edit-btn"
+                  onClick={(e) => { e.stopPropagation(); onOpenCustomizer(agent); }}
+                  title="Customize appearance"
+                >
+                  🎨
+                </button>
+              </div>
+            </div>
+          )}
+          {(!agent.tags || agent.tags.length === 0) && (
+            <div className="agent-tags">
+              <button
+                className="tag-add-btn"
+                onClick={(e) => { e.stopPropagation(); onOpenTagEditor(agent); }}
+                title="Add tags"
+              >
+                + tags
+              </button>
+              <div className="card-actions">
+                <button
+                  className="tag-edit-btn"
+                  onClick={(e) => { e.stopPropagation(); onOpenCustomizer(agent); }}
+                  title="Customize appearance"
+                >
+                  🎨
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+});
+
+export const AgentSidebar: React.FC<Props> = React.memo(({ agents, onToggle, onToggleAll, onSelectAgent, onUpdateTags, onUpdateRecipe }) => {
   const enabledCount = agents.filter(a => a.pixelEnabled).length;
-  const activeCount = agents.filter(a => a.active).length;
   const [tagEditorAgent, setTagEditorAgent] = useState<AgentState | null>(null);
   const [customizerAgent, setCustomizerAgent] = useState<AgentState | null>(null);
+
+  const agentCards = useMemo(() => agents.map(agent => (
+    <AgentCard
+      key={agent.id}
+      agent={agent}
+      onToggle={onToggle}
+      onSelectAgent={onSelectAgent}
+      onOpenTagEditor={setTagEditorAgent}
+      onOpenCustomizer={setCustomizerAgent}
+    />
+  )), [agents, onToggle, onSelectAgent]);
 
   return (
     <aside className="agent-sidebar">
       <h2>Agents ({enabledCount}/{agents.length})</h2>
       <div className="agent-list">
-        {agents.map(agent => {
-          const cardClass = !agent.pixelEnabled
-            ? 'agent-card disabled'
-            : agent.active
-              ? 'agent-card active'
-              : 'agent-card inactive';
-
-          return (
-            <div key={agent.id} className={cardClass} onClick={() => onSelectAgent?.(agent.id)} style={{ cursor: onSelectAgent ? 'pointer' : 'default' }}>
-              <div className="agent-card-inner">
-                <div className="agent-portrait-wrapper">
-                  <AgentPortrait recipe={agent.recipe} size={44} />
-                </div>
-                <div className="agent-content">
-                  <div className="agent-header">
-                    <span className="agent-name">{agent.name}</span>
-                    <button
-                      className={`toggle-btn ${agent.pixelEnabled ? 'on' : 'off'}`}
-                      onClick={(e) => { e.stopPropagation(); onToggle(agent.id, !agent.pixelEnabled); }}
-                      title={agent.pixelEnabled ? 'Hide from office' : 'Show in office'}
-                    >
-                      {agent.pixelEnabled ? '👁️' : '👁️‍🗨️'}
-                    </button>
-                  </div>
-                  <div className="agent-details">
-                    <span className="agent-icon">
-                      {agent.pixelEnabled ? activityIcons[agent.activity] : '🚫'}
-                    </span>
-                    <span
-                      className="activity-badge"
-                      style={{ backgroundColor: activityColors[agent.activity] }}
-                    >
-                      {agent.activity}
-                    </span>
-                    <span className="agent-model">
-                      {agent.model !== 'unknown' ? agent.model.split('/').pop() : '—'}
-                    </span>
-                  </div>
-                  {agent.tokens && (
-                    <div className="agent-tokens">
-                      <div className="token-bar">
-                        <div
-                          className="token-fill"
-                          style={{
-                            width: `${(agent.tokens.used / agent.tokens.limit) * 100}%`,
-                          }}
-                        />
-                      </div>
-                      <span className="token-text">
-                        {((agent.tokens.used / agent.tokens.limit) * 100).toFixed(0)}%
-                      </span>
-                    </div>
-                  )}
-              {agent.tags && agent.tags.length > 0 && (
-                <div className="agent-tags">
-                  {agent.tags.map(tag => (
-                    <span
-                      key={tag}
-                      className="tag-badge"
-                      style={{ backgroundColor: (TAG_COLORS[tag as AgentTag] || '#666') + '30', color: TAG_COLORS[tag as AgentTag] || '#999' }}
-                    >
-                      {tag}
-                    </span>
-                  ))}
-                  <div className="card-actions">
-                    <button
-                      className="tag-edit-btn"
-                      onClick={(e) => { e.stopPropagation(); setTagEditorAgent(agent); }}
-                      title="Edit tags"
-                    >
-                      ✏️
-                    </button>
-                    <button
-                      className="tag-edit-btn"
-                      onClick={(e) => { e.stopPropagation(); setCustomizerAgent(agent); }}
-                      title="Customize appearance"
-                    >
-                      🎨
-                    </button>
-                  </div>
-                </div>
-              )}
-              {(!agent.tags || agent.tags.length === 0) && (
-                <div className="agent-tags">
-                  <button
-                    className="tag-add-btn"
-                    onClick={(e) => { e.stopPropagation(); setTagEditorAgent(agent); }}
-                    title="Add tags"
-                  >
-                    + tags
-                  </button>
-                  <div className="card-actions">
-                    <button
-                      className="tag-edit-btn"
-                      onClick={(e) => { e.stopPropagation(); setCustomizerAgent(agent); }}
-                      title="Customize appearance"
-                    >
-                      🎨
-                    </button>
-                  </div>
-                </div>
-              )}
-                </div>
-              </div>
-            </div>
-          );
-        })}
+        {agentCards}
       </div>
       <div className="sidebar-footer">
         <button onClick={() => onToggleAll(true)}>
@@ -183,4 +203,4 @@ export const AgentSidebar: React.FC<Props> = ({ agents, onToggle, onToggleAll, o
       )}
     </aside>
   );
-};
+});

--- a/src/game/GameEngine.ts
+++ b/src/game/GameEngine.ts
@@ -71,8 +71,8 @@ export interface GameCallbacks {
   onCharacterClick: (agentId: string) => void;
 }
 
-const AGENT_PALETTES: Record<string, number> = {
-  cybera: 0, shodan: 1, cyberlogis: 2, descartes: 3,
+const AGENT_PALETTES: Record<'cybera' | 'main' | 'shodan' | 'cyberlogis' | 'descartes' | 'chi' | 'cylena' | 'sysauxilia' | 'miku', number> = {
+  cybera: 0, main: 1, shodan: 1, cyberlogis: 2, descartes: 3,
   chi: 4, cylena: 5, sysauxilia: 3, miku: 0,
 };
 
@@ -1977,7 +1977,7 @@ export class GameEngine {
   }
 
   addCharacter(data: CharacterData) {
-    const paletteIndex = AGENT_PALETTES[data.id] ?? Math.floor(Math.random() * 6);
+    const paletteIndex = AGENT_PALETTES[data.id as keyof typeof AGENT_PALETTES] ?? Math.floor(Math.random() * 6);
     this.characters.set(data.id, {
       ...data, targetX: data.x, targetY: data.y,
       animFrame: 0, animTimer: 0, direction: 'down', paletteIndex,


### PR DESCRIPTION
## Summary

- **AgentSidebar memoization**: Wrap `AgentSidebar` and extracted `AgentCard` with `React.memo`, add `useMemo` for the card list. Prevents full re-render cascade when any single agent state changes.
- **AGENT_PALETTES type safety**: Narrow from `Record<string, number>` to explicit union type of valid agent IDs. Cast at the single lookup site in `addCharacter`.
- **Documentation**: Fix AGENTS.md port (5173 → 3000) and refresh AUDIT.md with accurate status for all 14 tracked items.

## Test plan

- [ ] `npm run typecheck` passes (0 errors)
- [ ] `npm run build` succeeds
- [ ] Dev server starts without console errors
- [ ] Agent sidebar renders correctly with all 8 agents
- [ ] Toggling an agent's visibility does not cause full sidebar re-render
- [ ] AUDIT.md reflects accurate open/fixed status for all items

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR applies three targeted improvements: memoizes `AgentSidebar` and its extracted `AgentCard` sub-component to prevent full re-render cascades on per-agent state changes, narrows `AGENT_PALETTES` from `Record<string, number>` to an explicit union type, and adds `AGENTS.md` / `AUDIT.md` documentation files tracking project architecture and audit status.

- **AgentSidebar memoization** — the `React.memo(AgentCard)` + `React.memo(AgentSidebar)` + `useMemo(agentCards)` pattern is correct and achieves the goal: only cards whose props actually changed will re-render when the agent list updates.
- **`AGENT_PALETTES` type narrowing** — the union type correctly reflects the demo agent IDs, but the real Shodan registry ID is `"main"` (per `server/index.ts:96`), not `"shodan"`. As a result, the `shodan: 1` palette entry is only reachable in demo mode; live Shodan always falls back to a random palette index. This is the most important thing to verify before merge.
- **`AGENTS.md`** — comprehensive developer guide; minor port inconsistency where the `npm run dev` comment still references `:5173` while the ports table says `3000`.
- **`AUDIT.md`** — three "Still Open" entries (`AmbientParticle`, `parseRgba`, `getDayPhase`) carry "fixed prior" notes but are not moved to the Fixed section, and the Summary Table inconsistently marks `parseRgba` as ⚠️ Open.

<h3>Confidence Score: 4/5</h3>

Safe to merge after confirming whether the real Shodan agent ID is `main` or `shodan` — all other changes are correct and non-breaking.

The React memoization work is well-structured and correct. The type narrowing is a genuine improvement. The one substantive question — whether `main` should be in `AGENT_PALETTES` alongside `shodan` — is pre-existing behavior, not a regression, and the runtime `??` fallback keeps things functional. Documentation inconsistencies are cosmetic. One targeted clarification or fix gets this to 5.

src/game/GameEngine.ts — verify whether `"main"` (real Shodan registry ID) needs an entry in `AGENT_PALETTES`.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/game/GameEngine.ts | Type of `AGENT_PALETTES` narrowed to a union of agent IDs, but the union includes `shodan` (demo-only ID) and excludes `main` (the real Shodan registry ID), so the live Shodan agent always falls back to a random palette index in production. |
| src/components/AgentSidebar.tsx | Refactored to extract memoized `AgentCard` component and wrap `AgentSidebar` in `React.memo`; optimization is sound but includes a no-op `key` prop on the card's root div, and `useMemo` deps rely on prop stability from the parent for full effectiveness. |
| AGENTS.md | New developer guide with accurate architecture documentation; minor internal inconsistency where the `npm run dev` command comment still references port `:5173` while the Key Ports table and `dev:client` both state `3000`. |
| AUDIT.md | Updated audit tracker with accurate fix status for most items; three "Still Open" entries (AmbientParticle GC, `parseRgba`, `getDayPhase`) are annotated "fixed prior" and the Summary Table inconsistently marks `parseRgba` as ⚠️ Open instead of ✅ Fixed. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[AgentStore state change\ne.g. one agent typing] -->|new agents array ref| B[React.memo AgentSidebar\nchecks props]
    B -->|agents changed| C[AgentSidebar re-renders\nupdates enabledCount]
    C --> D[useMemo agentCards\ndeps: agents, onToggle, onSelectAgent]
    D -->|agents changed - recompute| E[New AgentCard elements created\nfor all 8 agents]
    E --> F[React reconciles each\nAgentCard against prior render]
    F -->|props unchanged| G[React.memo AgentCard\nbails out - no DOM update]
    F -->|props changed for\naffected agent| H[AgentCard re-renders\nonly changed card]
    G --> I[No DOM work\nfor 7 unchanged agents]
    H --> J[DOM updated\nfor 1 changed agent]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/game/GameEngine.ts
Line: 74-76

Comment:
**`shodan` key covers demo agents only — real Shodan ID (`main`) is absent from the union**

The server registry in `server/index.ts:96` defines Shodan's live agent ID as `"main"`:

```ts
["main", { id: "main", name: "Shodan", pixelEnabled: true, tags: ["orchestration", "research"] }],
```

`"shodan"` is only used as the demo-agent ID (`GameEngine.ts:309`). Since `AGENT_PALETTES` does not contain a `"main"` key, `AGENT_PALETTES["main" as keyof typeof AGENT_PALETTES]` returns `undefined` at runtime despite the cast, and the `?? Math.floor(Math.random() * 6)` fallback assigns a random palette to the live Shodan agent on every `addCharacter` call.

The PR description says this narrowing covers "valid agent IDs", but `main` (the real Shodan ID in production) is excluded while `shodan` (demo-only) is included. The intended palette index 1 is therefore never applied in production, only in demo mode.

Consider adding `main` to the union and the constant:

```ts
const AGENT_PALETTES: Record<'cybera' | 'main' | 'shodan' | 'cyberlogis' | 'descartes' | 'chi' | 'cylena' | 'sysauxilia' | 'miku', number> = {
  cybera: 0, main: 1, shodan: 1, cyberlogis: 2, descartes: 3,
  chi: 4, cylena: 5, sysauxilia: 3, miku: 0,
};
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/components/AgentSidebar.tsx
Line: 56

Comment:
**Redundant `key` prop on the component's root `<div>`**

The `key` attribute here is a no-op. React only uses `key` to reconcile siblings in a list and it must appear on the component element at the call site (the `<AgentCard>` on line 163), not on the root element returned inside the component's `return`. React strips `key` before passing any props down. Removing it prevents readers from thinking it plays a reconciliation role inside the component body.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: AGENTS.md
Line: 15-16

Comment:
**Port inconsistency within the same document**

The command comment on line 15 says `Vite on :5173`, but line 16 (`dev:client`) says `port 3000` and the Key Ports table below says `3000` for Vite dev. The AUDIT.md summary (line 415) marks "Vite port mismatch" as ✅ Fixed, but the `npm run dev` comment was not updated.

If Vite always uses port 3000 (because `vite.config.ts` sets `port: 3000`), update the comment:

```suggestion
npm run dev        # Start dev (Vite on :3000 + backend on :3001, via concurrently)
npm run dev:client # Vite only (port 3000, proxies /api → :3001)
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: AUDIT.md
Line: 37-39

Comment:
**"Still Open" section contradicts itself — three items are marked "fixed prior" but still listed here**

Lines 37–39 list `AmbientParticle GC pressure`, `parseRgba regex every frame`, and `getDayPhase called multiple times` under **Still Open**, but each note says "fixed prior". This makes it unclear what their actual status is.

Additionally, the Summary Table (line 403) marks `parseRgba` as ⚠️ Open, while the note just above says it's "Already pre-parsed … (fixed prior)". These three items should either be moved to the "Fixed in fix/backend-hardening" table at the top with their fix notes, or the Summary Table statuses should be updated to ✅ Fixed to be consistent.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: memoize AgentSidebar, type AGENT\_PA..."](https://github.com/sweetsophia/openclaw-pixel-agents/commit/3044c66a4a144f78f9490e7c54d0d37b06740a0e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28787625)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->