### PR TITLE
fix(server): structured logging and request correlation IDs (#49)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "express": "^4.21.0",
+        "pino": "^9.14.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "socket.io": "^4.8.0",
@@ -27,6 +28,7 @@
         "@vitest/coverage-v8": "^4.1.9",
         "concurrently": "^9.0.0",
         "jsdom": "^29.1.1",
+        "pino-pretty": "^11.3.0",
         "supertest": "^7.2.2",
         "tsx": "^4.21.0",
         "typescript": "^5.6.0",
@@ -1080,6 +1082,12 @@
         "@noble/hashes": "^1.1.5"
       }
     },
+    "node_modules/@pinojs/redact": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
+      "integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==",
+      "license": "MIT"
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.27",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
@@ -1942,6 +1950,19 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
     "node_modules/accepts": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -2038,6 +2059,36 @@
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
       "license": "MIT"
     },
     "node_modules/base64id": {
@@ -2143,6 +2194,31 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
       }
     },
     "node_modules/bytes": {
@@ -2276,6 +2352,13 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/colorette": {
+      "version": "2.0.20",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
       "dev": true,
       "license": "MIT"
     },
@@ -2436,6 +2519,16 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
+    "node_modules/dateformat": {
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz",
+      "integrity": "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -2559,6 +2652,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
       }
     },
     "node_modules/engine.io": {
@@ -2747,6 +2850,26 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
@@ -2816,6 +2939,13 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/fast-copy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-3.0.2.tgz",
+      "integrity": "sha512-dl0O9Vhju8IrcLndv2eU4ldt1ftXMqqfgN4H1cpmGV7P6jeB9FwpN9a2c8DPGE1Ys88rNUJVYDHq73CGAGOPfQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-safe-stringify": {
@@ -3085,6 +3215,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/help-me": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/help-me/-/help-me-5.0.0.tgz",
+      "integrity": "sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/html-encoding-sniffer": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
@@ -3136,6 +3273,27 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/indent-string": {
       "version": "4.0.0",
@@ -3229,6 +3387,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/joycon": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
+      "integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/js-tokens": {
@@ -3473,6 +3641,16 @@
         "node": ">=4"
       }
     },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -3547,6 +3725,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.20.0"
+      }
+    },
+    "node_modules/on-exit-leak-free": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
+      "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/on-finished": {
@@ -3626,6 +3813,69 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/pino": {
+      "version": "9.14.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-9.14.0.tgz",
+      "integrity": "sha512-8OEwKp5juEvb/MjpIc4hjqfgCNysrS94RIOMXYvpYCdm/jglrKEiAYmiumbmGhCvs+IcInsphYDFwqrjr7398w==",
+      "license": "MIT",
+      "dependencies": {
+        "@pinojs/redact": "^0.4.0",
+        "atomic-sleep": "^1.0.0",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^2.0.0",
+        "pino-std-serializers": "^7.0.0",
+        "process-warning": "^5.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "sonic-boom": "^4.0.1",
+        "thread-stream": "^3.0.0"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/pino-abstract-transport": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-2.0.0.tgz",
+      "integrity": "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/pino-pretty": {
+      "version": "11.3.0",
+      "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-11.3.0.tgz",
+      "integrity": "sha512-oXwn7ICywaZPHmu3epHGU2oJX4nPmKvHvB/bwrJHlGcbEWaVcotkpyVHMKLKmiVryWYByNp0jpgAcXpFJDXJzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "colorette": "^2.0.7",
+        "dateformat": "^4.6.3",
+        "fast-copy": "^3.0.2",
+        "fast-safe-stringify": "^2.1.1",
+        "help-me": "^5.0.0",
+        "joycon": "^3.1.1",
+        "minimist": "^1.2.6",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^2.0.0",
+        "pump": "^3.0.0",
+        "readable-stream": "^4.0.0",
+        "secure-json-parse": "^2.4.0",
+        "sonic-boom": "^4.0.1",
+        "strip-json-comments": "^3.1.1"
+      },
+      "bin": {
+        "pino-pretty": "bin.js"
+      }
+    },
+    "node_modules/pino-std-serializers": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
+      "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
+      "license": "MIT"
+    },
     "node_modules/postcss": {
       "version": "8.5.8",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
@@ -3685,6 +3935,32 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/process-warning": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
+      "integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -3696,6 +3972,17 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
       }
     },
     "node_modules/punycode": {
@@ -3722,6 +4009,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/quick-format-unescaped": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
+      "license": "MIT"
     },
     "node_modules/range-parser": {
       "version": "1.2.1",
@@ -3784,6 +4077,32 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/real-require": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.13.0"
       }
     },
     "node_modules/redent": {
@@ -3905,6 +4224,15 @@
       ],
       "license": "MIT"
     },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -3929,6 +4257,13 @@
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "license": "MIT"
+    },
+    "node_modules/secure-json-parse": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.7.0.tgz",
+      "integrity": "sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==",
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/semver": {
       "version": "6.3.1",
@@ -4148,6 +4483,15 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/sonic-boom": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.1.tgz",
+      "integrity": "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -4156,6 +4500,15 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
       }
     },
     "node_modules/stackback": {
@@ -4180,6 +4533,16 @@
       "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
     },
     "node_modules/string-width": {
       "version": "4.2.3",
@@ -4220,6 +4583,19 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/superagent": {
@@ -4303,6 +4679,15 @@
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/thread-stream": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.2.0.tgz",
+      "integrity": "sha512-zLBvqpwr4Esa0kRjcrzGU6zL25lePWaCLMx0RQFrmteozIfeNdaMLpG5U7PeHzvlFkAWaRKA9/KVW4F60iB+qw==",
+      "license": "MIT",
+      "dependencies": {
+        "real-require": "^0.2.0"
+      }
     },
     "node_modules/tinybench": {
       "version": "2.9.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,6 @@
         "@vitest/coverage-v8": "^4.1.9",
         "concurrently": "^9.0.0",
         "jsdom": "^29.1.1",
-        "pino-pretty": "^11.3.0",
         "supertest": "^7.2.2",
         "tsx": "^4.21.0",
         "typescript": "^5.6.0",
@@ -1950,19 +1949,6 @@
         "url": "https://opencollective.com/vitest"
       }
     },
-    "node_modules/abort-controller": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
-      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "event-target-shim": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=6.5"
-      }
-    },
     "node_modules/accepts": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -2070,27 +2056,6 @@
         "node": ">=8.0.0"
       }
     },
-    "node_modules/base64-js": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/base64id": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz",
@@ -2194,31 +2159,6 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
-      }
-    },
-    "node_modules/buffer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
       }
     },
     "node_modules/bytes": {
@@ -2352,13 +2292,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/colorette": {
-      "version": "2.0.20",
-      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
-      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
       "dev": true,
       "license": "MIT"
     },
@@ -2519,16 +2452,6 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
-    "node_modules/dateformat": {
-      "version": "4.6.3",
-      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz",
-      "integrity": "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -2652,16 +2575,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/end-of-stream": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
-      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "once": "^1.4.0"
       }
     },
     "node_modules/engine.io": {
@@ -2850,26 +2763,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/event-target-shim": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
-      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/events": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
-      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.x"
-      }
-    },
     "node_modules/expect-type": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
@@ -2939,13 +2832,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "license": "MIT"
-    },
-    "node_modules/fast-copy": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-3.0.2.tgz",
-      "integrity": "sha512-dl0O9Vhju8IrcLndv2eU4ldt1ftXMqqfgN4H1cpmGV7P6jeB9FwpN9a2c8DPGE1Ys88rNUJVYDHq73CGAGOPfQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-safe-stringify": {
@@ -3215,13 +3101,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/help-me": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/help-me/-/help-me-5.0.0.tgz",
-      "integrity": "sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/html-encoding-sniffer": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
@@ -3273,27 +3152,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/ieee754": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "BSD-3-Clause"
     },
     "node_modules/indent-string": {
       "version": "4.0.0",
@@ -3387,16 +3245,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/joycon": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
-      "integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/js-tokens": {
@@ -3641,16 +3489,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/minimist": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -3844,32 +3682,6 @@
         "split2": "^4.0.0"
       }
     },
-    "node_modules/pino-pretty": {
-      "version": "11.3.0",
-      "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-11.3.0.tgz",
-      "integrity": "sha512-oXwn7ICywaZPHmu3epHGU2oJX4nPmKvHvB/bwrJHlGcbEWaVcotkpyVHMKLKmiVryWYByNp0jpgAcXpFJDXJzA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "colorette": "^2.0.7",
-        "dateformat": "^4.6.3",
-        "fast-copy": "^3.0.2",
-        "fast-safe-stringify": "^2.1.1",
-        "help-me": "^5.0.0",
-        "joycon": "^3.1.1",
-        "minimist": "^1.2.6",
-        "on-exit-leak-free": "^2.1.0",
-        "pino-abstract-transport": "^2.0.0",
-        "pump": "^3.0.0",
-        "readable-stream": "^4.0.0",
-        "secure-json-parse": "^2.4.0",
-        "sonic-boom": "^4.0.1",
-        "strip-json-comments": "^3.1.1"
-      },
-      "bin": {
-        "pino-pretty": "bin.js"
-      }
-    },
     "node_modules/pino-std-serializers": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
@@ -3935,16 +3747,6 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/process": {
-      "version": "0.11.10",
-      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6.0"
-      }
-    },
     "node_modules/process-warning": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
@@ -3972,17 +3774,6 @@
       },
       "engines": {
         "node": ">= 0.10"
-      }
-    },
-    "node_modules/pump": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
-      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "end-of-stream": "^1.1.0",
-        "once": "^1.3.1"
       }
     },
     "node_modules/punycode": {
@@ -4077,23 +3868,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/readable-stream": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
-      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "abort-controller": "^3.0.0",
-        "buffer": "^6.0.3",
-        "events": "^3.3.0",
-        "process": "^0.11.10",
-        "string_decoder": "^1.3.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
     "node_modules/real-require": {
@@ -4257,13 +4031,6 @@
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "license": "MIT"
-    },
-    "node_modules/secure-json-parse": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.7.0.tgz",
-      "integrity": "sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==",
-      "dev": true,
-      "license": "BSD-3-Clause"
     },
     "node_modules/semver": {
       "version": "6.3.1",
@@ -4534,16 +4301,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.2.0"
-      }
-    },
     "node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -4583,19 +4340,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/strip-json-comments": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/superagent": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "express": "^4.21.0",
+    "pino": "^9.14.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "socket.io": "^4.8.0",
@@ -33,6 +34,7 @@
     "@vitest/coverage-v8": "^4.1.9",
     "concurrently": "^9.0.0",
     "jsdom": "^29.1.1",
+    "pino-pretty": "^11.3.0",
     "supertest": "^7.2.2",
     "tsx": "^4.21.0",
     "typescript": "^5.6.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "@vitest/coverage-v8": "^4.1.9",
     "concurrently": "^9.0.0",
     "jsdom": "^29.1.1",
-    "pino-pretty": "^11.3.0",
     "supertest": "^7.2.2",
     "tsx": "^4.21.0",
     "typescript": "^5.6.0",

--- a/server/correlation.test.ts
+++ b/server/correlation.test.ts
@@ -1,0 +1,70 @@
+import express from "express";
+import request from "supertest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { correlationMiddleware, pickRequestId } from "./correlation";
+
+describe("correlation middleware", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("accepts a safe incoming X-Request-Id header and echoes it on the response", async () => {
+    const app = express();
+    app.use(correlationMiddleware);
+    app.get("/probe", (req, res) => {
+      res.json({ id: req.id });
+    });
+
+    const response = await request(app)
+      .get("/probe")
+      .set("X-Request-Id", "req-abc-123")
+      .expect(200);
+
+    expect(response.headers["x-request-id"]).toBe("req-abc-123");
+    expect(response.body.id).toBe("req-abc-123");
+  });
+
+  it("generates a fresh id when no header is provided", async () => {
+    const app = express();
+    app.use(correlationMiddleware);
+    app.get("/probe", (req, res) => {
+      res.json({ id: req.id });
+    });
+
+    const response = await request(app).get("/probe").expect(200);
+    expect(response.body.id).toMatch(/^[a-f0-9-]{36}$/);
+    expect(response.headers["x-request-id"]).toBe(response.body.id);
+  });
+
+  it("rejects unsafe incoming X-Request-Id headers and falls back to a UUID", async () => {
+    const app = express();
+    app.use(correlationMiddleware);
+    app.get("/probe", (req, res) => {
+      res.json({ id: req.id });
+    });
+
+    const response = await request(app)
+      .get("/probe")
+      .set("X-Request-Id", "<script>alert(1)</script>")
+      .expect(200);
+
+    expect(response.body.id).not.toBe("<script>alert(1)</script>");
+    expect(response.body.id).toMatch(/^[a-f0-9-]{36}$/);
+  });
+
+  it("rejects excessively long X-Request-Id headers", async () => {
+    const tooLong = "a".repeat(200);
+    const generated = pickRequestId({ "x-request-id": tooLong });
+    expect(generated).not.toBe(tooLong);
+    expect(generated).toMatch(/^[a-f0-9-]{36}$/);
+  });
+
+  it("handles array-valued headers by inspecting the first element", () => {
+    const generated = pickRequestId({ "x-request-id": ["req-array-1", "req-array-2"] });
+    expect(generated).toBe("req-array-1");
+  });
+});

--- a/server/correlation.test.ts
+++ b/server/correlation.test.ts
@@ -1,7 +1,7 @@
 import express from "express";
 import request from "supertest";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { correlationMiddleware, pickRequestId } from "./correlation";
+import { correlationMiddleware, httpRequestLogMiddleware, pickRequestId } from "./correlation";
 
 describe("correlation middleware", () => {
   beforeEach(() => {
@@ -66,5 +66,42 @@ describe("correlation middleware", () => {
   it("handles array-valued headers by inspecting the first element", () => {
     const generated = pickRequestId({ "x-request-id": ["req-array-1", "req-array-2"] });
     expect(generated).toBe("req-array-1");
+  });
+
+  it("attaches a request-scoped child logger", async () => {
+    const app = express();
+    app.use(correlationMiddleware);
+    app.use(httpRequestLogMiddleware);
+    app.get("/probe", (req, res) => {
+      res.json({ hasLog: typeof req.log?.info === "function" });
+    });
+
+    await request(app)
+      .get("/probe")
+      .set("X-Request-Id", "req-with-log")
+      .expect(200)
+      .expect({ hasLog: true });
+  });
+
+  it("can correlate JSON parse errors because it runs before express.json", async () => {
+    const app = express();
+    app.use(correlationMiddleware);
+    app.use(httpRequestLogMiddleware);
+    app.use(express.json());
+    app.post("/probe", (_req, res) => res.json({ ok: true }));
+    app.use((err: unknown, req: express.Request, res: express.Response, _next: express.NextFunction) => {
+      expect(err).toBeDefined();
+      res.status(400).json({ id: req.id, hasLog: typeof req.log?.warn === "function" });
+    });
+
+    const response = await request(app)
+      .post("/probe")
+      .set("X-Request-Id", "parse-error-1")
+      .set("Content-Type", "application/json")
+      .send('{"bad"')
+      .expect(400);
+
+    expect(response.headers["x-request-id"]).toBe("parse-error-1");
+    expect(response.body).toEqual({ id: "parse-error-1", hasLog: true });
   });
 });

--- a/server/correlation.ts
+++ b/server/correlation.ts
@@ -1,8 +1,9 @@
 import type { NextFunction, Request, Response } from "express";
 import { randomUUID } from "node:crypto";
-import { logger } from "./logger";
+import { logger, type Logger } from "./logger";
 
-const REQUEST_ID_HEADER = "x-request-id";
+const REQUEST_ID_HEADER = "X-Request-Id";
+const REQUEST_ID_HEADER_KEY = REQUEST_ID_HEADER.toLowerCase();
 const SAFE_ID = /^[a-zA-Z0-9_.\-]{1,128}$/;
 
 /**
@@ -15,7 +16,7 @@ const SAFE_ID = /^[a-zA-Z0-9_.\-]{1,128}$/;
  * can correlate logs across the system.
  */
 export function pickRequestId(headers: NodeJS.Dict<string | string[]>): string {
-  const raw = headers[REQUEST_ID_HEADER];
+  const raw = headers[REQUEST_ID_HEADER_KEY];
   const value = Array.isArray(raw) ? raw[0] : raw;
   if (typeof value === "string" && SAFE_ID.test(value)) return value;
   return randomUUID();
@@ -24,13 +25,14 @@ export function pickRequestId(headers: NodeJS.Dict<string | string[]>): string {
 declare module "express-serve-static-core" {
   interface Request {
     id?: string;
+    log?: Logger;
   }
 }
 
 export function correlationMiddleware(req: Request, res: Response, next: NextFunction): void {
   const id = pickRequestId(req.headers);
   req.id = id;
-  res.setHeader("X-Request-Id", id);
+  res.setHeader(REQUEST_ID_HEADER, id);
   next();
 }
 
@@ -46,12 +48,14 @@ export function correlationMiddleware(req: Request, res: Response, next: NextFun
 export function httpRequestLogMiddleware(req: Request, res: Response, next: NextFunction): void {
   const startedAt = process.hrtime.bigint();
   const child = logger.child({ reqId: req.id, method: req.method, url: req.originalUrl ?? req.url });
+  req.log = child;
 
-  res.on("finish", () => {
+  res.once("close", () => {
     const durationMs = Number(process.hrtime.bigint() - startedAt) / 1_000_000;
     const status = res.statusCode;
     const fields = { status, durationMs: Number(durationMs.toFixed(2)) };
-    if (status >= 500) child.error(fields, "request failed");
+    if (!res.writableFinished) child.warn(fields, "request aborted");
+    else if (status >= 500) child.error(fields, "request failed");
     else if (status >= 400) child.warn(fields, "request rejected");
     else child.info(fields, "request completed");
   });

--- a/server/correlation.ts
+++ b/server/correlation.ts
@@ -1,0 +1,60 @@
+import type { NextFunction, Request, Response } from "express";
+import { randomUUID } from "node:crypto";
+import { logger } from "./logger";
+
+const REQUEST_ID_HEADER = "x-request-id";
+const SAFE_ID = /^[a-zA-Z0-9_.\-]{1,128}$/;
+
+/**
+ * Extract a request correlation id from the incoming `X-Request-Id` header,
+ * validating that it is a safe opaque token (alphanumeric + a few separators,
+ * max 128 chars) to prevent log injection. Falls back to a fresh UUID when
+ * the header is absent or invalid.
+ *
+ * The id is stored on `req.id` and echoed on the response header so callers
+ * can correlate logs across the system.
+ */
+export function pickRequestId(headers: NodeJS.Dict<string | string[]>): string {
+  const raw = headers[REQUEST_ID_HEADER];
+  const value = Array.isArray(raw) ? raw[0] : raw;
+  if (typeof value === "string" && SAFE_ID.test(value)) return value;
+  return randomUUID();
+}
+
+declare module "express-serve-static-core" {
+  interface Request {
+    id?: string;
+  }
+}
+
+export function correlationMiddleware(req: Request, res: Response, next: NextFunction): void {
+  const id = pickRequestId(req.headers);
+  req.id = id;
+  res.setHeader("X-Request-Id", id);
+  next();
+}
+
+/**
+ * Minimal HTTP request logger.
+ *
+ * pino-http was avoided because its type declarations augment Node's
+ * `http.IncomingMessage` in a way that breaks Express 4 + @types/express 5
+ * overload resolution. This middleware keeps the same operational contract
+ * (one structured log line per request, with `reqId`/`method`/`url`/`status`
+ * and response time) without disturbing the wider middleware chain.
+ */
+export function httpRequestLogMiddleware(req: Request, res: Response, next: NextFunction): void {
+  const startedAt = process.hrtime.bigint();
+  const child = logger.child({ reqId: req.id, method: req.method, url: req.originalUrl ?? req.url });
+
+  res.on("finish", () => {
+    const durationMs = Number(process.hrtime.bigint() - startedAt) / 1_000_000;
+    const status = res.statusCode;
+    const fields = { status, durationMs: Number(durationMs.toFixed(2)) };
+    if (status >= 500) child.error(fields, "request failed");
+    else if (status >= 400) child.warn(fields, "request rejected");
+    else child.info(fields, "request completed");
+  });
+
+  next();
+}

--- a/server/errors.test.ts
+++ b/server/errors.test.ts
@@ -2,6 +2,7 @@ import express from "express";
 import request from "supertest";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { apiErrorHandler, asyncHandler } from "./errors";
+import { logger } from "./logger";
 
 describe("Express error boundary", () => {
   afterEach(() => {
@@ -10,7 +11,7 @@ describe("Express error boundary", () => {
 
   it("turns async route rejections into 500 responses and keeps serving", async () => {
     const app = express();
-    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const errorSpy = vi.spyOn(logger, "error").mockImplementation(() => logger);
 
     app.get(
       "/reject",
@@ -27,7 +28,10 @@ describe("Express error boundary", () => {
       .expect("Content-Type", /json/)
       .expect({ error: "Internal server error" });
 
-    expect(errorSpy).toHaveBeenCalledWith("[api error]", expect.any(Error));
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ err: expect.any(Error) }),
+      "[api error]",
+    );
 
     await request(app)
       .get("/health")

--- a/server/errors.ts
+++ b/server/errors.ts
@@ -15,9 +15,8 @@ export const apiErrorHandler: ErrorRequestHandler = (err, req, res, next) => {
     return;
   }
 
-  // pino-http populates req.log with a per-request child logger when mounted;
-  // fall back to the base logger so unit tests that don't wire pino-http still work.
-  const log = (req as Request & { log?: typeof logger }).log ?? logger;
+  // Use the per-request child logger if available, otherwise fall back to the base logger.
+  const log = req.log ?? logger;
   log.error({ err, reqId: req.id }, "[api error]");
   res.status(500).json({ error: "Internal server error" });
 };
@@ -34,6 +33,7 @@ export function registerProcessErrorHandlers(): void {
 
   process.on("uncaughtException", (err) => {
     logger.fatal({ err }, "[uncaughtException]");
+    logger.flush?.();
     process.exit(1);
   });
 }

--- a/server/errors.ts
+++ b/server/errors.ts
@@ -1,4 +1,5 @@
 import type { ErrorRequestHandler, NextFunction, Request, RequestHandler, Response } from "express";
+import { logger } from "./logger";
 
 type AsyncRequestHandler = (req: Request, res: Response, next: NextFunction) => unknown | Promise<unknown>;
 
@@ -8,13 +9,16 @@ export function asyncHandler(handler: AsyncRequestHandler): RequestHandler {
   };
 }
 
-export const apiErrorHandler: ErrorRequestHandler = (err, _req, res, next) => {
+export const apiErrorHandler: ErrorRequestHandler = (err, req, res, next) => {
   if (res.headersSent) {
     next(err);
     return;
   }
 
-  console.error("[api error]", err);
+  // pino-http populates req.log with a per-request child logger when mounted;
+  // fall back to the base logger so unit tests that don't wire pino-http still work.
+  const log = (req as Request & { log?: typeof logger }).log ?? logger;
+  log.error({ err, reqId: req.id }, "[api error]");
   res.status(500).json({ error: "Internal server error" });
 };
 
@@ -25,11 +29,11 @@ export function registerProcessErrorHandlers(): void {
   processHandlersRegistered = true;
 
   process.on("unhandledRejection", (reason) => {
-    console.error("[unhandledRejection]", reason);
+    logger.error({ reason }, "[unhandledRejection]");
   });
 
   process.on("uncaughtException", (err) => {
-    console.error("[uncaughtException]", err);
+    logger.fatal({ err }, "[uncaughtException]");
     process.exit(1);
   });
 }

--- a/server/index.ts
+++ b/server/index.ts
@@ -16,9 +16,11 @@ import { randomUUID, timingSafeEqual } from "node:crypto";
 import { join, resolve } from "node:path";
 import { createInterface } from "node:readline";
 import { applyAgentSnapshot } from "./agentSnapshots";
+import { correlationMiddleware, httpRequestLogMiddleware } from "./correlation";
 import { createCorsConfig, isOriginAllowed } from "./cors";
 import { apiErrorHandler, registerProcessErrorHandlers } from "./errors";
 import { isValidLayoutId } from "./layouts";
+import { logger } from "./logger";
 import { parseLayoutMutationBody, parseOfficeLayoutDoc, parsePersistedPrefs, parseRecipe, parseSpriteBody, parseTagsBody, parseToggleBody, type OfficeLayoutDoc, type PersistedPrefs } from "./validation";
 import { ALL_TAGS, TAG_COLORS, DEFAULT_ROOMS, type AgentState, type AgentActivity, type SubAgentInfo, type TickerMessage, type Room, type AgentTag } from "../shared/types";
 const app = express();
@@ -49,6 +51,8 @@ app.use((_req, res, next) => {
 });
 
 app.use(express.json({ limit: "100kb" }));
+app.use(correlationMiddleware);
+app.use(httpRequestLogMiddleware);
 
 // Serve built frontend in production (Vite output is in dist/client, server is compiled to dist/server/index.js)
 const FRONTEND_DIR = resolve(__dirname, "..", "..", "client");
@@ -113,12 +117,12 @@ function loadPersistedPrefs(): Map<string, PersistedPrefs> {
       if (prefs) {
         map.set(k, prefs);
       } else {
-        console.warn(`[prefs] Skipping invalid persisted prefs for agent ${k}`);
+        logger.warn({ agentId: k, subsystem: "prefs" }, "skipping invalid persisted prefs");
       }
     }
     return map;
   } catch (err) {
-    console.warn("[prefs] Failed to load persisted prefs:", err);
+    logger.warn({ err, subsystem: "prefs" }, "failed to load persisted prefs");
     return new Map();
   }
 }
@@ -133,7 +137,7 @@ function savePersistedPrefs() {
     mkdirSync(DATA_DIR, { recursive: true });
     writeFileSync(PERSIST_PATH, JSON.stringify(prefs, null, 2));
   } catch (err) {
-    console.error("[persist] Failed to save prefs:", err);
+    logger.error({ err, subsystem: "persist" }, "failed to save prefs");
   }
 }
 
@@ -218,7 +222,7 @@ function pollSessions(): Promise<CliSessionsResult> {
 
     execFile(OPENCLAW_BIN, args, { timeout: 10000 }, (err, stdout, stderr) => {
       if (err) {
-        console.error("[poll] CLI error:", err.message);
+        logger.error({ err: err.message, subsystem: "poll" }, "cli error");
         resolve({ sessions: [], count: 0, sourceError: true });
         return;
       }
@@ -230,7 +234,7 @@ function pollSessions(): Promise<CliSessionsResult> {
           count: data.count || 0,
         });
       } catch (parseErr) {
-        console.error("[poll] JSON parse error:", parseErr);
+        logger.error({ err: parseErr, subsystem: "poll" }, "json parse error");
         resolve({ sessions: [], count: 0, sourceError: true });
       }
     });
@@ -586,13 +590,14 @@ let isPolling = false;
 async function pollAndBroadcast(): Promise<void> {
   if (isPolling) return;
   isPolling = true;
+  const cycleLog = logger.child({ cycleId: randomUUID(), subsystem: "poll" });
   try {
     const { sessions, sourceError } = await pollSessions();
     const agentMap = sourceError ? undefined : mapToAgentStates(sessions);
     const { applied, snapshot } = applyAgentSnapshot(agentStates, agentMap, { sourceError });
 
     if (!applied) {
-      console.warn("[poll] Keeping previous agent snapshot after source error");
+      cycleLog.warn("keeping previous agent snapshot after source error");
     } else {
       // Broadcast only when the visible agent snapshot actually changes.
       io.emit("agents:update", snapshot);
@@ -601,7 +606,7 @@ async function pollAndBroadcast(): Promise<void> {
     // Poll messages from transcripts
     await pollMessages();
   } catch (err) {
-    console.error("[poll] Poll cycle failed:", err);
+    cycleLog.error({ err }, "poll cycle failed");
   } finally {
     isPolling = false;
   }
@@ -694,7 +699,7 @@ app.post("/api/ingest/agents", (req, res) => {
   const { snapshot } = applyAgentSnapshot(agentStates, agentMap);
 
   lastIngestAt = Date.now();
-  console.log(`[ingest] ${snapshot.length} agents updated (${sessions.length} sessions)`);
+  logger.info({ sessionCount: sessions.length, agentCount: snapshot.length, subsystem: "ingest" }, "ingest applied");
   io.emit("agents:update", snapshot);
   res.json({ ok: true, agents: snapshot.length, received: sessions.length });
 });
@@ -886,9 +891,9 @@ function listLayouts(): OfficeLayoutDoc[] {
         const raw = readFileSync(join(LAYOUTS_DIR, file), "utf-8");
         const layout = parseOfficeLayoutDoc(JSON.parse(raw));
         if (layout) layouts.push(layout);
-        else console.warn(`[layout] Skipping invalid layout file ${file}`);
+        else logger.warn({ file, subsystem: "layout" }, "skipping invalid layout file");
       } catch (err) {
-        console.warn(`[layout] Skipping unreadable layout file ${file}:`, err);
+        logger.warn({ err, file, subsystem: "layout" }, "skipping unreadable layout file");
       }
     }
     return layouts.sort((a, b) => b.updatedAt - a.updatedAt);
@@ -903,11 +908,11 @@ function loadLayout(id: string): OfficeLayoutDoc | null {
   try {
     const raw = readFileSync(join(LAYOUTS_DIR, `${id}.json`), "utf-8");
     const layout = parseOfficeLayoutDoc(JSON.parse(raw));
-    if (!layout) console.warn(`[layout] Ignoring invalid layout file ${id}.json`);
+    if (!layout) logger.warn({ layoutId: id, subsystem: "layout" }, "ignoring invalid layout file");
     return layout;
   } catch (err) {
     if (!(typeof err === "object" && err !== null && "code" in err && err.code === "ENOENT")) {
-      console.warn(`[layout] Failed to load layout ${id}:`, err);
+      logger.warn({ err, layoutId: id, subsystem: "layout" }, "failed to load layout");
     }
     return null;
   }
@@ -1076,14 +1081,14 @@ app.get("/api/furniture-catalog", (_req, res) => {
 // ---- WebSocket ----
 
 io.on("connection", (socket) => {
-  console.log("[ws] Client connected:", socket.id);
+  logger.info({ socketId: socket.id, subsystem: "ws" }, "client connected");
 
   // Send current state on connect
   socket.emit("agents:update", Array.from(agentStates.values()));
   socket.emit("ticker:messages", tickerMessages);
 
   socket.on("disconnect", () => {
-    console.log("[ws] Client disconnected:", socket.id);
+    logger.info({ socketId: socket.id, subsystem: "ws" }, "client disconnected");
   });
 });
 
@@ -1119,7 +1124,7 @@ const GRACEFUL_SHUTDOWN_MS = 5000;
 async function shutdown(signal: string) {
   if (isShuttingDown) return;
   isShuttingDown = true;
-  console.log(`\n[server] Received ${signal}, shutting down gracefully...`);
+  logger.info({ signal, subsystem: "server" }, "received shutdown signal");
 
   // Clear periodic timers to prevent new work during shutdown
   clearInterval(ingestPruneTimer);
@@ -1129,25 +1134,27 @@ async function shutdown(signal: string) {
   const gracefulClose = new Promise<void>((resolve) => {
     // Close HTTP server (stops accepting new connections)
     server.close(() => {
-      console.log("[server] HTTP server closed");
+      logger.info({ subsystem: "server" }, "http server closed");
       resolve();
     });
 
     // Close Socket.IO connections
     io.close(() => {
-      console.log("[server] Socket.IO connections closed");
+      logger.info({ subsystem: "server" }, "socket.io connections closed");
     });
   });
 
   const hardTimeout = new Promise<void>((resolve) => {
     setTimeout(() => {
-      console.error("[server] Forced shutdown after timeout");
+      logger.error({ subsystem: "server" }, "forced shutdown after timeout");
       resolve();
     }, GRACEFUL_SHUTDOWN_MS);
   });
 
   await Promise.race([gracefulClose, hardTimeout]);
-  console.log("[server] Shutdown complete");
+  logger.info({ subsystem: "server" }, "shutdown complete");
+  // Flush buffered log lines before exit so structured output isn't dropped.
+  logger.flush?.();
   process.exit(0);
 }
 
@@ -1157,15 +1164,24 @@ function startServer(): void {
   process.on("SIGINT", () => shutdown("SIGINT"));
 
   server.listen(PORT, () => {
-    console.log(`🖥️  OpenClaw Pixel Agents server running on port ${PORT}`);
-    console.log(`📊 Data source: ${DATA_SOURCE} (effective: ${useCli && !ingestExplicit ? "cli-poll" : "ingest-only"})`);
+    logger.info({
+      port: PORT,
+      dataSource: DATA_SOURCE,
+      effective: useCli && !ingestExplicit ? "cli-poll" : "ingest-only",
+      subsystem: "server",
+    }, "🖥️  OpenClaw Pixel Agents server running");
 
     if (useCli && !ingestExplicit) {
-      console.log(`📡 Polling via: ${OPENCLAW_BIN} sessions --all-agents --json --active ${ACTIVE_THRESHOLD_MIN}`);
+      logger.info({
+        bin: OPENCLAW_BIN,
+        activeThresholdMin: ACTIVE_THRESHOLD_MIN,
+        pollIntervalMs: POLL_INTERVAL,
+        subsystem: "server",
+      }, "📡 Polling via CLI");
       pollAndBroadcast();
       pollTimer = setInterval(pollAndBroadcast, POLL_INTERVAL);
     } else {
-      console.log("📡 Awaiting ingest data from collector (no local CLI polling)");
+      logger.info({ subsystem: "server" }, "📡 Awaiting ingest data from collector (no local CLI polling)");
     }
   });
 }

--- a/server/index.ts
+++ b/server/index.ts
@@ -50,9 +50,9 @@ app.use((_req, res, next) => {
   next();
 });
 
-app.use(express.json({ limit: "100kb" }));
 app.use(correlationMiddleware);
 app.use(httpRequestLogMiddleware);
+app.use(express.json({ limit: "100kb" }));
 
 // Serve built frontend in production (Vite output is in dist/client, server is compiled to dist/server/index.js)
 const FRONTEND_DIR = resolve(__dirname, "..", "..", "client");
@@ -222,7 +222,7 @@ function pollSessions(): Promise<CliSessionsResult> {
 
     execFile(OPENCLAW_BIN, args, { timeout: 10000 }, (err, stdout, stderr) => {
       if (err) {
-        logger.error({ err: err.message, subsystem: "poll" }, "cli error");
+        logger.error({ err, subsystem: "poll" }, "cli error");
         resolve({ sessions: [], count: 0, sourceError: true });
         return;
       }
@@ -1131,11 +1131,11 @@ async function shutdown(signal: string) {
   if (pollTimer) clearInterval(pollTimer);
 
   // Race: graceful close vs. hard timeout
-  const gracefulClose = new Promise<void>((resolve) => {
+  const gracefulClose = new Promise<false>((resolve) => {
     // Close HTTP server (stops accepting new connections)
     server.close(() => {
       logger.info({ subsystem: "server" }, "http server closed");
-      resolve();
+      resolve(false);
     });
 
     // Close Socket.IO connections
@@ -1144,14 +1144,20 @@ async function shutdown(signal: string) {
     });
   });
 
-  const hardTimeout = new Promise<void>((resolve) => {
+  const hardTimeout = new Promise<true>((resolve) => {
     setTimeout(() => {
       logger.error({ subsystem: "server" }, "forced shutdown after timeout");
-      resolve();
+      resolve(true);
     }, GRACEFUL_SHUTDOWN_MS);
   });
 
-  await Promise.race([gracefulClose, hardTimeout]);
+  const timedOut = await Promise.race([gracefulClose, hardTimeout]);
+  if (timedOut) {
+    logger.error({ subsystem: "server" }, "shutdown complete (forced)");
+    logger.flush?.();
+    process.exit(1);
+  }
+
   logger.info({ subsystem: "server" }, "shutdown complete");
   // Flush buffered log lines before exit so structured output isn't dropped.
   logger.flush?.();

--- a/server/logger.test.ts
+++ b/server/logger.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("logger", () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    delete process.env.LOG_LEVEL;
+    delete process.env.NODE_ENV;
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+    vi.resetModules();
+  });
+
+  it("exports a pino logger instance with the expected interface", async () => {
+    const { logger } = await import("./logger");
+    expect(typeof logger.info).toBe("function");
+    expect(typeof logger.warn).toBe("function");
+    expect(typeof logger.error).toBe("function");
+    expect(typeof logger.child).toBe("function");
+    expect(typeof logger.flush).toBe("function");
+  });
+
+  it("uses info level in production by default", async () => {
+    process.env.NODE_ENV = "production";
+    const { logger } = await import("./logger");
+    expect(logger.level).toBe("info");
+  });
+
+  it("uses debug level outside production by default", async () => {
+    delete process.env.NODE_ENV;
+    const { logger } = await import("./logger");
+    expect(logger.level).toBe("debug");
+  });
+
+  it("honors explicit LOG_LEVEL override", async () => {
+    process.env.LOG_LEVEL = "warn";
+    process.env.NODE_ENV = "production";
+    const { logger } = await import("./logger");
+    expect(logger.level).toBe("warn");
+  });
+
+  it("redacts authorization headers via the redact option", async () => {
+    // Sanity check that the redact config is wired up at construction time
+    // by exercising the child logger API used by per-subsystem logging.
+    const { logger } = await import("./logger");
+    const child = logger.child({ subsystem: "auth" });
+    expect(typeof child.info).toBe("function");
+  });
+});

--- a/server/logger.test.ts
+++ b/server/logger.test.ts
@@ -41,9 +41,7 @@ describe("logger", () => {
     expect(logger.level).toBe("warn");
   });
 
-  it("redacts authorization headers via the redact option", async () => {
-    // Sanity check that the redact config is wired up at construction time
-    // by exercising the child logger API used by per-subsystem logging.
+  it("supports child loggers used by structured subsystem logging", async () => {
     const { logger } = await import("./logger");
     const child = logger.child({ subsystem: "auth" });
     expect(typeof child.info).toBe("function");

--- a/server/logger.ts
+++ b/server/logger.ts
@@ -1,0 +1,35 @@
+import { pino, type Logger, type LoggerOptions } from "pino";
+
+/**
+ * Build a default log level based on NODE_ENV:
+ *   production → info, otherwise → debug.
+ * Always overridable via LOG_LEVEL.
+ */
+function defaultLevel(): string {
+  const explicit = process.env.LOG_LEVEL;
+  if (explicit && explicit.trim()) return explicit.trim();
+  return process.env.NODE_ENV === "production" ? "info" : "debug";
+}
+
+function buildOptions(): LoggerOptions {
+  return {
+    level: defaultLevel(),
+    redact: {
+      paths: [
+        "req.headers.authorization",
+        "req.headers.cookie",
+        "res.headers['set-cookie']",
+      ],
+      remove: true,
+    },
+    base: {
+      service: "openclaw-pixel-agents",
+      pid: process.pid,
+    },
+    timestamp: pino.stdTimeFunctions.isoTime,
+  };
+}
+
+export const logger: Logger = pino(buildOptions());
+
+export type { Logger };

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,1 +1,5 @@
 import '@testing-library/jest-dom/vitest';
+
+// Silence pino logs during vitest runs so structured output does not flood CI.
+// Server tests still verify logger behaviour via spies on the singleton logger.
+process.env.LOG_LEVEL = process.env.LOG_LEVEL ?? 'silent';


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
## Summary

This pull request replaces ad-hoc `console.*` diagnostics in the server with structured JSON logging via pino, and introduces request correlation IDs so a single user-reported event can be traced back through server logs.

## Why

The server had no log levels, no structured fields, and no per-request correlation. A transient CLI failure and the WebSocket disconnect it preceded could not be linked, and the frontend store hooks shared the same gap. Operators had to grep interleaved human prose, which made incidents slow to diagnose.

## What's new

### `server/logger.ts`
A pino singleton with:
- **Level resolution** — `LOG_LEVEL` env override wins; otherwise `info` in production, `debug` elsewhere.
- **Redaction** — strips `req.headers.authorization`, `req.headers.cookie`, and `res.headers['set-cookie']` (`remove: true`) so secrets never land in log files.
- **Base fields** — `service: "openclaw-pixel-agents"` and `pid` on every record, plus ISO timestamps.

### `server/correlation.ts`
- `pickRequestId(headers)` — extracts `X-Request-Id`, validates against `/^[a-zA-Z0-9_.\-]{1,128}$/` to defeat log-injection, and falls back to a fresh UUID when the header is absent, malformed, or an array. Accepts the first element of array-valued headers safely.
- `correlationMiddleware` — assigns `req.id`, echoes it on the response as `X-Request-Id`.
- `httpRequestLogMiddleware` — emits one structured line per response with `reqId`, `method`, `url`, `status`, and `durationMs`; level follows status class (`error` ≥ 500, `warn` ≥ 400, `info` otherwise).
- A code comment documents why `pino-http` was rejected: its `http.IncomingMessage` augmentation breaks Express 4 + `@types/express 5` overload resolution, so this ~25 LOC middleware preserves the same contract.

### `server/errors.ts`
- `apiErrorHandler` now logs through `req.log` when wired and falls back to the base `logger` so unit tests stay tight. The error is attached as `err` (the pino standard) and the request id is included.
- `unhandledRejection` logs `{ reason }`; `uncaughtException` logs `{ err }` at `fatal`.

### `server/index.ts`
23 `console.*` call sites converted to structured pino records, each carrying:
- `subsystem` — one of `prefs`, `persist`, `poll`, `ingest`, `layout`, `ws`, `server`, identifying the area of the system.
- Entity fields where applicable — `agentId`, `layoutId`, `socketId`, `signal`, `file`, `sessionCount`, `agentCount`, `bin`, `port`, `pollIntervalMs`, etc.

The poll loop uses a per-cycle child logger with `cycleId = randomUUID()`, which makes a single polling cycle's events easy to filter. The shutdown handler calls `logger.flush?.()` before `process.exit(0)` so buffered structured lines aren't dropped on shutdown.

### `src/test/setup.ts`
Sets `LOG_LEVEL=silent` (when not already set) so structured output doesn't flood CI while server tests still verify behavior via spies on the singleton.

## Test coverage

- **`server/logger.test.ts` (5 tests)** — pino interface, level resolution (production / dev / explicit override), and child logger shape.
- **`server/correlation.test.ts` (5 tests)** — safe-header acceptance, UUID fallback when no header is provided, header-injection rejection (`<script>alert(1)</script>` falls back to UUID), 200-char header length cap, and array-valued header inspection.
- **`server/errors.test.ts` (migrated)** — the spy now targets `logger.error` and asserts the structured call shape `({ err: expect.any(Error) }, "[api error]")`.

Full gate is green: `npm run build` ✓, `npm test` 49/49 ✓, `npm run test:coverage` ✓, `npm run typecheck` ✓.

## Behavioral impact

- **Log output changes shape.** Interleaved human prose on stdout becomes structured JSON lines. Operators who grep for `[poll]` / `[ws]` bracket prefixes should migrate to the `subsystem` field. The shape change is documented in code comments and this PR body.
- **Redact list is conservative.** Only auth + cookie headers are stripped today. If new auth headers appear later, they must be added to `redact.paths` explicitly.
- **Out of scope:** frontend `console.*` sites (18 in `src/`) on a different stack — deferred; Socket.IO emit-payload correlation — `socket.id` already provides per-connection correlation in WS lifecycle logs; log sampling / OpenTelemetry / file transports — deferred.

Closes #49.

---

## Summary

This PR improves the server's structured logging and request correlation so that logs can be reliably traced back to individual HTTP requests, even when the client (or intermediate proxy) doesn't supply one.

## Changes

### Request correlation middleware (`server/correlation.ts`)
- Header lookups now use the lowercased header name, matching how Express normalizes incoming headers.
- Adds a `req.log` property typed as a child `Logger`, populated alongside the existing `req.id` so downstream handlers can log with per-request context without re-deriving it.
- The HTTP request log middleware now listens on `res.once("close", ...)` instead of `res.on("finish", ...)` and detects aborted (non-`writableFinished`) responses, logging them at `warn` as `"request aborted"` so client disconnects are no longer silently dropped.

### Error handler and process handlers (`server/errors.ts`)
- Cleans up the `req.log` lookup to use the now-typed field directly, and calls `logger.flush?.()` on `uncaughtException` so fatal logs aren't lost during process exit.

### App wiring (`server/index.ts`)
- Mounts `correlationMiddleware` and `httpRequestLogMiddleware` **before** `express.json`, so JSON parse failures can still be correlated back to the originating `X-Request-Id`.
- The shutdown sequence now distinguishes between a graceful close and the hard-timeout path: on forced shutdown it logs a `"shutdown complete (forced)"` message, flushes the logger, and exits with code `1`. A minor drive-by fixes logging the CLI poll error to pass the full `err` object instead of just `err.message`, preserving stack/context.

### Tests
- `server/correlation.test.ts`: adds two cases — one verifying `req.log` is exposed on requests, and one proving that a JSON parse error in `express.json` still receives the correlated `req.id` and `req.log` because the correlation middleware runs first.
- `server/logger.test.ts`: retitles and tightens the child-logger test to focus on the structured subsystem logging surface rather than redact specifics (no behavioral change to the logger itself).
<!-- kody-pr-summary:end -->