### PR TITLE
docs: fix stale :5173 port references to :3000

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ npm install
 npm run dev
 ```
 
-The dev server runs on `http://localhost:5173` and proxies API requests to the backend on port 3001.
+The dev server runs on `http://localhost:3000` and proxies API requests to the backend on port 3001.
 
 ## Project Structure
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ npm install
 npm run dev
 ```
 
-The app runs at `http://localhost:5173` with the backend API on port 3001.
+The app runs at `http://localhost:3000` with the backend API on port 3001.
 
 ### Requirements
 


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
## Summary

Corrects stale documentation that referenced the Vite default development port (`5173`) instead of the port actually pinned in `vite.config.ts` (`3000`). Without this fix, operators following the setup instructions would load a blank page on the wrong port.

## Changes

- **`README.md`** (line 40): Updated the quickstart URL from `http://localhost:5173` to `http://localhost:3000` to match the configured dev server port.
- **`CONTRIBUTING.md`** (line 14): Updated the developer onboarding instructions with the same port correction, ensuring contributors don't hit a blank page when starting the project.

Both files now point to the same backend port reference (`3001`), preserving the existing API documentation while fixing only the frontend dev server URL.
<!-- kody-pr-summary:end -->