### PR TITLE
fix(client): restore REST polling fallback in useAgentStore

### DIFF
--- a/src/hooks/useAgentStore.ts
+++ b/src/hooks/useAgentStore.ts
@@ -15,15 +15,18 @@ export function useAgentStore() {
   const [activeRoomId, setActiveRoomId] = useState<string>('office');
 
   const fetchAgents = useCallback(async () => {
+    // `connected` is a WebSocket-liveness signal and is driven only by the
+    // Socket.IO event handlers below. A successful REST response here is NOT
+    // evidence that the WS is up — flipping `connected` from this function
+    // would create a feedback loop with the REST polling fallback that gates
+    // on `connected` (see useEffect for the fallback).
     try {
       const res = await fetch(`${API_BASE}/agents`);
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       const data = await res.json();
       setAgents(data.agents || []);
-      setConnected(true);
       setError(null);
     } catch (err) {
-      setConnected(false);
       setError(err instanceof Error ? err.message : 'Connection failed');
     }
   }, []);

--- a/src/hooks/useAgentStore.ts
+++ b/src/hooks/useAgentStore.ts
@@ -164,6 +164,7 @@ export function useAgentStore() {
   // stale state. Matches the contract documented in AGENTS.md ("Data Flow").
   useEffect(() => {
     if (connected) return;
+    fetchAgents(); // immediate first fetch — don't wait the full interval on entry
     const pollTimer = setInterval(fetchAgents, 2000);
     return () => clearInterval(pollTimer);
   }, [connected, fetchAgents]);

--- a/src/hooks/useAgentStore.ts
+++ b/src/hooks/useAgentStore.ts
@@ -156,5 +156,14 @@ export function useAgentStore() {
     };
   }, [fetchAgents]);
 
+  // REST polling fallback — primary update channel is Socket.IO; this degraded-mode
+  // poll kicks in only when the WS connection is down so the UI does not freeze on
+  // stale state. Matches the contract documented in AGENTS.md ("Data Flow").
+  useEffect(() => {
+    if (connected) return;
+    const pollTimer = setInterval(fetchAgents, 2000);
+    return () => clearInterval(pollTimer);
+  }, [connected, fetchAgents]);
+
   return { agents, connected, error, toggleAgent, toggleAll, setCharacterSprite, updateTags, updateRecipe, activeRoomId, setActiveRoomId, roomAgents, refresh: fetchAgents };
 }


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
## Summary by Sourcery

Restore a REST-based polling fallback in the agent store hook so the UI continues to receive agent updates when the WebSocket connection is down.

### Bug Fixes
- Ensure agents are periodically refetched via REST when the WebSocket connection is disconnected, preventing stale UI state.

### Enhancements
- Add a connection-aware polling effect that starts when disconnected and automatically cleans up on reconnect or unmount.

## Pull Request Description

This change adds a REST polling fallback to `useAgentStore`. Socket.IO remains the primary update channel; a secondary polling loop is added that activates only when the WS connection is down.

### Functional Impact

- **Degraded-mode data flow**: When the WebSocket disconnects (`connected === false`), the hook now polls `/api/agents` every 2 seconds via the existing `fetchAgents` function, keeping the UI's agent list in sync with the backend.
- **Self-healing on reconnect**: The polling effect depends on `connected` and `fetchAgents`, so reconnecting (or any state change in either dependency) tears down the interval and stops the redundant REST traffic automatically — no reconnect logic itself is duplicated.
- **Bounded lifetime**: The `clearInterval` cleanup ensures the timer is removed both when the WS comes back online and when the consuming component unmounts, preventing leaked intervals.
- **No behavior change in the healthy path**: On a stable Socket.IO connection the new effect early-returns without creating a timer, so existing real-time behavior is preserved untouched.

### Why

The hook previously only performed a single `fetchAgents()` on mount. During any WebSocket outage (proxy reload, transport upgrade failure, transient disconnect) the UI would sit on stale state until a manual reload. This restores the secondary update channel described in `AGENTS.md`.

### Scope

- Single file: `src/hooks/useAgentStore.ts` (+9 lines, -0).
- The existing WebSocket lifecycle `useEffect` is unchanged.
- Test scaffolding, additional review findings, and other fixes remain in their respective follow-up issues and are not addressed here.

---

## Pull Request Description

**Restore REST polling fallback in `useAgentStore`**

The `fetchAgents` function was incorrectly flipping the `connected` state based on REST request outcomes. Since `connected` is meant to reflect WebSocket liveness (driven solely by Socket.IO event handlers), setting it from the REST path created a feedback loop with the REST polling fallback, which gates on the `connected` state.

**Changes:**
- Removed `setConnected(true)` from the success path of `fetchAgents`
- Removed `setConnected(false)` from the error path of `fetchAgents`
- Added an inline comment explaining why `connected` must only be driven by the WebSocket event handlers and not the REST fetch path

This preserves the intended behavior: REST polling continues to refresh agent data as a fallback whenever the WebSocket is disconnected, without the polling itself masking the disconnected state.

---

## Summary

Restored the immediate initial REST polling fetch in the `useAgentStore` hook so that when the WebSocket connection is unavailable, the agent list is fetched right away on entry instead of waiting for the first 2-second interval tick.

## Details

The polling fallback effect previously only set up a `setInterval` to call `fetchAgents` every 2 seconds when `connected` was `false`. While the recurring poll still fires on schedule, there was no immediate invocation when the effect first ran, meaning users could see stale (or empty) agent data for up to 2 seconds before the first refresh.

This change adds a single call to `fetchAgents()` immediately before the interval is established, ensuring the client displays up-to-date data as soon as the fallback path is engaged, while preserving the existing comment about the data-flow contract documented in `AGENTS.md`.

## Impact

- **Fresher data on load**: The agent view populates immediately when entering the disconnected/fallback state.
- **Behavior preserved**: The periodic 2-second polling continues to run as before; the effect cleanup and dependency list are unchanged.
- **Scope**: Localized to the REST polling fallback path only — the WebSocket-connected code path is unaffected.
<!-- kody-pr-summary:end -->