### PR TITLE
fix(server): validate persisted data and mutation bodies

### DIFF
--- a/server/auth.test.ts
+++ b/server/auth.test.ts
@@ -102,6 +102,12 @@ describe("API auth boundaries", () => {
       .send({ spriteId: "../char_1" })
       .expect(400)
       .expect({ error: "spriteId must be a safe string" });
+
+    await request(app)
+      .put("/api/agents/main/tags")
+      .set("Origin", appOrigin)
+      .send({ tags: ["coding"], extra: true })
+      .expect(400);
   });
 
   it("rejects malformed layout mutation bodies", async () => {

--- a/server/auth.test.ts
+++ b/server/auth.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { Express } from "express";
@@ -86,6 +86,68 @@ describe("API auth boundaries", () => {
     ];
 
     expect(responses.map((response) => response.status)).not.toContain(401);
+  });
+
+  it("rejects malformed agent mutation bodies", async () => {
+    await request(app)
+      .post("/api/agents/main/toggle")
+      .set("Origin", appOrigin)
+      .send({ enabled: "false" })
+      .expect(400)
+      .expect({ error: "enabled must be a boolean" });
+
+    await request(app)
+      .post("/api/agents/main/sprite")
+      .set("Origin", appOrigin)
+      .send({ spriteId: "../char_1" })
+      .expect(400)
+      .expect({ error: "spriteId must be a safe string" });
+  });
+
+  it("rejects malformed layout mutation bodies", async () => {
+    await request(app)
+      .put("/api/layouts/validation-regression")
+      .set("Origin", appOrigin)
+      .send({ width: "wide" })
+      .expect(400);
+
+    await request(app)
+      .put("/api/layouts/validation-regression")
+      .set("Origin", appOrigin)
+      .send({ baseUpdatedAt: "stale" })
+      .expect(400)
+      .expect({ error: "baseUpdatedAt must be a non-negative integer" });
+
+    await request(app)
+      .put("/api/layouts/validation-regression")
+      .set("Origin", appOrigin)
+      .send({ furniture: [{}] })
+      .expect(400);
+
+    await request(app)
+      .post("/api/layouts")
+      .set("Origin", appOrigin)
+      .send({ width: -1 })
+      .expect(400);
+
+    await request(app)
+      .post("/api/layouts")
+      .set("Origin", appOrigin)
+      .send({ furniture: "nope" })
+      .expect(400);
+  });
+
+  it("skips malformed persisted layout files", async () => {
+    const layoutsDir = join(dataDir, "layouts");
+    mkdirSync(layoutsDir, { recursive: true });
+    writeFileSync(join(layoutsDir, "bad.json"), JSON.stringify({ id: "bad", name: "Bad", width: "wide" }));
+
+    await request(app)
+      .get("/api/layouts")
+      .expect(200)
+      .expect((response) => {
+        expect(response.body.layouts.every((layout: { id: string }) => layout.id !== "bad")).toBe(true);
+      });
   });
 
   it("rejects UI mutations from origins outside the configured app allow-list", async () => {

--- a/server/index.ts
+++ b/server/index.ts
@@ -19,6 +19,7 @@ import { applyAgentSnapshot } from "./agentSnapshots";
 import { createCorsConfig, isOriginAllowed } from "./cors";
 import { apiErrorHandler, registerProcessErrorHandlers } from "./errors";
 import { isValidLayoutId } from "./layouts";
+import { parseAgentTags, parseLayoutMutationBody, parseOfficeLayoutDoc, parsePersistedPrefs, parseRecipe, parseSpriteBody, parseToggleBody, type OfficeLayoutDoc, type PersistedPrefs } from "./validation";
 import { ALL_TAGS, TAG_COLORS, DEFAULT_ROOMS, type AgentState, type AgentActivity, type SubAgentInfo, type TickerMessage, type Room, type AgentTag } from "../shared/types";
 const app = express();
 const server = createServer(app);
@@ -99,13 +100,6 @@ function defaultRegistry(): Map<string, KnownAgent> {
   ]);
 }
 
-interface PersistedPrefs {
-  pixelEnabled?: boolean;
-  characterSpriteId?: string;
-  tags?: AgentTag[];
-  recipe?: { bodyIndex: number; hairIndex: number; outfitIndex: number };
-}
-
 /** Load persisted agent preferences (pixelEnabled, spriteId, tags, recipe) from disk */
 function loadPersistedPrefs(): Map<string, PersistedPrefs> {
   try {
@@ -115,12 +109,16 @@ function loadPersistedPrefs(): Map<string, PersistedPrefs> {
     const map = new Map<string, PersistedPrefs>();
 
     for (const [k, v] of Object.entries(data)) {
-      if (v && typeof v === 'object' && !Array.isArray(v)) {
-        map.set(k, v as PersistedPrefs);
+      const prefs = parsePersistedPrefs(v);
+      if (prefs) {
+        map.set(k, prefs);
+      } else {
+        console.warn(`[prefs] Skipping invalid persisted prefs for agent ${k}`);
       }
     }
     return map;
-  } catch {
+  } catch (err) {
+    console.warn("[prefs] Failed to load persisted prefs:", err);
     return new Map();
   }
 }
@@ -742,7 +740,10 @@ app.get("/api/messages", (_req, res) => {
 
 app.post("/api/agents/:id/toggle", (req, res) => {
   const { id } = req.params;
-  const { enabled } = req.body;
+  const enabled = parseToggleBody(req.body);
+  if (enabled === null) {
+    return res.status(400).json({ error: "enabled must be a boolean" });
+  }
 
   const known = AGENT_REGISTRY.get(id);
   if (known) {
@@ -760,7 +761,10 @@ app.post("/api/agents/:id/toggle", (req, res) => {
 
 app.post("/api/agents/:id/sprite", (req, res) => {
   const { id } = req.params;
-  const { spriteId } = req.body;
+  const spriteId = parseSpriteBody(req.body);
+  if (spriteId === null) {
+    return res.status(400).json({ error: "spriteId must be a safe string" });
+  }
 
   const known = AGENT_REGISTRY.get(id);
   if (known) {
@@ -778,11 +782,9 @@ app.post("/api/agents/:id/sprite", (req, res) => {
 
 app.put("/api/agents/:id/recipe", (req, res) => {
   const { id } = req.params;
-  const { bodyIndex, hairIndex, outfitIndex } = req.body;
-
-  if (typeof bodyIndex !== 'number' || typeof hairIndex !== 'number' || typeof outfitIndex !== 'number') {
-    res.status(400).json({ error: "bodyIndex, hairIndex, outfitIndex required (numbers)" });
-    return;
+  const recipe = parseRecipe(req.body);
+  if (!recipe) {
+    return res.status(400).json({ error: "bodyIndex, hairIndex, outfitIndex must be valid recipe indices" });
   }
 
   const known = AGENT_REGISTRY.get(id);
@@ -791,13 +793,7 @@ app.put("/api/agents/:id/recipe", (req, res) => {
     return;
   }
 
-  // Validate ranges
-  if (bodyIndex < 0 || bodyIndex > 5 || hairIndex < 0 || hairIndex > 8 || outfitIndex < 0 || outfitIndex > 5) {
-    res.status(400).json({ error: "Indices out of range (body: 0-5, hair: 0-8, outfit: 0-5)" });
-    return;
-  }
-
-  known.recipe = { bodyIndex, hairIndex, outfitIndex };
+  known.recipe = recipe;
   const state = agentStates.get(id);
   if (state) state.recipe = known.recipe;
   savePersistedPrefs();
@@ -827,22 +823,9 @@ app.get("/api/tags", (_req, res) => {
 /** Update tags for an agent */
 app.put("/api/agents/:id/tags", (req, res) => {
   const { id } = req.params;
-  const { tags } = req.body as { tags: AgentTag[] };
-
-  if (!Array.isArray(tags)) {
-    return res.status(400).json({ error: "tags must be an array of strings" });
-  }
-
-  // Validate each tag against the known AgentTag set
-  const validTags = new Set<string>(ALL_TAGS);
-  for (const tag of tags) {
-    if (typeof tag !== "string" || !validTags.has(tag)) {
-      return res.status(400).json({ error: `Invalid tag: "${tag}". Valid tags: ${ALL_TAGS.join(", ")}` });
-    }
-  }
-
-  if (tags.length > 3) {
-    return res.status(400).json({ error: "Maximum 3 tags allowed per agent" });
+  const tags = parseAgentTags((req.body as { tags?: unknown }).tags);
+  if (!tags) {
+    return res.status(400).json({ error: `tags must be an array of up to 3 valid tags: ${ALL_TAGS.join(", ")}` });
   }
 
   const known = AGENT_REGISTRY.get(id);
@@ -887,18 +870,6 @@ app.get("/api/rooms", (_req, res) => {
 
 // ---- Layout persistence ----
 
-import type { PlacedFurniture } from "../shared/types";
-
-interface OfficeLayoutDoc {
-  id: string;
-  name: string;
-  width: number;
-  height: number;
-  furniture: PlacedFurniture[];
-  seats: Record<string, { x: number; y: number }>;
-  updatedAt: number;
-}
-
 const LAYOUTS_DIR = join(DATA_DIR, "layouts");
 
 function ensureLayoutsDir() {
@@ -909,13 +880,18 @@ function listLayouts(): OfficeLayoutDoc[] {
   ensureLayoutsDir();
   try {
     const files = readdirSync(LAYOUTS_DIR).filter(f => f.endsWith(".json"));
-    return files
-      .map(f => {
-        const raw = readFileSync(join(LAYOUTS_DIR, f), "utf-8");
-        return JSON.parse(raw) as OfficeLayoutDoc;
-      })
-      .filter(layout => isValidLayoutId(layout.id)) // Only return layouts with valid IDs
-      .sort((a, b) => b.updatedAt - a.updatedAt);
+    const layouts: OfficeLayoutDoc[] = [];
+    for (const file of files) {
+      try {
+        const raw = readFileSync(join(LAYOUTS_DIR, file), "utf-8");
+        const layout = parseOfficeLayoutDoc(JSON.parse(raw));
+        if (layout) layouts.push(layout);
+        else console.warn(`[layout] Skipping invalid layout file ${file}`);
+      } catch (err) {
+        console.warn(`[layout] Skipping unreadable layout file ${file}:`, err);
+      }
+    }
+    return layouts.sort((a, b) => b.updatedAt - a.updatedAt);
   } catch {
     return [];
   }
@@ -926,8 +902,13 @@ function loadLayout(id: string): OfficeLayoutDoc | null {
   if (!isValidLayoutId(id)) return null;
   try {
     const raw = readFileSync(join(LAYOUTS_DIR, `${id}.json`), "utf-8");
-    return JSON.parse(raw) as OfficeLayoutDoc;
-  } catch {
+    const layout = parseOfficeLayoutDoc(JSON.parse(raw));
+    if (!layout) console.warn(`[layout] Ignoring invalid layout file ${id}.json`);
+    return layout;
+  } catch (err) {
+    if (!(typeof err === "object" && err !== null && "code" in err && err.code === "ENOENT")) {
+      console.warn(`[layout] Failed to load layout ${id}:`, err);
+    }
     return null;
   }
 }
@@ -936,7 +917,9 @@ function saveLayout(layout: OfficeLayoutDoc): void {
   if (!isValidLayoutId(layout.id)) throw new Error(`Invalid layout ID: ${layout.id}`);
   ensureLayoutsDir();
   layout.updatedAt = Date.now();
-  writeFileSync(join(LAYOUTS_DIR, `${layout.id}.json`), JSON.stringify(layout, null, 2));
+  const validated = parseOfficeLayoutDoc(layout);
+  if (!validated) throw new Error(`Invalid layout document: ${layout.id}`);
+  writeFileSync(join(LAYOUTS_DIR, `${validated.id}.json`), JSON.stringify(validated, null, 2));
 }
 
 function deleteLayout(id: string): boolean {
@@ -1020,11 +1003,13 @@ app.put("/api/layouts/:id", (req, res) => {
   const { id } = req.params;
   if (!isValidLayoutId(id)) return res.status(400).json({ error: "Invalid layout ID" });
   const existing = loadLayout(id);
+  const baseLayout: OfficeLayoutDoc = existing || { id, name: id, width: 24, height: 16, furniture: [], seats: {}, updatedAt: Date.now() };
+  const parsed = parseLayoutMutationBody(req.body, { width: baseLayout.width, height: baseLayout.height });
+  if (!parsed.ok) return res.status(400).json({ error: parsed.error });
 
   // Server-side conflict detection: reject stale writes using baseUpdatedAt
-  const { baseUpdatedAt, ...body } = req.body;
-  if (existing && baseUpdatedAt != null && existing.updatedAt != null) {
-    if (baseUpdatedAt < existing.updatedAt) {
+  if (existing && parsed.baseUpdatedAt != null && existing.updatedAt != null) {
+    if (parsed.baseUpdatedAt < existing.updatedAt) {
       return res.status(409).json({
         error: "Conflict: your data is stale. Reload and try again.",
         serverUpdatedAt: existing.updatedAt,
@@ -1033,27 +1018,31 @@ app.put("/api/layouts/:id", (req, res) => {
   }
 
   const layout: OfficeLayoutDoc = {
-    ...(existing || { id, name: id, width: 24, height: 16 }),
-    ...body,
+    ...baseLayout,
+    ...parsed.body,
     id, // prevent id overwrite
   };
+  if (!parseOfficeLayoutDoc(layout)) return res.status(400).json({ error: "Invalid layout document" });
   saveLayout(layout);
   io.emit("layout:update", layout);
   res.json({ success: true, layout });
 });
 
 app.post("/api/layouts", (req, res) => {
-  const { name, width, height, furniture, seats } = req.body;
   const id = `layout-${randomUUID()}`;
+  const parsed = parseLayoutMutationBody(req.body, { width: 24, height: 16 });
+  if (!parsed.ok) return res.status(400).json({ error: parsed.error });
+
   const layout: OfficeLayoutDoc = {
     id,
-    name: name || "Untitled Layout",
-    width: width || 24,
-    height: height || 16,
-    furniture: furniture || [],
-    seats: seats || {},
+    name: parsed.body.name || "Untitled Layout",
+    width: parsed.body.width || 24,
+    height: parsed.body.height || 16,
+    furniture: parsed.body.furniture || [],
+    seats: parsed.body.seats || {},
     updatedAt: Date.now(),
   };
+  if (!parseOfficeLayoutDoc(layout)) return res.status(400).json({ error: "Invalid layout document" });
   saveLayout(layout);
   io.emit("layout:update", layout);
   res.json({ success: true, layout });

--- a/server/index.ts
+++ b/server/index.ts
@@ -19,7 +19,7 @@ import { applyAgentSnapshot } from "./agentSnapshots";
 import { createCorsConfig, isOriginAllowed } from "./cors";
 import { apiErrorHandler, registerProcessErrorHandlers } from "./errors";
 import { isValidLayoutId } from "./layouts";
-import { parseAgentTags, parseLayoutMutationBody, parseOfficeLayoutDoc, parsePersistedPrefs, parseRecipe, parseSpriteBody, parseToggleBody, type OfficeLayoutDoc, type PersistedPrefs } from "./validation";
+import { parseLayoutMutationBody, parseOfficeLayoutDoc, parsePersistedPrefs, parseRecipe, parseSpriteBody, parseTagsBody, parseToggleBody, type OfficeLayoutDoc, type PersistedPrefs } from "./validation";
 import { ALL_TAGS, TAG_COLORS, DEFAULT_ROOMS, type AgentState, type AgentActivity, type SubAgentInfo, type TickerMessage, type Room, type AgentTag } from "../shared/types";
 const app = express();
 const server = createServer(app);
@@ -823,7 +823,7 @@ app.get("/api/tags", (_req, res) => {
 /** Update tags for an agent */
 app.put("/api/agents/:id/tags", (req, res) => {
   const { id } = req.params;
-  const tags = parseAgentTags((req.body as { tags?: unknown }).tags);
+  const tags = parseTagsBody(req.body);
   if (!tags) {
     return res.status(400).json({ error: `tags must be an array of up to 3 valid tags: ${ALL_TAGS.join(", ")}` });
   }

--- a/server/validation.test.ts
+++ b/server/validation.test.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
-import { parseLayoutMutationBody, parseOfficeLayoutDoc, parsePersistedPrefs, parseRecipe, parseSpriteBody, parseToggleBody } from "./validation";
+import { parseAgentTags, parseLayoutMutationBody, parseOfficeLayoutDoc, parsePersistedPrefs, parseRecipe, parseSpriteBody, parseTagsBody, parseToggleBody } from "./validation";
 
 const defaultLayout = JSON.parse(readFileSync(join(process.cwd(), "data/layouts/default.json"), "utf-8"));
 const persistedPrefs = JSON.parse(readFileSync(join(process.cwd(), "data/agent-prefs.json"), "utf-8"));
@@ -9,7 +9,9 @@ const persistedPrefs = JSON.parse(readFileSync(join(process.cwd(), "data/agent-p
 describe("runtime validators", () => {
   it("accepts the committed persisted prefs fixture", () => {
     for (const value of Object.values(persistedPrefs)) {
-      expect(parsePersistedPrefs(value)).toEqual({ pixelEnabled: true });
+      const prefs = parsePersistedPrefs(value);
+      expect(prefs).not.toBeNull();
+      expect(prefs?.pixelEnabled).toBe(true);
     }
   });
 
@@ -29,11 +31,14 @@ describe("runtime validators", () => {
 
   it("rejects malformed layout documents", () => {
     expect(parseOfficeLayoutDoc({ ...defaultLayout, id: "../default" })).toBeNull();
+    expect(parseOfficeLayoutDoc({ ...defaultLayout, name: "   " })).toBeNull();
     expect(parseOfficeLayoutDoc({ ...defaultLayout, width: 129 })).toBeNull();
     expect(parseOfficeLayoutDoc({ ...defaultLayout, width: Number.POSITIVE_INFINITY })).toBeNull();
     expect(parseOfficeLayoutDoc({ ...defaultLayout, furniture: [{ ...defaultLayout.furniture[0], rotation: 45 }] })).toBeNull();
     expect(parseOfficeLayoutDoc({ ...defaultLayout, furniture: [{ ...defaultLayout.furniture[0], x: -1 }] })).toBeNull();
     expect(parseOfficeLayoutDoc({ ...defaultLayout, seats: { main: { x: "1", y: 1 } } })).toBeNull();
+    expect(parseOfficeLayoutDoc({ ...defaultLayout, seats: JSON.parse('{"__proto__":{"x":1,"y":1}}') })).toBeNull();
+    expect(parseOfficeLayoutDoc({ ...defaultLayout, seats: Object.fromEntries(Array.from({ length: 201 }, (_, index) => [`agent-${index}`, { x: 0, y: 0 }])) })).toBeNull();
     expect(parseOfficeLayoutDoc({ ...defaultLayout, unexpected: true })).toBeNull();
   });
 
@@ -46,6 +51,7 @@ describe("runtime validators", () => {
   });
 
   it("rejects invalid layout mutation bodies", () => {
+    expect(parseLayoutMutationBody({ name: "   " }, { width: 24, height: 16 }).ok).toBe(false);
     expect(parseLayoutMutationBody({ width: "wide" }, { width: 24, height: 16 }).ok).toBe(false);
     expect(parseLayoutMutationBody({ baseUpdatedAt: "old" }, { width: 24, height: 16 }).ok).toBe(false);
     expect(parseLayoutMutationBody({ baseUpdatedAt: -1 }, { width: 24, height: 16 }).ok).toBe(false);
@@ -59,6 +65,9 @@ describe("runtime validators", () => {
     expect(parseToggleBody({ enabled: 0 })).toBeNull();
     expect(parseSpriteBody({ spriteId: "char_1" })).toBe("char_1");
     expect(parseSpriteBody({ spriteId: "../char_1" })).toBeNull();
+    expect(parseAgentTags(["coding", "logic"])).toEqual(["coding", "logic"]);
+    expect(parseAgentTags(["coding", "coding"])).toBeNull();
+    expect(parseTagsBody({ tags: ["coding"], extra: true })).toBeNull();
     expect(parseRecipe({ bodyIndex: 0, hairIndex: 0, outfitIndex: 0 })).toEqual({ bodyIndex: 0, hairIndex: 0, outfitIndex: 0 });
     expect(parseRecipe({ bodyIndex: 0, hairIndex: 9, outfitIndex: 0 })).toBeNull();
   });

--- a/server/validation.test.ts
+++ b/server/validation.test.ts
@@ -1,0 +1,65 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { parseLayoutMutationBody, parseOfficeLayoutDoc, parsePersistedPrefs, parseRecipe, parseSpriteBody, parseToggleBody } from "./validation";
+
+const defaultLayout = JSON.parse(readFileSync(join(process.cwd(), "data/layouts/default.json"), "utf-8"));
+const persistedPrefs = JSON.parse(readFileSync(join(process.cwd(), "data/agent-prefs.json"), "utf-8"));
+
+describe("runtime validators", () => {
+  it("accepts the committed persisted prefs fixture", () => {
+    for (const value of Object.values(persistedPrefs)) {
+      expect(parsePersistedPrefs(value)).toEqual({ pixelEnabled: true });
+    }
+  });
+
+  it("rejects malformed persisted prefs", () => {
+    expect(parsePersistedPrefs(null)).toBeNull();
+    expect(parsePersistedPrefs([])).toBeNull();
+    expect(parsePersistedPrefs({ pixelEnabled: "true" })).toBeNull();
+    expect(parsePersistedPrefs({ characterSpriteId: "../evil" })).toBeNull();
+    expect(parsePersistedPrefs({ tags: ["coding", "logic", "research", "frontend"] })).toBeNull();
+    expect(parsePersistedPrefs({ recipe: { bodyIndex: 6, hairIndex: 0, outfitIndex: 0 } })).toBeNull();
+    expect(parsePersistedPrefs({ pixelEnabled: true, extra: true })).toBeNull();
+  });
+
+  it("accepts the committed default layout fixture", () => {
+    expect(parseOfficeLayoutDoc(defaultLayout)).toMatchObject({ id: "default", width: 24, height: 16 });
+  });
+
+  it("rejects malformed layout documents", () => {
+    expect(parseOfficeLayoutDoc({ ...defaultLayout, id: "../default" })).toBeNull();
+    expect(parseOfficeLayoutDoc({ ...defaultLayout, width: 129 })).toBeNull();
+    expect(parseOfficeLayoutDoc({ ...defaultLayout, width: Number.POSITIVE_INFINITY })).toBeNull();
+    expect(parseOfficeLayoutDoc({ ...defaultLayout, furniture: [{ ...defaultLayout.furniture[0], rotation: 45 }] })).toBeNull();
+    expect(parseOfficeLayoutDoc({ ...defaultLayout, furniture: [{ ...defaultLayout.furniture[0], x: -1 }] })).toBeNull();
+    expect(parseOfficeLayoutDoc({ ...defaultLayout, seats: { main: { x: "1", y: 1 } } })).toBeNull();
+    expect(parseOfficeLayoutDoc({ ...defaultLayout, unexpected: true })).toBeNull();
+  });
+
+  it("parses valid layout mutation bodies", () => {
+    expect(parseLayoutMutationBody({ name: "Team Room", width: 24, height: 16, furniture: [], seats: {}, baseUpdatedAt: 1 }, { width: 24, height: 16 })).toEqual({
+      ok: true,
+      body: { name: "Team Room", width: 24, height: 16, furniture: [], seats: {} },
+      baseUpdatedAt: 1,
+    });
+  });
+
+  it("rejects invalid layout mutation bodies", () => {
+    expect(parseLayoutMutationBody({ width: "wide" }, { width: 24, height: 16 }).ok).toBe(false);
+    expect(parseLayoutMutationBody({ baseUpdatedAt: "old" }, { width: 24, height: 16 }).ok).toBe(false);
+    expect(parseLayoutMutationBody({ baseUpdatedAt: -1 }, { width: 24, height: 16 }).ok).toBe(false);
+    expect(parseLayoutMutationBody({ furniture: [{}] }, { width: 24, height: 16 }).ok).toBe(false);
+    expect(parseLayoutMutationBody({ furniture: "nope" }, { width: 24, height: 16 }).ok).toBe(false);
+    expect(parseLayoutMutationBody({ unknown: true }, { width: 24, height: 16 }).ok).toBe(false);
+  });
+
+  it("validates agent mutation bodies", () => {
+    expect(parseToggleBody({ enabled: false })).toBe(false);
+    expect(parseToggleBody({ enabled: 0 })).toBeNull();
+    expect(parseSpriteBody({ spriteId: "char_1" })).toBe("char_1");
+    expect(parseSpriteBody({ spriteId: "../char_1" })).toBeNull();
+    expect(parseRecipe({ bodyIndex: 0, hairIndex: 0, outfitIndex: 0 })).toEqual({ bodyIndex: 0, hairIndex: 0, outfitIndex: 0 });
+    expect(parseRecipe({ bodyIndex: 0, hairIndex: 9, outfitIndex: 0 })).toBeNull();
+  });
+});

--- a/server/validation.ts
+++ b/server/validation.ts
@@ -28,6 +28,9 @@ const VALID_ROTATIONS = new Set([0, 90, 180, 270]);
 const PREF_KEYS = new Set(["pixelEnabled", "characterSpriteId", "tags", "recipe"]);
 const LAYOUT_KEYS = new Set(["id", "name", "width", "height", "furniture", "seats", "updatedAt"]);
 const LAYOUT_MUTATION_KEYS = new Set([...LAYOUT_KEYS, "baseUpdatedAt"]);
+const TAGS_BODY_KEYS = new Set(["tags"]);
+const RESERVED_OBJECT_KEYS = new Set(["__proto__", "constructor", "prototype"]);
+const MAX_SEATS = 200;
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -38,7 +41,7 @@ function hasOnlyKeys(value: Record<string, unknown>, allowed: Set<string>): bool
 }
 
 function isIntInRange(value: unknown, min: number, max: number): value is number {
-  return typeof value === "number" && Number.isInteger(value) && Number.isFinite(value) && value >= min && value <= max;
+  return typeof value === "number" && Number.isInteger(value) && value >= min && value <= max;
 }
 
 function isSafeString(value: unknown, maxLength: number): value is string {
@@ -61,11 +64,18 @@ export function parseRecipe(value: unknown): CharacterRecipe | null {
 export function parseAgentTags(value: unknown): AgentTag[] | null {
   if (!Array.isArray(value) || value.length > 3) return null;
   const tags: AgentTag[] = [];
+  const seen = new Set<AgentTag>();
   for (const tag of value) {
-    if (!isAgentTag(tag)) return null;
+    if (!isAgentTag(tag) || seen.has(tag)) return null;
+    seen.add(tag);
     tags.push(tag);
   }
   return tags;
+}
+
+export function parseTagsBody(value: unknown): AgentTag[] | null {
+  if (!isPlainObject(value) || !hasOnlyKeys(value, TAGS_BODY_KEYS)) return null;
+  return parseAgentTags(value.tags);
 }
 
 export function parsePersistedPrefs(value: unknown): PersistedPrefs | null {
@@ -124,8 +134,12 @@ function parseFurnitureArray(value: unknown, width: number, height: number): Pla
 
 function parseSeats(value: unknown, width: number, height: number): Record<string, { x: number; y: number }> | null {
   if (!isPlainObject(value)) return null;
-  const seats: Record<string, { x: number; y: number }> = {};
-  for (const [agentId, seat] of Object.entries(value)) {
+  const entries = Object.entries(value);
+  if (entries.length > MAX_SEATS) return null;
+
+  const seats: Record<string, { x: number; y: number }> = Object.create(null);
+  for (const [agentId, seat] of entries) {
+    if (RESERVED_OBJECT_KEYS.has(agentId)) return null;
     if (!isSafeString(agentId, 64) || !isPlainObject(seat) || !hasOnlyKeys(seat, new Set(["x", "y"]))) return null;
     const { x, y } = seat;
     if (!isIntInRange(x, 0, width - 1) || !isIntInRange(y, 0, height - 1)) return null;
@@ -138,7 +152,7 @@ export function parseOfficeLayoutDoc(value: unknown): OfficeLayoutDoc | null {
   if (!isPlainObject(value) || !hasOnlyKeys(value, LAYOUT_KEYS)) return null;
   const { id, name, width, height, furniture, seats, updatedAt } = value;
   if (typeof id !== "string" || !isValidLayoutId(id)) return null;
-  if (typeof name !== "string" || name.length < 1 || name.length > 128) return null;
+  if (typeof name !== "string" || name.trim().length < 1 || name.length > 128) return null;
   if (!isIntInRange(width, 1, 128) || !isIntInRange(height, 1, 128)) return null;
   const parsedFurniture = parseFurnitureArray(furniture, width, height);
   if (!parsedFurniture) return null;
@@ -169,7 +183,7 @@ export function parseLayoutMutationBody(
   if ("id" in value && !isValidLayoutId(value.id)) return { ok: false, error: "id must be a valid layout ID" };
   if ("updatedAt" in value && !isIntInRange(value.updatedAt, 0, Number.MAX_SAFE_INTEGER)) return { ok: false, error: "updatedAt must be a non-negative integer" };
   if ("name" in value) {
-    if (typeof value.name !== "string" || value.name.length < 1 || value.name.length > 128) return { ok: false, error: "name must be a non-empty string up to 128 characters" };
+    if (typeof value.name !== "string" || value.name.trim().length < 1 || value.name.length > 128) return { ok: false, error: "name must be a non-empty string up to 128 characters" };
     body.name = value.name;
   }
   if ("width" in value) {

--- a/server/validation.ts
+++ b/server/validation.ts
@@ -1,0 +1,207 @@
+import { ALL_TAGS, type AgentTag, type CharacterRecipe, type PlacedFurniture } from "../shared/types";
+import { isValidLayoutId } from "./layouts";
+
+export interface PersistedPrefs {
+  pixelEnabled?: boolean;
+  characterSpriteId?: string;
+  tags?: AgentTag[];
+  recipe?: CharacterRecipe;
+}
+
+export interface OfficeLayoutDoc {
+  id: string;
+  name: string;
+  width: number;
+  height: number;
+  furniture: PlacedFurniture[];
+  seats: Record<string, { x: number; y: number }>;
+  updatedAt: number;
+}
+
+export type LayoutMutationResult =
+  | { ok: true; body: Partial<OfficeLayoutDoc>; baseUpdatedAt?: number }
+  | { ok: false; error: string };
+
+const SAFE_ID_RE = /^[a-zA-Z0-9_.-]+$/;
+const VALID_TAGS = new Set<string>(ALL_TAGS);
+const VALID_ROTATIONS = new Set([0, 90, 180, 270]);
+const PREF_KEYS = new Set(["pixelEnabled", "characterSpriteId", "tags", "recipe"]);
+const LAYOUT_KEYS = new Set(["id", "name", "width", "height", "furniture", "seats", "updatedAt"]);
+const LAYOUT_MUTATION_KEYS = new Set([...LAYOUT_KEYS, "baseUpdatedAt"]);
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function hasOnlyKeys(value: Record<string, unknown>, allowed: Set<string>): boolean {
+  return Object.keys(value).every((key) => allowed.has(key));
+}
+
+function isIntInRange(value: unknown, min: number, max: number): value is number {
+  return typeof value === "number" && Number.isInteger(value) && Number.isFinite(value) && value >= min && value <= max;
+}
+
+function isSafeString(value: unknown, maxLength: number): value is string {
+  return typeof value === "string" && value.length > 0 && value.length <= maxLength && SAFE_ID_RE.test(value);
+}
+
+function isAgentTag(value: unknown): value is AgentTag {
+  return typeof value === "string" && VALID_TAGS.has(value);
+}
+
+export function parseRecipe(value: unknown): CharacterRecipe | null {
+  if (!isPlainObject(value) || !hasOnlyKeys(value, new Set(["bodyIndex", "hairIndex", "outfitIndex"]))) return null;
+  const { bodyIndex, hairIndex, outfitIndex } = value;
+  if (!isIntInRange(bodyIndex, 0, 5)) return null;
+  if (!isIntInRange(hairIndex, 0, 8)) return null;
+  if (!isIntInRange(outfitIndex, 0, 5)) return null;
+  return { bodyIndex, hairIndex, outfitIndex };
+}
+
+export function parseAgentTags(value: unknown): AgentTag[] | null {
+  if (!Array.isArray(value) || value.length > 3) return null;
+  const tags: AgentTag[] = [];
+  for (const tag of value) {
+    if (!isAgentTag(tag)) return null;
+    tags.push(tag);
+  }
+  return tags;
+}
+
+export function parsePersistedPrefs(value: unknown): PersistedPrefs | null {
+  if (!isPlainObject(value) || !hasOnlyKeys(value, PREF_KEYS)) return null;
+
+  const prefs: PersistedPrefs = {};
+  if ("pixelEnabled" in value) {
+    if (typeof value.pixelEnabled !== "boolean") return null;
+    prefs.pixelEnabled = value.pixelEnabled;
+  }
+  if ("characterSpriteId" in value) {
+    if (!isSafeString(value.characterSpriteId, 64)) return null;
+    prefs.characterSpriteId = value.characterSpriteId;
+  }
+  if ("tags" in value) {
+    const tags = parseAgentTags(value.tags);
+    if (!tags) return null;
+    prefs.tags = tags;
+  }
+  if ("recipe" in value) {
+    const recipe = parseRecipe(value.recipe);
+    if (!recipe) return null;
+    prefs.recipe = recipe;
+  }
+
+  return prefs;
+}
+
+function parseFurniture(value: unknown, width: number, height: number): PlacedFurniture | null {
+  if (!isPlainObject(value)) return null;
+  const allowed = new Set(["id", "type", "x", "y", "rotation", "state"]);
+  if (!hasOnlyKeys(value, allowed)) return null;
+  const { id, type, x, y, rotation, state } = value;
+  if (!isSafeString(id, 64)) return null;
+  if (!isSafeString(type, 64)) return null;
+  if (!isIntInRange(x, 0, width - 1)) return null;
+  if (!isIntInRange(y, 0, height - 1)) return null;
+  if (typeof rotation !== "number" || !VALID_ROTATIONS.has(rotation)) return null;
+  if (state !== undefined && (typeof state !== "string" || state.length > 32)) return null;
+
+  return state === undefined
+    ? { id, type, x, y, rotation }
+    : { id, type, x, y, rotation, state };
+}
+
+function parseFurnitureArray(value: unknown, width: number, height: number): PlacedFurniture[] | null {
+  if (!Array.isArray(value) || value.length > 200) return null;
+  const furniture: PlacedFurniture[] = [];
+  for (const item of value) {
+    const parsed = parseFurniture(item, width, height);
+    if (!parsed) return null;
+    furniture.push(parsed);
+  }
+  return furniture;
+}
+
+function parseSeats(value: unknown, width: number, height: number): Record<string, { x: number; y: number }> | null {
+  if (!isPlainObject(value)) return null;
+  const seats: Record<string, { x: number; y: number }> = {};
+  for (const [agentId, seat] of Object.entries(value)) {
+    if (!isSafeString(agentId, 64) || !isPlainObject(seat) || !hasOnlyKeys(seat, new Set(["x", "y"]))) return null;
+    const { x, y } = seat;
+    if (!isIntInRange(x, 0, width - 1) || !isIntInRange(y, 0, height - 1)) return null;
+    seats[agentId] = { x, y };
+  }
+  return seats;
+}
+
+export function parseOfficeLayoutDoc(value: unknown): OfficeLayoutDoc | null {
+  if (!isPlainObject(value) || !hasOnlyKeys(value, LAYOUT_KEYS)) return null;
+  const { id, name, width, height, furniture, seats, updatedAt } = value;
+  if (typeof id !== "string" || !isValidLayoutId(id)) return null;
+  if (typeof name !== "string" || name.length < 1 || name.length > 128) return null;
+  if (!isIntInRange(width, 1, 128) || !isIntInRange(height, 1, 128)) return null;
+  const parsedFurniture = parseFurnitureArray(furniture, width, height);
+  if (!parsedFurniture) return null;
+  const parsedSeats = parseSeats(seats, width, height);
+  if (!parsedSeats) return null;
+  if (!isIntInRange(updatedAt, 0, Number.MAX_SAFE_INTEGER)) return null;
+
+  return { id, name, width, height, furniture: parsedFurniture, seats: parsedSeats, updatedAt };
+}
+
+export function parseLayoutMutationBody(
+  value: unknown,
+  bounds: { width: number; height: number },
+): LayoutMutationResult {
+  if (!isPlainObject(value) || !hasOnlyKeys(value, LAYOUT_MUTATION_KEYS)) {
+    return { ok: false, error: "Invalid layout body" };
+  }
+
+  const body: Partial<OfficeLayoutDoc> = {};
+  let width = bounds.width;
+  let height = bounds.height;
+
+  let baseUpdatedAt: number | undefined;
+  if ("baseUpdatedAt" in value) {
+    if (!isIntInRange(value.baseUpdatedAt, 0, Number.MAX_SAFE_INTEGER)) return { ok: false, error: "baseUpdatedAt must be a non-negative integer" };
+    baseUpdatedAt = value.baseUpdatedAt;
+  }
+  if ("id" in value && !isValidLayoutId(value.id)) return { ok: false, error: "id must be a valid layout ID" };
+  if ("updatedAt" in value && !isIntInRange(value.updatedAt, 0, Number.MAX_SAFE_INTEGER)) return { ok: false, error: "updatedAt must be a non-negative integer" };
+  if ("name" in value) {
+    if (typeof value.name !== "string" || value.name.length < 1 || value.name.length > 128) return { ok: false, error: "name must be a non-empty string up to 128 characters" };
+    body.name = value.name;
+  }
+  if ("width" in value) {
+    if (!isIntInRange(value.width, 1, 128)) return { ok: false, error: "width must be an integer from 1 to 128" };
+    width = value.width;
+    body.width = value.width;
+  }
+  if ("height" in value) {
+    if (!isIntInRange(value.height, 1, 128)) return { ok: false, error: "height must be an integer from 1 to 128" };
+    height = value.height;
+    body.height = value.height;
+  }
+  if ("furniture" in value) {
+    const furniture = parseFurnitureArray(value.furniture, width, height);
+    if (!furniture) return { ok: false, error: "furniture must be a valid furniture array" };
+    body.furniture = furniture;
+  }
+  if ("seats" in value) {
+    const seats = parseSeats(value.seats, width, height);
+    if (!seats) return { ok: false, error: "seats must be a valid seat map" };
+    body.seats = seats;
+  }
+
+  return { ok: true, body, baseUpdatedAt };
+}
+
+export function parseToggleBody(value: unknown): boolean | null {
+  if (!isPlainObject(value) || !hasOnlyKeys(value, new Set(["enabled"]))) return null;
+  return typeof value.enabled === "boolean" ? value.enabled : null;
+}
+
+export function parseSpriteBody(value: unknown): string | null {
+  if (!isPlainObject(value) || !hasOnlyKeys(value, new Set(["spriteId"]))) return null;
+  return isSafeString(value.spriteId, 64) ? value.spriteId : null;
+}


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
## Summary

This pull request introduces a dedicated runtime validation layer (`server/validation.ts`) and wires it into every server trust boundary, replacing `JSON.parse(...) as Type` and ad-hoc `typeof` checks with explicit, type-returning parsers that fail closed.

### New validation module (`server/validation.ts`)

A new file establishes pure validator functions covering all persisted and request shapes:

- **`parsePersistedPrefs`** — validates agent preference records from `data/agent-prefs.json`, enforcing allowed keys, boolean `pixelEnabled`, safe `characterSpriteId` (regex-restricted, ≤64 chars), ≤3 validated `AgentTag` entries, and a complete `CharacterRecipe`.
- **`parseOfficeLayoutDoc`** — validates full layout documents: layout `id` via `isValidLayoutId`, name length (1–128), integer `width`/`height` (1–128), `updatedAt` as a non-negative safe integer, plus parsed `furniture` and `seats` collections. Rejects unknown keys.
- **`parseFurniture`** — validates each `PlacedFurniture`: safe `id`/`type` strings, integer coordinates bounded by the parent layout's `width`/`height`, rotation restricted to `{0, 90, 180, 270}`, and optional `state` string ≤32 chars.
- **`parseLayoutMutationBody`** — partial mutator that accepts either an update payload or full create payload, validating each optional field against the layout's current dimensions and returning `{ ok, body, baseUpdatedAt }` or `{ ok: false, error }`. Critical for detecting stale writes.
- **`parseToggleBody`** — requires a single boolean `enabled` field.
- **`parseSpriteBody`** — requires a single safe-string `spriteId` (rejects traversal-style inputs).
- **`parseRecipe`** — validates `bodyIndex` (0–5), `hairIndex` (0–8), `outfitIndex` (0–5) as integers.
- **`parseAgentTags`** — requires an array of ≤3 valid `AgentTag` values.

Shared helpers (`isPlainObject`, `hasOnlyKeys`, `isIntInRange`, `isSafeString`, `isAgentTag`) centralize key-restriction and bounds logic.

### Persisted-data hardening (`server/index.ts`)

- **Agent prefs load** — `loadPersistedPrefs()` now parses each entry with `parsePersistedPrefs`; invalid entries are skipped with a console warning, and outer failures are also logged.
- **Layout listing** — `listLayouts()` parses each file individually with `parseOfficeLayoutDoc`, skipping and warning on malformed or unreadable files instead of trusting them.
- **Layout loading** — `loadLayout()` validates the parsed JSON and warns on invalid content; distinguishes `ENOENT` from other read errors to avoid noisy logs.
- **Layout saving** — `saveLayout()` runs the document through `parseOfficeLayoutDoc` before writing, preventing invalid layouts from being persisted.

### API write hardening (`server/index.ts`)

- **`POST /api/agents/:id/toggle`** — uses `parseToggleBody`; non-boolean or malformed bodies return `400 enabled must be a boolean`.
- **`POST /api/agents/:id/sprite`** — uses `parseSpriteBody`; traversal-like or non-string sprite IDs return `400 spriteId must be a safe string`.
- **`PUT /api/agents/:id/recipe`** — replaces inline range/type checks with `parseRecipe`; on failure returns `400 bodyIndex, hairIndex, outfitIndex must be valid recipe indices`. The successful path now stores the validated recipe directly.
- **`PUT /api/agents/:id/tags`** — uses `parseAgentTags`; invalid tag arrays, unknown tag values, or >3 tags return `400 tags must be an array of up to 3 valid tags: …`.
- **`PUT /api/layouts/:id`** — body now flows through `parseLayoutMutationBody` with the current layout's dimensions as bounds. `baseUpdatedAt` is required to be a non-negative integer. The merged document is re-validated with `parseOfficeLayoutDoc` before being saved. Stale-write conflict detection now uses the validated `baseUpdatedAt`.
- **`POST /api/layouts`** — uses `parseLayoutMutationBody` with the default bounds `{ width: 24, height: 16 }`, then re-validates the final constructed document. All field defaults (name, dimensions, furniture, seats) flow from the validated body.

### Test coverage

- **`server/validation.test.ts`** (new) — exercises every validator against the committed `data/agent-prefs.json` and `data/layouts/default.json` fixtures, plus targeted negative cases (wrong types, traversal IDs, out-of-range indices, unknown keys, infinite/negative coordinates, non-90° rotations, malformed seat entries, invalid `baseUpdatedAt`).
- **`server/auth.test.ts`** — adds three new boundary tests:
  - Rejects non-boolean `enabled` and traversal-style `spriteId` on the toggle and sprite endpoints.
  - Rejects non-integer `width`, non-integer `baseUpdatedAt`, empty furniture objects, negative dimensions, and non-array furniture on the layout endpoints.
  - Confirms that a malformed `data/layouts/bad.json` is silently skipped on `GET /api/layouts` rather than poisoning the response.

### Scope discipline

- No external schema library is added; all validation is hand-rolled and dependency-free.
- No semantic catalog validation is introduced (e.g., cross-checking furniture `type` against a furniture catalog); the PR stays strictly on request-shape and persisted-shape validation.
- The `PersistedPrefs` and `OfficeLayoutDoc` interfaces are moved out of `server/index.ts` and into `server/validation.ts`, becoming the canonical runtime-validated shapes.

---

**Summary**

This pull request tightens runtime schema validation for persisted office data and HTTP mutation bodies, hardening the server against malformed or hostile inputs.

**Key changes**

- **Tags endpoint strictness**: Replaces the loose `parseAgentTags((req.body as { tags?: unknown }).tags)` call with a new `parseTagsBody` validator that requires the body to be a plain object containing only the expected `tags` key. Any additional fields are rejected with a 400 response. The internal `parseAgentTags` helper now also rejects duplicate tags.

- **Layout name trimming**: `parseOfficeLayoutDoc` and `parseLayoutMutationBody` now apply `.trim().length` checks, so blank/whitespace-only names are rejected in both stored documents and mutation payloads.

- **Seats cap and prototype-pollution guard**: `parseSeats` now (1) refuses objects with more than 200 entries, (2) stores results on a null-prototype object, and (3) rejects reserved keys like `__proto__`, `constructor`, and `prototype`, preventing prototype pollution and excessive seat counts.

- **Minor integer-range fix**: `isIntInRange` no longer requires `Number.isFinite(value)`; `Number.isInteger` already excludes `NaN` and infinities, simplifying the helper.

**Test coverage**

- `server/validation.test.ts` adds explicit cases for the new behaviors: duplicate tags, extra body fields on the tags mutation, whitespace-only layout/document names, oversized seats (201 entries), and prototype-polluting seat keys.
- `server/auth.test.ts` adds a new boundary test confirming that the tags endpoint returns 400 when the request body contains extra fields beyond `tags`.

**Impact**

These changes make the server more resilient to bad persisted data on disk and to mutation payloads that try to sneak in unexpected keys, oversized collections, or prototype-pollution vectors.
<!-- kody-pr-summary:end -->