### PR TITLE
fix: eliminate useLayoutStore race condition via useReducer

### DIFF
--- a/src/hooks/useLayoutStore.test.tsx
+++ b/src/hooks/useLayoutStore.test.tsx
@@ -1,0 +1,231 @@
+import { act, render } from '@testing-library/react';
+import { useEffect } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useLayoutStore } from './useLayoutStore';
+import type { LayoutDoc } from './useLayoutStore';
+
+type LayoutStoreSnapshot = ReturnType<typeof useLayoutStore>;
+
+/** Standard mock layout used across tests. */
+const MOCK_LAYOUT: LayoutDoc = {
+  id: 'default',
+  name: 'Default',
+  width: 24,
+  height: 16,
+  furniture: [],
+  seats: {},
+  updatedAt: 1000,
+};
+
+/** A different layout to simulate switching. */
+const OTHER_LAYOUT: LayoutDoc = {
+  id: 'other',
+  name: 'Other',
+  width: 24,
+  height: 16,
+  furniture: [],
+  seats: {},
+  updatedAt: 2000,
+};
+
+function StoreProbe({ onSnapshot }: { onSnapshot: (snapshot: LayoutStoreSnapshot) => void }) {
+  const store = useLayoutStore();
+
+  useEffect(() => {
+    onSnapshot(store);
+  }, [onSnapshot, store]);
+
+  return null;
+}
+
+function latest<T>(items: T[]): T {
+  const item = items[items.length - 1];
+  if (!item) throw new Error('Expected at least one item');
+  return item;
+}
+
+/** Create a fetch mock that responds to the layout API routes. */
+function makeFetchMock(
+  layouts: Record<string, LayoutDoc> = { default: MOCK_LAYOUT },
+  captures: { lastPutBody?: LayoutDoc & { baseUpdatedAt?: number } } = {},
+) {
+  return vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+    const url = typeof input === 'string' ? input : input.toString();
+
+    // GET /api/layouts — list all layouts
+    if (url.endsWith('/api/layouts') && (!init || init.method === undefined || init.method === 'GET')) {
+      return new Response(JSON.stringify({ layouts: Object.values(layouts) }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    // POST /api/layouts — create new layout
+    if (url.endsWith('/api/layouts') && init?.method === 'POST') {
+      const body = JSON.parse(init.body as string);
+      const newLayout: LayoutDoc = {
+        id: body.name.toLowerCase().replace(/\s+/g, '-'),
+        name: body.name,
+        width: body.width ?? 24,
+        height: body.height ?? 16,
+        furniture: [],
+        seats: {},
+        updatedAt: Date.now(),
+      };
+      layouts[newLayout.id] = newLayout;
+      return new Response(JSON.stringify({ layout: newLayout }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    // PUT /api/layouts/:id — save layout
+    const putMatch = url.match(/\/api\/layouts\/(.+)$/);
+    if (putMatch && init?.method === 'PUT') {
+      const body = JSON.parse(init.body as string) as LayoutDoc;
+      captures.lastPutBody = body;
+      layouts[body.id] = body;
+      return new Response(JSON.stringify({ layout: body }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    // GET /api/layouts/:id — load specific layout
+    const getMatch = url.match(/\/api\/layouts\/([^/?]+)$/);
+    if (getMatch) {
+      const id = getMatch[1];
+      const layout = layouts[id];
+      if (layout) {
+        return new Response(JSON.stringify(layout), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      return new Response(JSON.stringify({ error: 'Not found' }), { status: 404 });
+    }
+
+    // GET /api/furniture-catalog
+    if (url.endsWith('/api/furniture-catalog')) {
+      return new Response(JSON.stringify({ types: ['desk'] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    return new Response(JSON.stringify({ error: 'Not found' }), { status: 404 });
+  });
+}
+
+describe('useLayoutStore', () => {
+  let layouts: Record<string, LayoutDoc>;
+  let captures: { lastPutBody?: LayoutDoc & { baseUpdatedAt?: number } };
+  let snapshots: LayoutStoreSnapshot[];
+  let unmount: () => void;
+
+  beforeEach(() => {
+    layouts = { default: { ...MOCK_LAYOUT }, other: { ...OTHER_LAYOUT } };
+    captures = {};
+    vi.stubGlobal('fetch', makeFetchMock(layouts, captures));
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    snapshots = [];
+  });
+
+  async function renderStoreProbe() {
+    snapshots = [];
+    const view = render(<StoreProbe onSnapshot={(snapshot) => snapshots.push(snapshot)} />);
+    unmount = view.unmount;
+    // Flush microtasks for initial fetchLayouts + loadLayoutById('default')
+    await act(async () => { await vi.waitFor(() => expect(snapshots.length).toBeGreaterThan(0)); });
+    return view;
+  }
+
+  it('loads the default layout on mount', async () => {
+    await renderStoreProbe();
+    expect(latest(snapshots).activeLayout?.id).toBe('default');
+  });
+
+  it('saveActiveLayout uses the most-recent active layout, not a stale closure', async () => {
+    await renderStoreProbe();
+
+    // The initial layout has updatedAt=1000
+    expect(latest(snapshots).activeLayout?.updatedAt).toBe(1000);
+
+    // Switch to the "other" layout (updatedAt=2000)
+    await act(async () => {
+      await latest(snapshots).loadLayoutById('other');
+    });
+    expect(latest(snapshots).activeLayout?.id).toBe('other');
+    expect(latest(snapshots).activeLayout?.updatedAt).toBe(2000);
+
+    // Save — should PUT with the "other" layout's updatedAt (2000),
+    // not the stale "default" layout's updatedAt (1000).
+    await act(async () => {
+      await latest(snapshots).saveActiveLayout();
+    });
+
+    expect(captures.lastPutBody).toBeDefined();
+    expect(captures.lastPutBody!.id).toBe('other');
+    // baseUpdatedAt should be the "other" layout's updatedAt (2000),
+    // proving saveActiveLayout read the latest state, not a stale one.
+    expect(captures.lastPutBody!.baseUpdatedAt).toBe(2000);
+  });
+
+  it('saveActiveLayout is a no-op when no layout is active', async () => {
+    await renderStoreProbe();
+
+    // Force-clear the active layout
+    await act(async () => {
+      // Switch to a non-existent layout to trigger a load error;
+      // the active layout stays as whatever was last loaded.
+      // Instead, test via deleteLayout on the active layout.
+      await latest(snapshots).deleteLayout('default');
+    });
+
+    // After deleting the active layout, it should be null
+    expect(latest(snapshots).activeLayout).toBeNull();
+
+    // Saving should be a no-op — no PUT should be made for this call
+    const fetchCallsBefore = (fetch as ReturnType<typeof vi.fn>).mock.calls.length;
+    await act(async () => {
+      await latest(snapshots).saveActiveLayout();
+    });
+    // Allow the save promise chain to settle
+    await act(async () => { await new Promise(r => setTimeout(r, 0)); });
+
+    // No PUT request should have been made in the saveActiveLayout call
+    const putCalls = (fetch as ReturnType<typeof vi.fn>).mock.calls.filter(
+      (call: unknown[]) => {
+        const init = call[1] as RequestInit | undefined;
+        return init?.method === 'PUT';
+      }
+    );
+    // The only PUTs should be from before the deleteLayout, if any
+    expect(putCalls.length).toBe(0);
+  });
+
+  it('updateFurniture applies functional updater to current layout', async () => {
+    await renderStoreProbe();
+
+    const furniture = [
+      { id: 'f1', type: 'desk', x: 5, y: 5, rotation: 0 },
+    ];
+
+    await act(async () => {
+      latest(snapshots).updateFurniture(furniture);
+    });
+
+    expect(latest(snapshots).activeLayout?.furniture).toEqual(furniture);
+
+    // Functional updater form — delete by id
+    await act(async () => {
+      latest(snapshots).updateFurniture(prev => prev.filter(f => f.id !== 'f1'));
+    });
+
+    expect(latest(snapshots).activeLayout?.furniture).toEqual([]);
+  });
+});

--- a/src/hooks/useLayoutStore.test.tsx
+++ b/src/hooks/useLayoutStore.test.tsx
@@ -149,7 +149,7 @@ describe('useLayoutStore', () => {
     expect(latest(snapshots).activeLayout?.id).toBe('default');
   });
 
-  it('saveActiveLayout uses the most-recent active layout, not a stale closure', async () => {
+  it('saveActiveLayout always reads the latest active layout (invariant test)', async () => {
     await renderStoreProbe();
 
     // The initial layout has updatedAt=1000
@@ -162,16 +162,19 @@ describe('useLayoutStore', () => {
     expect(latest(snapshots).activeLayout?.id).toBe('other');
     expect(latest(snapshots).activeLayout?.updatedAt).toBe(2000);
 
-    // Save — should PUT with the "other" layout's updatedAt (2000),
-    // not the stale "default" layout's updatedAt (1000).
+    // Save — the PUT body's baseUpdatedAt should be 2000 (the "other"
+    // layout's updatedAt), proving saveActiveLayout read the latest
+    // committed state at the moment its async chain ran.
+    //
+    // This is an INVARIANT test for the new useReducer architecture: if
+    // a future refactor introduces a path that bypasses the reducer
+    // (and thus desyncs the ref), this test will catch the regression.
     await act(async () => {
       await latest(snapshots).saveActiveLayout();
     });
 
     expect(captures.lastPutBody).toBeDefined();
     expect(captures.lastPutBody!.id).toBe('other');
-    // baseUpdatedAt should be the "other" layout's updatedAt (2000),
-    // proving saveActiveLayout read the latest state, not a stale one.
     expect(captures.lastPutBody!.baseUpdatedAt).toBe(2000);
   });
 

--- a/src/hooks/useLayoutStore.ts
+++ b/src/hooks/useLayoutStore.ts
@@ -25,8 +25,15 @@ export function useLayoutStore() {
   const activeLayoutRef = useRef<LayoutDoc | null>(null);
 
   // useReducer replaces the dual useState+useRef pattern. The reducer
-  // ALWAYS syncs the ref, making desync architecturally impossible.
+  // ALWAYS syncs the ref, making desync architecturally impossible —
   // dispatch is the single entry point for all active-layout mutations.
+  //
+  // Note: the ref-write inside the reducer is technically impure (React
+  // invokes reducers twice in Strict Mode), but it is idempotent —
+  // writing the same value twice is harmless. This trade-off is preferred
+  // over a useEffect sync because the ref is read synchronously inside
+  // saveActiveLayout's async callback chain, which would otherwise have a
+  // one-render stale window.
   const [activeLayout, setActiveLayout] = useReducer(
     function reducer(state: LayoutDoc | null, action: LayoutAction): LayoutDoc | null {
       const next = typeof action === 'function' ? action(state) : action;

--- a/src/hooks/useLayoutStore.ts
+++ b/src/hooks/useLayoutStore.ts
@@ -1,5 +1,5 @@
-import { useState, useEffect, useCallback, useRef } from 'react';
-import type { PlacedFurniture, OfficeLayout } from '../../shared/types';
+import { useState, useEffect, useCallback, useReducer, useRef } from 'react';
+import type { PlacedFurniture } from '../../shared/types';
 
 const API_BASE = '/api';
 
@@ -13,22 +13,31 @@ export interface LayoutDoc {
   updatedAt: number;
 }
 
+/**
+ * Dispatched action: a new layout value, or a functional updater.
+ * Every mutation flows through the reducer, which guarantees the ref
+ * stays in sync — there is no separate raw setter that could bypass it.
+ */
+type LayoutAction = LayoutDoc | null | ((prev: LayoutDoc | null) => LayoutDoc | null);
+
 export function useLayoutStore() {
   const [layouts, setLayouts] = useState<LayoutDoc[]>([]);
-  const [activeLayoutState, _setActiveLayout] = useState<LayoutDoc | null>(null);
   const activeLayoutRef = useRef<LayoutDoc | null>(null);
-  const [catalog, setCatalog] = useState<string[]>([]);
-  const savePromiseRef = useRef<Promise<void>>(Promise.resolve());
 
-  const setActiveLayout = useCallback((layout: LayoutDoc | null | ((prev: LayoutDoc | null) => LayoutDoc | null)) => {
-    _setActiveLayout(prev => {
-      const next = typeof layout === 'function' ? layout(prev) : layout;
+  // useReducer replaces the dual useState+useRef pattern. The reducer
+  // ALWAYS syncs the ref, making desync architecturally impossible.
+  // dispatch is the single entry point for all active-layout mutations.
+  const [activeLayout, setActiveLayout] = useReducer(
+    function reducer(state: LayoutDoc | null, action: LayoutAction): LayoutDoc | null {
+      const next = typeof action === 'function' ? action(state) : action;
       activeLayoutRef.current = next;
       return next;
-    });
-  }, []);
+    },
+    null,
+  );
 
-  const activeLayout = activeLayoutState;
+  const [catalog, setCatalog] = useState<string[]>([]);
+  const savePromiseRef = useRef<Promise<void>>(Promise.resolve());
 
   const fetchLayouts = useCallback(async () => {
     try {
@@ -54,6 +63,10 @@ export function useLayoutStore() {
 
   const saveActiveLayout = useCallback(async (updates?: Partial<LayoutDoc>) => {
     savePromiseRef.current = savePromiseRef.current.then(async () => {
+      // Read from the ref — it's always synced by the reducer, so this
+      // always reflects the latest committed state. This replaces the
+      // old dual-setter pattern where a raw useState setter could bypass
+      // the ref sync.
       const currentLayout = activeLayoutRef.current;
       if (!currentLayout) return;
 


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
## Summary

This pull request refactors the state management in `useLayoutStore` to eliminate a race condition where the active layout could become desynchronized between React state and a `useRef`. The fix replaces the dual `useState` + `useRef` pattern (which depended on a naming convention `_setActiveLayout` to prevent bypassing ref sync) with `useReducer`, making the ref sync architecturally guaranteed rather than relying on convention.

## Changes

### `src/hooks/useLayoutStore.ts`
- **Added `useReducer` import** and removed the `OfficeLayout` type import (which was unused).
- **Introduced `LayoutAction` type** — supports both direct value updates (`LayoutDoc | null`) and functional updaters (`(prev) => LayoutDoc | null`).
- **Replaced `useState` + wrapped setter** for the active layout:
  - Old: `useState<LayoutDoc | null>` with a `useCallback` wrapper that called the raw `_setActiveLayout` and manually synced the ref.
  - New: `useReducer` whose reducer body **unconditionally** syncs `activeLayoutRef.current = next` on every dispatch. The dispatched function is aliased as `setActiveLayout`, which is now the only way to mutate the active layout.
- **Removed dead aliasing**: the `const activeLayout = activeLayoutState` indirection is gone since the reducer's state name is already `activeLayout`.
- **Added explanatory comment on `saveActiveLayout`** clarifying why it reads from the ref (synchronous access inside async callback chains; functional setState updaters are deferred to the next render).

### `src/hooks/useLayoutStore.test.tsx` (new file)
Four tests verifying the new reducer-based behavior:

1. **`loads the default layout on mount`** — Smoke test that the initial fetch/load flow populates `activeLayout` with the default layout.
2. **`saveActiveLayout uses the most-recent active layout, not a stale closure`** — The regression test for the bug: loads the default layout (updatedAt=1000), switches to another layout (updatedAt=2000), calls `saveActiveLayout()`, and asserts the PUT body's `baseUpdatedAt` is 2000 — proving the ref holds the latest value and save doesn't read stale state.
3. **`saveActiveLayout is a no-op when no layout is active`** — Deletes the active layout, then calls `saveActiveLayout()` and verifies no PUT request is issued.
4. **`updateFurniture applies functional updater to current layout`** — Confirms both value-form and function-form dispatches through the reducer work correctly (adds furniture by value, removes by functional filter).

## Technical Notes

- **Why the ref is preserved**: `saveActiveLayout` reads the current layout inside an async `.then()` chain (`savePromiseRef.current.then(...)`). React's functional `setState(prev => prev)` updaters are deferred to the next render, so they cannot provide synchronous mid-callback access to current state. The ref remains the correct mechanism for this access pattern — the fix ensures it can never desync by routing all mutations through the reducer.
- **Why a reducer rather than other approaches**: The reducer centralizes the ref-sync invariant in one place. Any future contributor who adds a new mutation only needs to call `setActiveLayout(...)` — there is no separate raw setter to forget to wire up.
<!-- kody-pr-summary:end -->