### PR TITLE
fix(server): preserve agent snapshot on poll source errors

### DIFF
--- a/server/agentSnapshots.test.ts
+++ b/server/agentSnapshots.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import type { AgentState } from "../shared/types";
+import { applyAgentSnapshot } from "./agentSnapshots";
+
+function agent(id: string, activity: AgentState["activity"] = "idle"): AgentState {
+  return {
+    id,
+    name: id,
+    activity,
+    model: "test/model",
+    sessionKey: `${id}-session`,
+    active: activity !== "sleeping",
+    lastActivity: 123,
+    pixelEnabled: true,
+    tags: [],
+  };
+}
+
+describe("applyAgentSnapshot", () => {
+  it("replaces the current snapshot when the source succeeds", () => {
+    const current = new Map([["old", agent("old")]]);
+    const next = new Map([["new", agent("new", "typing")]]);
+
+    const result = applyAgentSnapshot(current, next);
+
+    expect(result.applied).toBe(true);
+    expect(current.has("old")).toBe(false);
+    expect(current.get("new")?.activity).toBe("typing");
+    expect(result.snapshot).toEqual([{ ...agent("new", "typing") }]);
+  });
+
+  it("applies an empty snapshot when the source succeeds", () => {
+    const current = new Map([["old", agent("old", "typing")]]);
+    const next = new Map<string, AgentState>();
+
+    const result = applyAgentSnapshot(current, next);
+
+    expect(result.applied).toBe(true);
+    expect(current.size).toBe(0);
+    expect(result.snapshot).toEqual([]);
+  });
+
+  it("keeps the previous non-empty snapshot when the source errors", () => {
+    const current = new Map([["old", agent("old", "typing")]]);
+    const next = new Map([["new", agent("new", "sleeping")]]);
+
+    const result = applyAgentSnapshot(current, next, { sourceError: true });
+
+    expect(result.applied).toBe(false);
+    expect(current.has("new")).toBe(false);
+    expect(current.get("old")?.activity).toBe("typing");
+    expect(result.snapshot).toEqual([{ ...agent("old", "typing") }]);
+  });
+
+  it("allows an empty first snapshot when there is no previous data to preserve", () => {
+    const current = new Map<string, AgentState>();
+    const next = new Map<string, AgentState>();
+
+    const result = applyAgentSnapshot(current, next, { sourceError: true });
+
+    expect(result.applied).toBe(true);
+    expect(result.snapshot).toEqual([]);
+  });
+});

--- a/server/agentSnapshots.test.ts
+++ b/server/agentSnapshots.test.ts
@@ -39,6 +39,15 @@ describe("applyAgentSnapshot", () => {
     expect(current.get("old")?.tags).toEqual(["coding"]);
   });
 
+  it("returns deep-cloned snapshots when preserving on source error", () => {
+    const current = new Map([["old", { ...agent("old", "typing"), tags: ["coding" as const] }]]);
+    const result = applyAgentSnapshot(current, undefined, { sourceError: true });
+
+    result.snapshot[0].tags.push("logic");
+
+    expect(current.get("old")?.tags).toEqual(["coding"]);
+  });
+
   it("applies an empty snapshot when the source succeeds", () => {
     const current = new Map([["old", agent("old", "typing")]]);
     const next = new Map<string, AgentState>();

--- a/server/agentSnapshots.test.ts
+++ b/server/agentSnapshots.test.ts
@@ -29,6 +29,16 @@ describe("applyAgentSnapshot", () => {
     expect(result.snapshot).toEqual([{ ...agent("new", "typing") }]);
   });
 
+  it("returns deep-cloned snapshots", () => {
+    const current = new Map<string, AgentState>();
+    const next = new Map([["old", { ...agent("old"), tags: ["coding" as const] }]]);
+    const result = applyAgentSnapshot(current, next);
+
+    result.snapshot[0].tags.push("logic");
+
+    expect(current.get("old")?.tags).toEqual(["coding"]);
+  });
+
   it("applies an empty snapshot when the source succeeds", () => {
     const current = new Map([["old", agent("old", "typing")]]);
     const next = new Map<string, AgentState>();
@@ -54,9 +64,8 @@ describe("applyAgentSnapshot", () => {
 
   it("allows an empty first snapshot when there is no previous data to preserve", () => {
     const current = new Map<string, AgentState>();
-    const next = new Map<string, AgentState>();
 
-    const result = applyAgentSnapshot(current, next, { sourceError: true });
+    const result = applyAgentSnapshot(current, undefined, { sourceError: true });
 
     expect(result.applied).toBe(true);
     expect(result.snapshot).toEqual([]);

--- a/server/agentSnapshots.ts
+++ b/server/agentSnapshots.ts
@@ -1,0 +1,33 @@
+import type { AgentState } from "../shared/types";
+
+export interface AgentSnapshotApplyResult {
+  applied: boolean;
+  snapshot: AgentState[];
+}
+
+function snapshotAgents(agentStates: Map<string, AgentState>): AgentState[] {
+  return Array.from(agentStates.values()).map((agent) => ({ ...agent }));
+}
+
+/**
+ * Atomically applies a new agent snapshot unless the source failed.
+ *
+ * On source errors, keep the previous non-empty snapshot so transient upstream
+ * failures do not make every agent flash to sleeping/disconnected in the UI.
+ */
+export function applyAgentSnapshot(
+  agentStates: Map<string, AgentState>,
+  nextAgents: Map<string, AgentState>,
+  options: { sourceError?: boolean } = {},
+): AgentSnapshotApplyResult {
+  if (options.sourceError && agentStates.size > 0) {
+    return { applied: false, snapshot: snapshotAgents(agentStates) };
+  }
+
+  agentStates.clear();
+  for (const agent of nextAgents.values()) {
+    agentStates.set(agent.id, agent);
+  }
+
+  return { applied: true, snapshot: snapshotAgents(agentStates) };
+}

--- a/server/agentSnapshots.ts
+++ b/server/agentSnapshots.ts
@@ -6,7 +6,7 @@ export interface AgentSnapshotApplyResult {
 }
 
 function snapshotAgents(agentStates: Map<string, AgentState>): AgentState[] {
-  return Array.from(agentStates.values()).map((agent) => ({ ...agent }));
+  return Array.from(agentStates.values()).map((agent) => structuredClone(agent));
 }
 
 /**
@@ -17,7 +17,7 @@ function snapshotAgents(agentStates: Map<string, AgentState>): AgentState[] {
  */
 export function applyAgentSnapshot(
   agentStates: Map<string, AgentState>,
-  nextAgents: Map<string, AgentState>,
+  nextAgents?: Map<string, AgentState>,
   options: { sourceError?: boolean } = {},
 ): AgentSnapshotApplyResult {
   if (options.sourceError && agentStates.size > 0) {
@@ -25,7 +25,7 @@ export function applyAgentSnapshot(
   }
 
   agentStates.clear();
-  for (const agent of nextAgents.values()) {
+  for (const agent of nextAgents?.values() ?? []) {
     agentStates.set(agent.id, agent);
   }
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -590,18 +590,20 @@ async function pollAndBroadcast(): Promise<void> {
   isPolling = true;
   try {
     const { sessions, sourceError } = await pollSessions();
-    const agentMap = sourceError ? new Map<string, AgentState>() : mapToAgentStates(sessions);
+    const agentMap = sourceError ? undefined : mapToAgentStates(sessions);
     const { applied, snapshot } = applyAgentSnapshot(agentStates, agentMap, { sourceError });
 
     if (!applied) {
       console.warn("[poll] Keeping previous agent snapshot after source error");
+    } else {
+      // Broadcast only when the visible agent snapshot actually changes.
+      io.emit("agents:update", snapshot);
     }
-
-    // Broadcast an immutable snapshot, preserving the previous one on source errors.
-    io.emit("agents:update", snapshot);
 
     // Poll messages from transcripts
     await pollMessages();
+  } catch (err) {
+    console.error("[poll] Poll cycle failed:", err);
   } finally {
     isPolling = false;
   }
@@ -796,6 +798,8 @@ app.put("/api/agents/:id/recipe", (req, res) => {
   }
 
   known.recipe = { bodyIndex, hairIndex, outfitIndex };
+  const state = agentStates.get(id);
+  if (state) state.recipe = known.recipe;
   savePersistedPrefs();
 
   // Broadcast recipe change to connected Socket.IO clients

--- a/server/index.ts
+++ b/server/index.ts
@@ -15,6 +15,7 @@ import { stat as statAsync } from "node:fs/promises";
 import { randomUUID, timingSafeEqual } from "node:crypto";
 import { join, resolve } from "node:path";
 import { createInterface } from "node:readline";
+import { applyAgentSnapshot } from "./agentSnapshots";
 import { createCorsConfig, isOriginAllowed } from "./cors";
 import { apiErrorHandler, registerProcessErrorHandlers } from "./errors";
 import { isValidLayoutId } from "./layouts";
@@ -199,6 +200,7 @@ interface CliSession {
 interface CliSessionsResult {
   sessions: CliSession[];
   count: number;
+  sourceError?: boolean;
 }
 
 /**
@@ -219,7 +221,7 @@ function pollSessions(): Promise<CliSessionsResult> {
     execFile(OPENCLAW_BIN, args, { timeout: 10000 }, (err, stdout, stderr) => {
       if (err) {
         console.error("[poll] CLI error:", err.message);
-        resolve({ sessions: [], count: 0 });
+        resolve({ sessions: [], count: 0, sourceError: true });
         return;
       }
 
@@ -231,7 +233,7 @@ function pollSessions(): Promise<CliSessionsResult> {
         });
       } catch (parseErr) {
         console.error("[poll] JSON parse error:", parseErr);
-        resolve({ sessions: [], count: 0 });
+        resolve({ sessions: [], count: 0, sourceError: true });
       }
     });
   });
@@ -587,20 +589,15 @@ async function pollAndBroadcast(): Promise<void> {
   if (isPolling) return;
   isPolling = true;
   try {
-    const { sessions } = await pollSessions();
-    const agentMap = mapToAgentStates(sessions);
-    const agentList = Array.from(agentMap.values());
+    const { sessions, sourceError } = await pollSessions();
+    const agentMap = sourceError ? new Map<string, AgentState>() : mapToAgentStates(sessions);
+    const { applied, snapshot } = applyAgentSnapshot(agentStates, agentMap, { sourceError });
 
-    // Create immutable snapshot before any async operations
-    const snapshot = agentList.map(a => ({ ...a }));
-
-    // Update global state atomically
-    agentStates.clear();
-    for (const agent of agentMap.values()) {
-      agentStates.set(agent.id, agent);
+    if (!applied) {
+      console.warn("[poll] Keeping previous agent snapshot after source error");
     }
 
-    // Broadcast the snapshot (not the mutable global state)
+    // Broadcast an immutable snapshot, preserving the previous one on source errors.
     io.emit("agents:update", snapshot);
 
     // Poll messages from transcripts
@@ -694,18 +691,12 @@ app.post("/api/ingest/agents", (req, res) => {
 
   // Map and broadcast
   const agentMap = mapToAgentStates(sessions as CliSession[]);
-  const agentList = Array.from(agentMap.values());
-
-  // Update global state
-  agentStates.clear();
-  for (const agent of agentMap.values()) {
-    agentStates.set(agent.id, agent);
-  }
+  const { snapshot } = applyAgentSnapshot(agentStates, agentMap);
 
   lastIngestAt = Date.now();
-  console.log(`[ingest] ${agentList.length} agents updated (${sessions.length} sessions)`);
-  io.emit("agents:update", agentList);
-  res.json({ ok: true, agents: agentList.length, received: sessions.length });
+  console.log(`[ingest] ${snapshot.length} agents updated (${sessions.length} sessions)`);
+  io.emit("agents:update", snapshot);
+  res.json({ ok: true, agents: snapshot.length, received: sessions.length });
 });
 
 let lastIngestAt = 0;


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
## Summary

This PR prevents transient CLI poll failures from briefly blanking the agent list in the UI by preserving the previous snapshot on source errors.

## What changed

**New `server/agentSnapshots.ts`**
- Adds `applyAgentSnapshot()`, a single helper that owns all agent-snapshot replacement logic.
- On a successful source, it atomically replaces the `agentStates` map and returns an immutable array snapshot for broadcasting.
- When called with `sourceError: true` and there is existing state, it skips the replacement and re-snapshots the current state.
- When called with `sourceError: true` and there is no prior state, it still allows the (empty) replacement so initial load is not blocked.

**`server/index.ts` updates**
- `pollSessions()` now returns `sourceError: true` when `execFile` fails or when the CLI output cannot be JSON-parsed. A successful run with `sessions: []` does **not** set the flag, so legitimate empty results still clear the snapshot.
- `pollAndBroadcast()` routes the polled result through `applyAgentSnapshot` and skips the `mapToAgentStates` call entirely on source errors, which avoids the side effect of registering every known agent as sleeping.
- The `/api/ingest/agents` route also goes through the same helper, so ingest replacements and poll replacements behave consistently and both broadcast immutable snapshots.
- The previous "clear then re-set" inline state mutation pattern is removed in both call sites in favor of the helper.

**New `server/agentSnapshots.test.ts`**
- Covers four cases: successful replacement, successful empty snapshot clears state, source-error keeps prior state, and first source-error with no prior state is allowed.

## Functional impact

- Brief CLI failures, timeouts, or malformed JSON no longer cause every agent to flash to a sleeping/disconnected state in connected clients — the last known good snapshot is held until a fresh successful poll arrives.
- Legitimate "no sessions running" responses still update the UI to an empty list, so an actually empty workspace is still represented correctly.
- The poll loop and ingest endpoint now share one code path for snapshot replacement, reducing drift between the two flows.

---

## Summary

This PR fixes how the server handles polling errors and snapshot broadcasts, ensuring that the previous agent state is properly preserved when a poll source error occurs.

### Changes

**Server polling logic (`server/index.ts`)**
- On source errors, the server now passes `undefined` (instead of an empty map) to `applyAgentSnapshot`, allowing it to detect the "no fresh data" condition and retain the previously known agents.
- Broadcasts of `agents:update` are now skipped when no fresh snapshot was applied (i.e., on source errors), so clients don't receive redundant empty updates and previously rendered agents remain visible.
- Added a top-level catch around the poll cycle that logs unexpected failures instead of letting them propagate silently.
- The recipe update endpoint now also persists the new recipe into the in-memory `agentStates` map (in addition to the persisted preferences), so the next snapshot reflects the change.

**Snapshot helper (`server/agentSnapshots.ts`)**
- Snapshots are now produced via `structuredClone` instead of a shallow spread, preventing later mutations of the returned objects from leaking back into the source map.
- `applyAgentSnapshot` now accepts an optional `nextAgents` argument; when omitted, the function falls back to clearing the map (used for the "no previous data to preserve" case) or simply has nothing to merge in.

**Tests (`server/agentSnapshots.test.ts`)**
- Added a regression test verifying that mutating a returned snapshot (e.g., pushing into an agent's `tags` array) does not affect the underlying agent state.
- Updated the "empty first snapshot" test to pass `undefined` instead of an empty map, matching the new signature and behavior.
<!-- kody-pr-summary:end -->