### PR TITLE
infra: multi-stage Dockerfile, .dockerignore, npm ci

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -25,6 +25,9 @@ docs/
 test-results/
 public/test-*.html
 
+# Coverage reports (not in builder context, would just bloat layers)
+coverage/
+
 # Runtime data (mounted as a volume in production)
 data/
 
@@ -35,6 +38,7 @@ data/
 .worktrees/
 .understand-anything/
 .ua/
+.cortexkit/
 .tmp-pr*/
 
 # Docker metadata

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,42 @@
+# Version control
+.git
+.gitignore
+
+# Dependencies (fetched fresh inside the builder)
+node_modules
+
+# Build output (produced inside the builder)
+dist
+
+# Environment files
+.env*
+
+# Logs
+*.log
+
+# Documentation — not needed at runtime
+AGENTS.md
+AUDIT.md
+CONTRIBUTING.md
+README.md
+docs/
+
+# Test artifacts
+test-results/
+public/test-*.html
+
+# Runtime data (mounted as a volume in production)
+data/
+
+# Agent / IDE workspace state
+.vscode/
+.idea/
+.codegraph/
+.worktrees/
+.understand-anything/
+.ua/
+.tmp-pr*/
+
+# Docker metadata
+Dockerfile
+.dockerignore

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ npm run dev        # Start dev (Vite on :3000 + backend on :3001, via concurrent
 npm run dev:client # Vite only (port 3000, proxies /api → :3001)
 npm run dev:server # Backend only (tsx watch on :3001)
 npm run build      # Vite build + tsc -p tsconfig.server.json → dist/
-npm run start      # Run production build (node dist/server/index.js)
+npm run start      # Run production build (node dist/server/server/index.js)
 npm run typecheck  # tsc --noEmit
 ```
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,27 +1,31 @@
-FROM node:20-slim
+# syntax=docker/dockerfile:1.7
 
+# ---- Builder stage -----------------------------------------------------------
+# Full dev deps + source, produces the compiled output in /app/dist.
+FROM node:20-alpine AS builder
 WORKDIR /app
-
 COPY package.json package-lock.json ./
-RUN npm install && npm cache clean --force
-
+RUN npm ci
 COPY . .
-
 RUN npm run build
 
-RUN rm -rf node_modules && npm install --omit=dev && npm cache clean --force
+# ---- Runtime stage -----------------------------------------------------------
+# Production deps only + compiled dist. No source, no dev deps, no .git.
+FROM node:20-alpine
+WORKDIR /app
+ENV NODE_ENV=production
 
-# Run as non-root user
-RUN groupadd -r appuser && useradd -r -g appuser -d /app -s /sbin/nologin appuser
+COPY package.json package-lock.json ./
+RUN npm ci --omit=dev && npm cache clean --force
 
-ENV PORT=3400
-ENV DATA_SOURCE=ingest
-ENV DATA_DIR=/app/data
-EXPOSE 3400
+COPY --from=builder /app/dist ./dist
 
-# Create data dir owned by appuser
-RUN mkdir -p /app/data && chown -R appuser:appuser /app/data /app
+# Non-root user
+RUN addgroup -S appuser && adduser -S -G appuser -d /app -s /sbin/nologin appuser \
+    && mkdir -p /app/data && chown -R appuser:appuser /app
 
 USER appuser
+ENV PORT=3001 DATA_SOURCE=ingest DATA_DIR=/app/data
+EXPOSE 3001
 
-CMD ["node", "dist/server/index.js"]
+CMD ["node", "dist/server/server/index.js"]

--- a/package.json
+++ b/package.json
@@ -12,8 +12,7 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:coverage": "vitest run --coverage",
-    "audit:runtime": "npm audit --omit=dev --audit-level=moderate"
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
     "express": "^4.21.0",

--- a/package.json
+++ b/package.json
@@ -8,11 +8,12 @@
     "dev:client": "vite",
     "dev:server": "npx tsx watch server/index.ts",
     "build": "vite build && tsc -p tsconfig.server.json",
-    "start": "NODE_ENV=production node dist/server/index.js",
+    "start": "NODE_ENV=production node dist/server/server/index.js",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "audit:runtime": "npm audit --omit=dev --audit-level=moderate"
   },
   "dependencies": {
     "express": "^4.21.0",


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
## Summary

Restructures the project's Docker setup into a clean multi-stage build and fixes a server entrypoint bug introduced by TypeScript's compilation output structure.

## Changes

### `Dockerfile` — Rewritten as multi-stage

- **Builder stage** (`node:20-alpine AS builder`): installs dev dependencies via `npm ci`, copies source, and runs `npm run build` to produce `dist/`.
- **Runtime stage** (`node:20-alpine`): starts from a fresh base, installs only production deps via `npm ci --omit=dev`, and copies **only** `dist/` from the builder — no source, no `.git`, no dev dependencies.
- **Non-root user**: runtime runs as `appuser` (Alpine-compatible `addgroup`/`adduser` instead of the previous `groupadd`/`useradd`).
- **Port/ENV defaults**: `PORT=3001`, `DATA_SOURCE=ingest`, `DATA_DIR=/app/data`, exposing `3001`.
- **CMD path fix**: previously pointed at `dist/server/index.js`, now correctly points at `dist/server/server/index.js` (see bug fix below).

### `.dockerignore` — New

Excludes non-runtime files from the Docker build context, keeping images lean and avoiding accidental inclusion of secrets or local state:

- VCS: `.git`, `.gitignore`
- Rebuild artifacts: `node_modules`, `dist`
- Environment: `.env*`
- Logs: `*.log`
- Documentation: `AGENTS.md`, `AUDIT.md`, `CONTRIBUTING.md`, `README.md`, `docs/`
- Test artifacts: `test-results/`, `public/test-*.html`
- Runtime data: `data/` (mounted as a volume in production)
- Workspace/IDE state: `.vscode/`, `.idea/`, `.codegraph/`, `.worktrees/`, `.understand-anything/`, `.ua/`, `.tmp-pr*/`
- Docker metadata: `Dockerfile`, `.dockerignore`

## Bug Fixes

### Server entrypoint path

Both `CMD` in the Dockerfile and the `start` script in `package.json` referenced `dist/server/index.js`, but the TypeScript compiler actually emits to `dist/server/server/index.js` (because the project root `tsconfig.json`'s `outDir` interacts with the `server/` source root, preserving an extra `server/` segment). Running the container with the old path would fail with `MODULE_NOT_FOUND`.

## Key improvements over the previous Dockerfile

| Aspect | Before | After |
|--------|--------|-------|
| Base image | `node:20-slim` | `node:20-alpine` (smaller) |
| Install command | `npm install` | `npm ci` (reproducible, respects lockfile) |
| Source in runtime | Yes | No — only `dist/` copied from builder |
| Dev deps in runtime | Yes (deleted & reinstalled) | Never installed |
| `.git` in runtime | Yes | No |
| User creation | `groupadd`/`useradd` (Debian-style) | `addgroup`/`adduser` (Alpine-compatible) |
| Server entrypoint | `dist/server/index.js` ❌ | `dist/server/server/index.js` ✅ |

Closes #52.

---

## Summary

This PR updates the `.dockerignore` file to refine which files are excluded from Docker build contexts.

**Changes:**

- Added `coverage/` directory to the coverage/exclusion patterns section to prevent coverage reports from bloating Docker layers
- Added `.cortexkit/` to the development tooling exclusion patterns alongside other dev environment directories
<!-- kody-pr-summary:end -->