### PR TITLE
fix: use randomUUID for entity IDs to prevent same-millisecond collision

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -17,7 +17,7 @@ import { join, resolve } from "node:path";
 import { createReadStream } from "node:fs";
 import { createInterface } from "node:readline";
 import { ALL_TAGS, TAG_COLORS, DEFAULT_ROOMS, type AgentState, type AgentActivity, type SubAgentInfo, type TickerMessage, type Room, type AgentTag } from "../shared/types";
-
+import { randomUUID } from "node:crypto";
 const app = express();
 const server = createServer(app);
 // Pre-compute allowed origins once (not per-request)
@@ -1057,7 +1057,7 @@ app.put("/api/layouts/:id", (req, res) => {
 
 app.post("/api/layouts", (req, res) => {
   const { name, width, height, furniture, seats } = req.body;
-  const id = `layout-${Date.now()}`;
+  const id = `layout-${randomUUID()}`;
   const layout: OfficeLayoutDoc = {
     id,
     name: name || "Untitled Layout",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -31,7 +31,7 @@ export const App: React.FC = () => {
     const newFurniture: PlacedFurniture[] = [
       ...activeLayout.furniture,
       {
-        id: `${type.toLowerCase()}-${Date.now()}`,
+        id: `${type.toLowerCase()}-${crypto.randomUUID()}`,
         type,
         x: gridX,
         y: gridY,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -31,7 +31,7 @@ export const App: React.FC = () => {
     const newFurniture: PlacedFurniture[] = [
       ...activeLayout.furniture,
       {
-        id: `${type.toLowerCase()}-${crypto.randomUUID()}`,
+        id: type.toLowerCase() + "-" + (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function" ? crypto.randomUUID() : Math.random().toString(36).substring(2, 15)),
         type,
         x: gridX,
         y: gridY,


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
**Fix for Entity ID Collisions**

This PR addresses an issue where entities (layouts and furniture) could end up with duplicate IDs when created within the same millisecond. The fix replaces timestamp-based ID generation with UUIDs, which provide uniqueness guarantees independent of creation timing.

**Changes:**

- **`server/index.ts`**: Replaced `Date.now()` with `randomUUID()` from `node:crypto` for generating layout IDs in the `POST /api/layouts` endpoint.

- **`src/App.tsx`**: Replaced `Date.now()` with `crypto.randomUUID()` for generating furniture IDs when placing new furniture items in the office layout editor.

**Impact:**

- Prevents ID collisions when multiple entities (layouts on the server or furniture items on the client) are created in rapid succession or concurrently
- Eliminates the risk of client-side `Date.now()` collisions across server-client boundaries, since each environment generates its own timestamps
- Ensures IDs remain unique even when creation events happen within the same millisecond, which was previously a race condition
- Improves system reliability for operations that depend on entity IDs being unique (e.g., lookups, updates, referencing)

---

This pull request fixes entity ID generation in the App component to prevent same-millisecond collisions. 

Previously, furniture items were assigned IDs using `crypto.randomUUID()`, but the change adds a fallback mechanism that uses `Math.random()` when `crypto.randomUUID` is unavailable in the environment. This ensures consistent and unique ID generation across different runtime environments while maintaining collision resistance for entity identification.
<!-- kody-pr-summary:end -->