### PR TITLE
fix(server): split ingest auth from UI mutations

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ Furniture uses per-type directories with `manifest.json` for dimensions and rota
 |---------------------|---------|-------------|
 | `PORT` | `3001` | Backend server port (`3000` in production) |
 | `NODE_ENV` | *(set to `production` by `npm start`)* | Runtime mode; production requires `CORS_ORIGIN` for WebSocket origin checks |
-| `CORS_ORIGIN` | *(none)* | Comma-separated browser origins allowed to open Socket.IO connections in production |
+| `CORS_ORIGIN` | *(none)* | Comma-separated browser origins allowed to open Socket.IO connections and to send state-mutating REST requests in production |
 | `DATA_SOURCE` | `auto` | Data mode: `auto`, `cli` (local polling), or `ingest` (push-based) |
 | `OPENCLAW_CLI` | `openclaw` | Path to OpenClaw CLI binary (cli mode only) |
 | `POLL_INTERVAL` | `3000` | Agent state poll interval in ms (cli mode only) |
@@ -207,6 +207,10 @@ Furniture uses per-type directories with `manifest.json` for dimensions and rota
 | `INGEST_API_TOKEN` | *(none)* | Shared secret for ingest API auth (required for ingest mode) |
 | `OPENCLAW_AGENTS_DIR` | `~/.openclaw/agents` | Path to agent session transcripts |
 | `DATA_DIR` | `./data` | Persistence directory for preferences and layouts |
+
+### Reverse-proxy deployments
+
+If you terminate TLS or rewrite requests in a reverse proxy in front of the Node server, make sure the `Origin` header from the browser is forwarded unchanged. State-mutating REST routes (`POST/PUT/PATCH/DELETE /api/*`) require an allowed `Origin` in production; stripping or rewriting it will cause legitimate browser mutations to fail with `403 Forbidden origin`.
 
 ## Scripts
 

--- a/server/auth.test.ts
+++ b/server/auth.test.ts
@@ -8,7 +8,7 @@ import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 
 describe("API auth boundaries", () => {
   let app: Express;
-  let io: SocketIOServer | undefined;
+  let io: SocketIOServer;
   let dataDir: string;
   const appOrigin = "https://pixel.test";
 
@@ -27,8 +27,8 @@ describe("API auth boundaries", () => {
   });
 
   afterAll(() => {
-    io?.close();
-    if (dataDir) rmSync(dataDir, { recursive: true, force: true });
+    io.close();
+    rmSync(dataDir, { recursive: true, force: true });
     vi.unstubAllEnvs();
     vi.resetModules();
   });
@@ -92,6 +92,16 @@ describe("API auth boundaries", () => {
     await request(app)
       .post("/api/agents/main/toggle")
       .set("Origin", "https://attacker.test")
+      .send({ enabled: true })
+      .expect(403)
+      .expect({ error: "Forbidden origin" });
+  });
+
+  it("rejects UI mutations that omit the Origin header in production", async () => {
+    // A non-browser caller without an Origin header must not bypass the
+    // production Origin allow-list for state-mutating routes.
+    await request(app)
+      .post("/api/agents/main/toggle")
       .send({ enabled: true })
       .expect(403)
       .expect({ error: "Forbidden origin" });

--- a/server/auth.test.ts
+++ b/server/auth.test.ts
@@ -1,0 +1,77 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { Express } from "express";
+import type { Server as SocketIOServer } from "socket.io";
+import request from "supertest";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+describe("API auth boundaries", () => {
+  let app: Express;
+  let io: SocketIOServer;
+  let dataDir: string;
+  const previousEnv = { ...process.env };
+
+  beforeAll(async () => {
+    dataDir = mkdtempSync(join(tmpdir(), "pixel-agents-auth-test-"));
+    process.env.DATA_DIR = dataDir;
+    process.env.DATA_SOURCE = "ingest";
+    process.env.INGEST_API_TOKEN = "test-secret";
+
+    const serverModule = await import("./index");
+    app = serverModule.app;
+    io = serverModule.io;
+  });
+
+  afterAll(() => {
+    io.close();
+    rmSync(dataDir, { recursive: true, force: true });
+    process.env = previousEnv;
+  });
+
+  it("keeps collector ingest token-protected", async () => {
+    await request(app)
+      .post("/api/ingest/agents")
+      .send({ sessions: [] })
+      .expect(401)
+      .expect({ error: "Unauthorized" });
+  });
+
+  it("accepts collector ingest when the token is valid", async () => {
+    await request(app)
+      .post("/api/ingest/agents")
+      .set("Authorization", "Bearer test-secret")
+      .send({ sessions: [] })
+      .expect(200)
+      .expect((response) => {
+        expect(response.body).toMatchObject({ ok: true, received: 0 });
+        expect(response.body.agents).toBeGreaterThanOrEqual(0);
+      });
+  });
+
+  it("does not require the collector token for same-origin UI mutation endpoints", async () => {
+    const responses = [
+      await request(app).post("/api/agents/main/toggle").send({ enabled: false }).expect(200),
+      await request(app).post("/api/agents/main/sprite").send({ spriteId: "char_1" }).expect(200),
+      await request(app).put("/api/agents/main/recipe").send({ bodyIndex: 0, hairIndex: 0, outfitIndex: 0 }).expect(200),
+      await request(app).put("/api/agents/main/tags").send({ tags: ["coding"] }).expect(200),
+      await request(app).put("/api/layouts/auth-regression").send({
+        name: "Auth Regression",
+        width: 24,
+        height: 16,
+        furniture: [],
+        seats: {},
+      }).expect(200),
+      await request(app).post("/api/layouts").send({
+        name: "Auth Regression Created",
+        width: 24,
+        height: 16,
+        furniture: [],
+        seats: {},
+      }).expect(200),
+      await request(app).delete("/api/layouts/auth-regression").expect(200),
+    ];
+
+    expect(responses.map((response) => response.status)).not.toContain(401);
+  });
+});

--- a/server/auth.test.ts
+++ b/server/auth.test.ts
@@ -4,34 +4,47 @@ import { join } from "node:path";
 import type { Express } from "express";
 import type { Server as SocketIOServer } from "socket.io";
 import request from "supertest";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 
 describe("API auth boundaries", () => {
   let app: Express;
-  let io: SocketIOServer;
+  let io: SocketIOServer | undefined;
   let dataDir: string;
-  const previousEnv = { ...process.env };
+  const appOrigin = "https://pixel.test";
 
   beforeAll(async () => {
     dataDir = mkdtempSync(join(tmpdir(), "pixel-agents-auth-test-"));
-    process.env.DATA_DIR = dataDir;
-    process.env.DATA_SOURCE = "ingest";
-    process.env.INGEST_API_TOKEN = "test-secret";
+    vi.stubEnv("DATA_DIR", dataDir);
+    vi.stubEnv("DATA_SOURCE", "ingest");
+    vi.stubEnv("INGEST_API_TOKEN", "test-secret");
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("CORS_ORIGIN", appOrigin);
 
+    vi.resetModules();
     const serverModule = await import("./index");
     app = serverModule.app;
     io = serverModule.io;
   });
 
   afterAll(() => {
-    io.close();
-    rmSync(dataDir, { recursive: true, force: true });
-    process.env = previousEnv;
+    io?.close();
+    if (dataDir) rmSync(dataDir, { recursive: true, force: true });
+    vi.unstubAllEnvs();
+    vi.resetModules();
   });
 
   it("keeps collector ingest token-protected", async () => {
     await request(app)
       .post("/api/ingest/agents")
+      .send({ sessions: [] })
+      .expect(401)
+      .expect({ error: "Unauthorized" });
+  });
+
+  it("rejects collector ingest when the bearer token is wrong", async () => {
+    await request(app)
+      .post("/api/ingest/agents")
+      .set("Authorization", "Bearer not-the-secret")
       .send({ sessions: [] })
       .expect(401)
       .expect({ error: "Unauthorized" });
@@ -51,27 +64,36 @@ describe("API auth boundaries", () => {
 
   it("does not require the collector token for same-origin UI mutation endpoints", async () => {
     const responses = [
-      await request(app).post("/api/agents/main/toggle").send({ enabled: false }).expect(200),
-      await request(app).post("/api/agents/main/sprite").send({ spriteId: "char_1" }).expect(200),
-      await request(app).put("/api/agents/main/recipe").send({ bodyIndex: 0, hairIndex: 0, outfitIndex: 0 }).expect(200),
-      await request(app).put("/api/agents/main/tags").send({ tags: ["coding"] }).expect(200),
-      await request(app).put("/api/layouts/auth-regression").send({
+      await request(app).post("/api/agents/main/toggle").set("Origin", appOrigin).send({ enabled: false }).expect(200),
+      await request(app).post("/api/agents/main/sprite").set("Origin", appOrigin).send({ spriteId: "char_1" }).expect(200),
+      await request(app).put("/api/agents/main/recipe").set("Origin", appOrigin).send({ bodyIndex: 0, hairIndex: 0, outfitIndex: 0 }).expect(200),
+      await request(app).put("/api/agents/main/tags").set("Origin", appOrigin).send({ tags: ["coding"] }).expect(200),
+      await request(app).put("/api/layouts/auth-regression").set("Origin", appOrigin).send({
         name: "Auth Regression",
         width: 24,
         height: 16,
         furniture: [],
         seats: {},
       }).expect(200),
-      await request(app).post("/api/layouts").send({
+      await request(app).post("/api/layouts").set("Origin", appOrigin).send({
         name: "Auth Regression Created",
         width: 24,
         height: 16,
         furniture: [],
         seats: {},
       }).expect(200),
-      await request(app).delete("/api/layouts/auth-regression").expect(200),
+      await request(app).delete("/api/layouts/auth-regression").set("Origin", appOrigin).expect(200),
     ];
 
     expect(responses.map((response) => response.status)).not.toContain(401);
+  });
+
+  it("rejects UI mutations from origins outside the configured app allow-list", async () => {
+    await request(app)
+      .post("/api/agents/main/toggle")
+      .set("Origin", "https://attacker.test")
+      .send({ enabled: true })
+      .expect(403)
+      .expect({ error: "Forbidden origin" });
   });
 });

--- a/server/index.ts
+++ b/server/index.ts
@@ -652,6 +652,7 @@ const ingestPruneTimer = setInterval(() => {
     else ingestRateBuckets.set(key, pruned);
   }
 }, RATE_LIMIT_WINDOW_MS);
+ingestPruneTimer.unref?.();
 
 app.post("/api/ingest/agents", (req, res) => {
   if (!INGEST_TOKEN) {
@@ -711,17 +712,6 @@ app.post("/api/ingest/agents", (req, res) => {
 let lastIngestAt = 0;
 
 // ---- REST API ----
-
-// General authorization middleware for state-modifying REST endpoints
-// Scoped to /api to avoid blocking Socket.IO polling transport POSTs
-app.use("/api", (req, res, next) => {
-  if (req.method === "GET") return next();
-  if (req.path === "/ingest/agents") return next(); // Handles its own auth
-
-  if (authenticateIngest(req, res)) return next();
-
-  res.status(401).json({ error: "Authentication required: provide 'Authorization: Bearer <INGEST_API_TOKEN>' header" });
-});
 
 app.get("/api/agents", (_req, res) => {
   res.json({ agents: Array.from(agentStates.values()) });

--- a/server/index.ts
+++ b/server/index.ts
@@ -717,7 +717,9 @@ const MUTATING_API_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
 
 app.use("/api", (req, res, next) => {
   if (!MUTATING_API_METHODS.has(req.method)) return next();
-  if (req.path === "/ingest/agents") return next(); // Ingest has bearer-token auth inside the route.
+  // Ingest runs above this middleware and ends the chain with a response, so
+  // this exemption is defensive belt-and-suspenders for the future ordering.
+  if (req.path === "/ingest/agents") return next();
   if (isOriginAllowed(req.headers.origin, corsConfig)) return next();
 
   res.status(403).json({ error: "Forbidden origin" });

--- a/server/index.ts
+++ b/server/index.ts
@@ -713,6 +713,16 @@ let lastIngestAt = 0;
 
 // ---- REST API ----
 
+const MUTATING_API_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
+
+app.use("/api", (req, res, next) => {
+  if (!MUTATING_API_METHODS.has(req.method)) return next();
+  if (req.path === "/ingest/agents") return next(); // Ingest has bearer-token auth inside the route.
+  if (isOriginAllowed(req.headers.origin, corsConfig)) return next();
+
+  res.status(403).json({ error: "Forbidden origin" });
+});
+
 app.get("/api/agents", (_req, res) => {
   res.json({ agents: Array.from(agentStates.values()) });
 });


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
## Summary

This PR removes an over-broad authentication gate that incorrectly required the collector ingest secret (`INGEST_API_TOKEN`) for all non-GET `/api` requests, which made the dashboard effectively read-only for the browser SPA since frontend requests never send that header.

### What's changed

- **Removed middleware**: The global `app.use("/api", ...)` block that demanded ingest bearer auth for every state-modifying REST endpoint has been deleted. Only `POST /api/ingest/agents` still requires the token, with its existing route-local `authenticateIngest` check.
- **UI endpoints are now reachable** without the collector token: `POST /api/agents/:id/toggle`, `POST /api/agents/:id/sprite`, `PUT /api/agents/:id/recipe`, `PUT /api/agents/:id/tags`, `PUT /api/layouts/:id`, `POST /api/layouts`, and `DELETE /api/layouts/:id`.
- **Test isolation fix**: `ingestPruneTimer.unref?.()` is called so the rate-limit cleanup interval doesn't hold the event loop open after tests import the Express app.

### Why

Sending the collector secret into the browser would violate the trust boundary the secret was meant to enforce. The product model treats UI endpoints as same-origin app endpoints (already constrained by production CORS/Socket.IO allow-lists added in PR #60) and treats `/api/ingest/agents` as a separate token-authenticated machine endpoint. This split mirrors that distinction.

### New test coverage (`server/auth.test.ts`)

Added Supertest-based regressions that mount the real Express app in a temp `DATA_DIR`:

1. Ingest without bearer returns `401 Unauthorized`.
2. Ingest with a valid bearer returns `200` with `{ ok: true, received: 0 }`.
3. The seven UI mutation endpoints above all return non-401 status codes without the collector token, proving the gate no longer applies to them.

Each test creates/cleans up its own temp directory and restores `process.env` in `afterAll`.

### Notable insights beyond the description

- The deletion of the global middleware removes a path collision with the Socket.IO polling `POST /socket.io/...` requests and the `/ingest/agents` self-handling auth — both of which the old middleware had to explicitly carve out, neither of which is needed anymore.
- The new test file directly imports `./index` (`serverModule.app`, `serverModule.io`) rather than spawning the server, which is why the `unref?.()` call on the prune timer was necessary to let Vitest exit cleanly.
- The expected ingest response shape (`ok`, `received`, `agents`) is now pinned by the success-path test, giving the ingest endpoint a small but useful contract assertion for free.

---

# Pull Request: Split ingest auth from UI mutations

## Summary
Separates collector (ingest) authentication from UI mutation endpoints so each surface has a distinct authorization boundary, and locks UI mutations behind an origin allow-list in production.

## What Changed

### Server (`server/index.ts`)
- **New middleware on `/api`**: For mutating verbs (`POST`, `PUT`, `PATCH`, `DELETE`), requests are now checked against the configured allowed origins via `isOriginAllowed(...)`. Unallowed origins receive `403` with `{ error: "Forbidden origin" }`.
- **Exception for ingest**: The `/api/ingest/agents` route is explicitly bypassed by this new middleware because it carries its own bearer-token check inside the route handler. This ensures the two auth surfaces don't collide.
- **Non-mutating methods** (`GET`, etc.) continue to flow through unchanged.

### Tests (`server/auth.test.ts`)
- Switched environment setup to use Vitest's `vi.stubEnv` / `vi.unstubAllEnvs` and `vi.resetModules` for cleaner isolation across test runs.
- Added a stable, production-shaped environment: `NODE_ENV=production` and `CORS_ORIGIN=https://pixel.test` so the origin gate is actually exercised.
- Set `Origin: https://pixel.test` on UI mutation requests so they pass the new allow-list.
- **New test**: rejects collector ingest when the bearer token is wrong (`401`).
- **New test**: rejects UI mutations from origins outside the allow-list (`403`, `Forbidden origin`).
- All existing tests preserved and adjusted to send the allowed origin header.

## Why
Previously, ingest and UI mutations shared an auth treatment that could either over-restrict the UI or under-restrict the ingest endpoint. This change makes the security model explicit:

- **Ingest (collector)**: protected by a `INGEST_API_TOKEN` bearer token, independent of where the request comes from.
- **UI mutations**: protected by same-origin / allow-list enforcement (`CORS_ORIGIN`), so cross-site requests from unauthorized origins are blocked.
- **Read endpoints and ingest**: unaffected by the new gate, maintaining current behavior.

## Behavior

| Endpoint | Auth |
|---|---|
| `POST /api/ingest/agents` | Bearer token (`INGEST_API_TOKEN`) |
| `POST`/`PUT`/`PATCH`/`DELETE` under `/api` | Origin must match `CORS_ORIGIN` allow-list |
| `GET` under `/api` | Open as before |

## Impact
- Collectors configured with the bearer token continue to ingest normally.
- The web UI served from an allowed origin continues to work without sending tokens.
- Cross-site requests attempting UI mutations now receive `403 Forbidden origin`.
- Misconfigured bearer tokens on ingest now produce a clear `401` in tests.
<!-- kody-pr-summary:end -->