### PR TITLE
fix(server): fail closed for production WebSocket origins

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,8 @@ Furniture uses per-type directories with `manifest.json` for dimensions and rota
 | Environment Variable | Default | Description |
 |---------------------|---------|-------------|
 | `PORT` | `3001` | Backend server port (`3000` in production) |
+| `NODE_ENV` | *(set to `production` by `npm start`)* | Runtime mode; production requires `CORS_ORIGIN` for WebSocket origin checks |
+| `CORS_ORIGIN` | *(none)* | Comma-separated browser origins allowed to open Socket.IO connections in production |
 | `DATA_SOURCE` | `auto` | Data mode: `auto`, `cli` (local polling), or `ingest` (push-based) |
 | `OPENCLAW_CLI` | `openclaw` | Path to OpenClaw CLI binary (cli mode only) |
 | `POLL_INTERVAL` | `3000` | Agent state poll interval in ms (cli mode only) |

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "dev:client": "vite",
     "dev:server": "npx tsx watch server/index.ts",
     "build": "vite build && tsc -p tsconfig.server.json",
-    "start": "node dist/server/index.js",
+    "start": "NODE_ENV=production node dist/server/index.js",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/server/cors.test.ts
+++ b/server/cors.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { createCorsConfig, isOriginAllowed, parseCorsOrigins } from "./cors";
+
+describe("CORS origin configuration", () => {
+  it("parses comma-separated CORS_ORIGIN values", () => {
+    expect(parseCorsOrigins(" https://app.example.com,https://admin.example.com , ")).toEqual([
+      "https://app.example.com",
+      "https://admin.example.com",
+    ]);
+  });
+
+  it("allows all origins only in non-production when no allow-list is configured", () => {
+    const config = createCorsConfig({ NODE_ENV: "development" });
+
+    expect(config.allowAllOrigins).toBe(true);
+    expect(config.socketOrigin).toBe("*");
+    expect(isOriginAllowed("https://attacker.example", config)).toBe(true);
+  });
+
+  it("uses the configured allow-list in production", () => {
+    const config = createCorsConfig({
+      NODE_ENV: "production",
+      CORS_ORIGIN: "https://app.example.com, https://admin.example.com",
+    });
+
+    expect(config.allowAllOrigins).toBe(false);
+    expect(config.socketOrigin).toEqual(["https://app.example.com", "https://admin.example.com"]);
+    expect(isOriginAllowed("https://app.example.com", config)).toBe(true);
+    expect(isOriginAllowed("https://attacker.example", config)).toBe(false);
+  });
+
+  it("fails fast in production when CORS_ORIGIN is missing", () => {
+    expect(() => createCorsConfig({ NODE_ENV: "production" })).toThrow(
+      "CORS_ORIGIN is required when NODE_ENV=production",
+    );
+  });
+});

--- a/server/cors.ts
+++ b/server/cors.ts
@@ -1,0 +1,35 @@
+export interface CorsConfig {
+  allowedOrigins: string[];
+  allowAllOrigins: boolean;
+  socketOrigin: string[] | "*";
+}
+
+export function parseCorsOrigins(value: string | undefined): string[] {
+  return (value ?? "")
+    .split(",")
+    .map((origin) => origin.trim())
+    .filter(Boolean);
+}
+
+export function createCorsConfig(env: NodeJS.ProcessEnv = process.env): CorsConfig {
+  const allowedOrigins = parseCorsOrigins(env.CORS_ORIGIN);
+  const isProduction = env.NODE_ENV === "production";
+
+  if (isProduction && allowedOrigins.length === 0) {
+    throw new Error("CORS_ORIGIN is required when NODE_ENV=production");
+  }
+
+  const allowAllOrigins = !isProduction && allowedOrigins.length === 0;
+
+  return {
+    allowedOrigins,
+    allowAllOrigins,
+    socketOrigin: allowAllOrigins ? "*" : allowedOrigins,
+  };
+}
+
+export function isOriginAllowed(origin: string | string[] | undefined, config: CorsConfig): boolean {
+  if (config.allowAllOrigins) return true;
+  if (typeof origin !== "string") return false;
+  return config.allowedOrigins.includes(origin);
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -16,28 +16,22 @@ import { timingSafeEqual } from "node:crypto";
 import { join, resolve } from "node:path";
 import { createReadStream } from "node:fs";
 import { createInterface } from "node:readline";
+import { createCorsConfig, isOriginAllowed } from "./cors";
 import { ALL_TAGS, TAG_COLORS, DEFAULT_ROOMS, type AgentState, type AgentActivity, type SubAgentInfo, type TickerMessage, type Room, type AgentTag } from "../shared/types";
 
 const app = express();
 const server = createServer(app);
-// Pre-compute allowed origins once (not per-request)
-const allowedOrigins = process.env.CORS_ORIGIN
-  ? process.env.CORS_ORIGIN.split(",").map((o) => o.trim())
-  : [];
-const allowAllOrigins = !process.env.CORS_ORIGIN && process.env.NODE_ENV !== "production";
+const corsConfig = createCorsConfig();
 
 const io = new SocketIOServer(server, {
   cors: {
-    origin: allowedOrigins.length > 0
-      ? allowedOrigins
-      : process.env.NODE_ENV === "production" ? false : "*",
+    origin: corsConfig.socketOrigin,
   },
 });
 
 // WebSocket origin validation
 io.engine.on("initial_headers", (_headers, req: any) => {
-  if (allowAllOrigins) return; // Dev mode: allow all
-  if (allowedOrigins.length === 0 || !allowedOrigins.includes(req.headers.origin)) {
+  if (!isOriginAllowed(req.headers.origin, corsConfig)) {
     // Send explicit 403 before destroying to avoid noisy engine.io error logs
     req.socket?.write("HTTP/1.1 403 Forbidden\r\n\r\n");
     req.socket?.destroy();

--- a/tsconfig.server.json
+++ b/tsconfig.server.json
@@ -10,5 +10,6 @@
     "resolveJsonModule": true,
     "outDir": "./dist/server"
   },
-  "include": ["server"]
+  "include": ["server"],
+  "exclude": ["**/*.test.ts", "**/*.spec.ts"]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,9 +1,10 @@
-import { defineConfig } from 'vitest/config';
+import { configDefaults, defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
     environment: 'jsdom',
     setupFiles: ['./src/test/setup.ts'],
     clearMocks: true,
+    exclude: [...configDefaults.exclude, '**/dist/**'],
   },
 });


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
**New Insights from Code Changes**

**Centralized CORS Policy Module (`server/cors.ts`)**
- Introduces a `CorsConfig` interface with three pieces: `allowedOrigins` (parsed list), `allowAllOrigins` (boolean), and `socketOrigin` (computed as either `"*"` or the allow-list).
- Production rule is strictly enforced: `isProduction && allowedOrigins.length === 0` throws at construction time, making failures loud and early rather than silent.
- `isOriginAllowed` is written defensively: non-string origins (or undefined, which Engine.IO may surface) return `false` rather than `true`, preventing array-shaped input from accidentally bypassing the check.

**Server Wiring (`server/index.ts`)**
- Removed the inline `allowedOrigins`/`allowAllOrigins` derivation that mixed `CORS_ORIGIN` presence with `NODE_ENV` checks in two places.
- Socket.IO `cors.origin` is now driven entirely by `corsConfig.socketOrigin`, eliminating the previous ternary that could yield `false` in production (which silently breaks clients without a clear error).
- Engine.IO `initial_headers` now delegates to `isOriginAllowed`, so the WebSocket upgrade phase and Socket.IO negotiation phase share a single predicate. Removed the pre-check short-circuit for `allowAllOrigins`; the helper handles it.

**Behavior Matrix (inferred from `createCorsConfig`)**
- `NODE_ENV=production` + empty `CORS_ORIGIN` → throws (fail-closed).
- `NODE_ENV=production` + populated `CORS_ORIGIN` → exact-match allow-list.
- `NODE_ENV=development` (or unset) + empty `CORS_ORIGIN` → `*` (preserve permissive dev experience).
- `NODE_ENV=development` + populated `CORS_ORIGIN` → exact-match allow-list (option to lock down dev too).

**Test Coverage (`server/cors.test.ts`)**
- Trims whitespace and filters empty strings in `parseCorsOrigins` (e.g. trailing comma, spaces around entries).
- Asserts both `config.socketOrigin` shape **and** runtime `isOriginAllowed` outcome, so a future regression in either layer is caught.
- The production-missing test verifies the exact error message, locking in the operator-facing failure mode rather than just "throws".

**Build/Test Isolation (`vitest.config.ts`)**
- `exclude: [...configDefaults.exclude, '**/dist/**']` prevents Vitest from rediscovering compiled `.test.ts` files emitted into `dist/` by `tsc`/`npm run build`. The existing description mentions this in passing; the change itself preserves `configDefaults.exclude` (node_modules, etc.) and only appends the `dist/` glob, so it doesn't alter other exclusion behavior.

**Documentation (`README.md`)**
- Adds `NODE_ENV` and `CORS_ORIGIN` rows to the env-var table, explicitly noting that `npm start` defaults to production and that production **requires** `CORS_ORIGIN` for WebSocket origin checks. This makes the deployment contract discoverable from the README rather than only from operational notes.

**Cross-File Consistency**
- `server/index.ts` imports `cors` and no longer references `process.env.CORS_ORIGIN` / `process.env.NODE_ENV` directly, so future CORS policy changes (e.g. regex matching, dynamic config) only need edits in `server/cors.ts` and its tests.
<!-- kody-pr-summary:end -->