### PR TITLE
fix(server): add Express async error boundary

### DIFF
--- a/server/errors.test.ts
+++ b/server/errors.test.ts
@@ -1,0 +1,37 @@
+import express from "express";
+import request from "supertest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { apiErrorHandler, asyncHandler } from "./errors";
+
+describe("Express error boundary", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("turns async route rejections into 500 responses and keeps serving", async () => {
+    const app = express();
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    app.get(
+      "/reject",
+      asyncHandler(async () => {
+        throw new Error("boom");
+      }),
+    );
+    app.get("/health", (_req, res) => res.json({ ok: true }));
+    app.use(apiErrorHandler);
+
+    await request(app)
+      .get("/reject")
+      .expect(500)
+      .expect("Content-Type", /json/)
+      .expect({ error: "Internal server error" });
+
+    expect(errorSpy).toHaveBeenCalledWith("[api error]", expect.any(Error));
+
+    await request(app)
+      .get("/health")
+      .expect(200)
+      .expect({ ok: true });
+  });
+});

--- a/server/errors.ts
+++ b/server/errors.ts
@@ -1,0 +1,35 @@
+import type { ErrorRequestHandler, NextFunction, Request, RequestHandler, Response } from "express";
+
+type AsyncRequestHandler = (req: Request, res: Response, next: NextFunction) => unknown | Promise<unknown>;
+
+export function asyncHandler(handler: AsyncRequestHandler): RequestHandler {
+  return (req, res, next) => {
+    Promise.resolve(handler(req, res, next)).catch(next);
+  };
+}
+
+export const apiErrorHandler: ErrorRequestHandler = (err, _req, res, next) => {
+  if (res.headersSent) {
+    next(err);
+    return;
+  }
+
+  console.error("[api error]", err);
+  res.status(500).json({ error: "Internal server error" });
+};
+
+let processHandlersRegistered = false;
+
+export function registerProcessErrorHandlers(): void {
+  if (processHandlersRegistered) return;
+  processHandlersRegistered = true;
+
+  process.on("unhandledRejection", (reason) => {
+    console.error("[unhandledRejection]", reason);
+  });
+
+  process.on("uncaughtException", (err) => {
+    console.error("[uncaughtException]", err);
+    process.exit(1);
+  });
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -17,6 +17,7 @@ import { join, resolve } from "node:path";
 import { createReadStream } from "node:fs";
 import { createInterface } from "node:readline";
 import { createCorsConfig, isOriginAllowed } from "./cors";
+import { apiErrorHandler, registerProcessErrorHandlers } from "./errors";
 import { ALL_TAGS, TAG_COLORS, DEFAULT_ROOMS, type AgentState, type AgentActivity, type SubAgentInfo, type TickerMessage, type Room, type AgentTag } from "../shared/types";
 
 const app = express();
@@ -1115,6 +1116,8 @@ app.get("*", (_req, res) => {
   }
 });
 
+app.use(apiErrorHandler);
+
 // ---- Start ----
 
 const PORT = parseInt(process.env.PORT || "3001", 10);
@@ -1167,20 +1170,27 @@ async function shutdown(signal: string) {
   process.exit(0);
 }
 
-process.on("SIGTERM", () => shutdown("SIGTERM"));
-process.on("SIGINT", () => shutdown("SIGINT"));
+function startServer(): void {
+  registerProcessErrorHandlers();
+  process.on("SIGTERM", () => shutdown("SIGTERM"));
+  process.on("SIGINT", () => shutdown("SIGINT"));
 
-server.listen(PORT, () => {
-  console.log(`🖥️  OpenClaw Pixel Agents server running on port ${PORT}`);
-  console.log(`📊 Data source: ${DATA_SOURCE} (effective: ${useCli && !ingestExplicit ? "cli-poll" : "ingest-only"})`);
+  server.listen(PORT, () => {
+    console.log(`🖥️  OpenClaw Pixel Agents server running on port ${PORT}`);
+    console.log(`📊 Data source: ${DATA_SOURCE} (effective: ${useCli && !ingestExplicit ? "cli-poll" : "ingest-only"})`);
 
-  if (useCli && !ingestExplicit) {
-    console.log(`📡 Polling via: ${OPENCLAW_BIN} sessions --all-agents --json --active ${ACTIVE_THRESHOLD_MIN}`);
-    pollAndBroadcast();
-    pollTimer = setInterval(pollAndBroadcast, POLL_INTERVAL);
-  } else {
-    console.log("📡 Awaiting ingest data from collector (no local CLI polling)");
-  }
-});
+    if (useCli && !ingestExplicit) {
+      console.log(`📡 Polling via: ${OPENCLAW_BIN} sessions --all-agents --json --active ${ACTIVE_THRESHOLD_MIN}`);
+      pollAndBroadcast();
+      pollTimer = setInterval(pollAndBroadcast, POLL_INTERVAL);
+    } else {
+      console.log("📡 Awaiting ingest data from collector (no local CLI polling)");
+    }
+  });
+}
 
-export { app, server, io };
+if (require.main === module) {
+  startServer();
+}
+
+export { app, server, io, startServer };


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
## Summary

This PR hardens the Express server against async route failures and ensures the HTTP listener only starts when the module is executed directly, not when it's imported (e.g., by tests).

## Key Changes

### New error boundary module (`server/errors.ts`)
- **`asyncHandler()`** — wraps async Express route handlers so that thrown errors or rejected promises are forwarded to `next()`, which Express 4 would otherwise ignore.
- **`apiErrorHandler`** — terminal Express error middleware that logs the failure and returns a standardized `{ error: "Internal server error" }` JSON 500 response, delegating to `next()` if headers have already been sent.
- **`registerProcessErrorHandlers()`** — idempotently attaches `unhandledRejection` (log only) and `uncaughtException` (log + `process.exit(1)`) listeners as a last-resort safety net.

### Server wiring (`server/index.ts`)
- Installs `apiErrorHandler` after the catch-all `app.get("*")` route, so every request passes through the error boundary.
- Wraps server bootstrap (process error handlers, SIGTERM/SIGINT, `server.listen`, polling timer setup) into a new exported `startServer()` function.
- Guards execution with `if (require.main === module)`, so `npm start` still boots normally, but importing `app`/`server`/`io` from tests no longer opens a port or begins polling.
- Exports `startServer` alongside the existing `app`, `server`, `io`.

### Test coverage (`server/errors.test.ts`)
- Builds a minimal Express app that uses `asyncHandler` around a route that throws, plus a healthy control route and `apiErrorHandler`.
- Asserts the rejection becomes a 500 JSON response with the expected body and `Content-Type`.
- Spies on `console.error` to confirm the error was logged.
- Confirms a follow-up `/health` request still succeeds, proving the boundary doesn't poison the app for subsequent requests.

## Why It Matters

Express 4 does not automatically forward rejected promises from route handlers to error middleware, so any future `async` route could silently fail. The issue's `PUT /api/layouts/:id` is currently synchronous, but the risk applies to any async route added later. This change introduces the boundary now and pins its behavior with a regression test, while also making the server module safely importable for unit tests.
<!-- kody-pr-summary:end -->