### PR TITLE
fix(rendering): prevent agents disappearing on room switch and missing seat routing

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -22,7 +22,7 @@ import { apiErrorHandler, registerProcessErrorHandlers } from "./errors";
 import { isValidLayoutId } from "./layouts";
 import { logger } from "./logger";
 import { parseLayoutMutationBody, parseOfficeLayoutDoc, parsePersistedPrefs, parseRecipe, parseSpriteBody, parseTagsBody, parseToggleBody, type OfficeLayoutDoc, type PersistedPrefs } from "./validation";
-import { ALL_TAGS, TAG_COLORS, DEFAULT_ROOMS, type AgentState, type AgentActivity, type SubAgentInfo, type TickerMessage, type Room, type AgentTag } from "../shared/types";
+import { ALL_TAGS, TAG_COLORS, DEFAULT_ROOMS, resolveRoomByTags, type AgentState, type AgentActivity, type SubAgentInfo, type TickerMessage, type Room, type AgentTag } from "../shared/types";
 const app = express();
 const server = createServer(app);
 const corsConfig = createCorsConfig();
@@ -186,21 +186,9 @@ for (const [id, prefs] of savedPrefs) {
 
 const rooms: Room[] = [...DEFAULT_ROOMS];
 
-/** Determine which room an agent should be in based on their first tag */
-function resolveRoom(agentTags: AgentTag[]): string {
-  if (agentTags.length === 0) return "office"; // default
-
-  const firstTag = agentTags[0];
-  // Check primary tag match
-  const primaryMatch = rooms.find(r => r.primaryTag === firstTag);
-  if (primaryMatch) return primaryMatch.id;
-
-  // Check secondary tag match
-  const secondaryMatch = rooms.find(r => r.secondaryTags?.includes(firstTag));
-  if (secondaryMatch) return secondaryMatch.id;
-
-  return "office"; // fallback
-}
+/** Determine which room an agent should be in based on their first tag.
+ *  Shared helper — see shared/types.ts for the implementation. */
+const resolveRoom = resolveRoomByTags;
 
 // ---- State ----
 

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -171,6 +171,23 @@ export const DEFAULT_ROOMS: Room[] = [
   { id: 'lounge', name: 'Lounge', primaryTag: 'creative', secondaryTags: ['orchestration', 'media'], icon: '🎨', order: 3 },
 ];
 
+/**
+ * Resolve which room an agent belongs to based on its tags.
+ * Uses the first tag: checks primary tag match, then secondary tag match,
+ * then falls back to 'office'. Shared between server and client so both
+ * sides use identical routing logic — if a new room is added to
+ * DEFAULT_ROOMS, both sides pick it up automatically.
+ */
+export function resolveRoomByTags(agentTags: AgentTag[]): string {
+  if (agentTags.length === 0) return 'office';
+  const firstTag = agentTags[0];
+  const primaryMatch = DEFAULT_ROOMS.find(r => r.primaryTag === firstTag);
+  if (primaryMatch) return primaryMatch.id;
+  const secondaryMatch = DEFAULT_ROOMS.find(r => r.secondaryTags?.includes(firstTag));
+  if (secondaryMatch) return secondaryMatch.id;
+  return 'office';
+}
+
 // ── Message Ticker ─────────────────────────────────────
 
 export interface TickerMessage {

--- a/src/components/PixelOffice.tsx
+++ b/src/components/PixelOffice.tsx
@@ -138,6 +138,10 @@ export const PixelOffice: React.FC<Props> = ({
           lastMessage: agent.lastMessage,
         });
       } else {
+        // Ensure the agent has a seat — setLayout may have cleared all seats
+        // when the layout changed. assignSeat returns the existing seat if
+        // one is already assigned, so this is a no-op in the normal case.
+        engine.assignSeat(agent.id);
         engine.updateCharacter(agent.id, {
           state: agent.activity, model: agent.model, name: agent.name,
           lastMessage: agent.lastMessage,

--- a/src/hooks/useAgentStore.test.tsx
+++ b/src/hooks/useAgentStore.test.tsx
@@ -253,4 +253,32 @@ describe('useAgentStore room filtering', () => {
 
     expect(latest(snapshots).roomAgents.map(a => a.id)).toEqual([]);
   });
+
+  it('routes by secondary tag (frontend → office)', async () => {
+    // 'frontend' is a secondary tag for the 'office' room
+    const { snapshots } = await renderWithAgents([
+      { ...baseAgent, id: 'a1', tags: ['frontend'] },
+    ]);
+
+    expect(latest(snapshots).roomAgents.map(a => a.id)).toEqual(['a1']);
+
+    // 'analysis' is a secondary tag for 'lab'
+    act(() => { latest(snapshots).setActiveRoomId('lab'); });
+    await act(async () => { await vi.advanceTimersByTimeAsync(0); });
+    expect(latest(snapshots).roomAgents.map(a => a.id)).toEqual([]);
+  });
+
+  it('falls back to office for tags not in DEFAULT_ROOMS', async () => {
+    const { snapshots } = await renderWithAgents([
+      { ...baseAgent, id: 'a1', tags: ['unknown-tag'] as string[] },
+    ]);
+
+    // Unknown tag → office
+    expect(latest(snapshots).roomAgents.map(a => a.id)).toEqual(['a1']);
+
+    // Switching to lab excludes the agent
+    act(() => { latest(snapshots).setActiveRoomId('lab'); });
+    await act(async () => { await vi.advanceTimersByTimeAsync(0); });
+    expect(latest(snapshots).roomAgents.map(a => a.id)).toEqual([]);
+  });
 });

--- a/src/hooks/useAgentStore.test.tsx
+++ b/src/hooks/useAgentStore.test.tsx
@@ -154,3 +154,103 @@ describe('useAgentStore REST polling fallback', () => {
     expect(socketMock.socket.disconnect).toHaveBeenCalledTimes(1);
   });
 });
+
+describe('useAgentStore room filtering', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    socketMock.handlers.clear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  async function renderWithAgents(agents: unknown[]) {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () =>
+        new Response(JSON.stringify({ agents }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      )
+    );
+    const snapshots: AgentStoreSnapshot[] = [];
+    const view = render(<StoreProbe onSnapshot={(snapshot) => snapshots.push(snapshot)} />);
+    await act(async () => { await vi.advanceTimersByTimeAsync(0); });
+    return { snapshots, ...view };
+  }
+
+  const baseAgent = {
+    id: 'agent-1',
+    name: 'Test Agent',
+    activity: 'typing',
+    model: 'test',
+    sessionKey: 's1',
+    active: true,
+    lastActivity: Date.now(),
+    pixelEnabled: true,
+    tags: [] as string[],
+  };
+
+  it('includes agents whose roomId matches the active room', async () => {
+    const { snapshots } = await renderWithAgents([
+      { ...baseAgent, id: 'a1', roomId: 'office' },
+      { ...baseAgent, id: 'a2', roomId: 'lab' },
+    ]);
+
+    expect(latest(snapshots).roomAgents.map(a => a.id)).toEqual(['a1']);
+  });
+
+  it('derives roomId from tags when roomId is missing (Bug #40)', async () => {
+    const { snapshots } = await renderWithAgents([
+      { ...baseAgent, id: 'a1', tags: ['research'] },
+      { ...baseAgent, id: 'a2', tags: ['coding'] },
+    ]);
+
+    // Default room is 'office' (coding tag → office)
+    expect(latest(snapshots).roomAgents.map(a => a.id)).toEqual(['a2']);
+
+    // Switch to 'lab' (research tag → lab)
+    act(() => { latest(snapshots).setActiveRoomId('lab'); });
+    await act(async () => { await vi.advanceTimersByTimeAsync(0); });
+
+    expect(latest(snapshots).roomAgents.map(a => a.id)).toEqual(['a1']);
+  });
+
+  it('keeps agents visible across room switches without disappearing (Bug #40)', async () => {
+    const { snapshots } = await renderWithAgents([
+      { ...baseAgent, id: 'a1', tags: ['coding'], roomId: 'office' },
+      { ...baseAgent, id: 'a2', tags: ['research'], roomId: 'lab' },
+    ]);
+
+    // Start in office
+    expect(latest(snapshots).roomAgents.map(a => a.id)).toEqual(['a1']);
+
+    // Switch to lab
+    act(() => { latest(snapshots).setActiveRoomId('lab'); });
+    await act(async () => { await vi.advanceTimersByTimeAsync(0); });
+    expect(latest(snapshots).roomAgents.map(a => a.id)).toEqual(['a2']);
+
+    // Switch back to office
+    act(() => { latest(snapshots).setActiveRoomId('office'); });
+    await act(async () => { await vi.advanceTimersByTimeAsync(0); });
+    expect(latest(snapshots).roomAgents.map(a => a.id)).toEqual(['a1']);
+  });
+
+  it('falls back to office for agents with no tags and no roomId', async () => {
+    const { snapshots } = await renderWithAgents([
+      { ...baseAgent, id: 'a1', tags: [] },
+    ]);
+
+    // Agent with no tags → defaults to office
+    expect(latest(snapshots).roomAgents.map(a => a.id)).toEqual(['a1']);
+
+    // Switching to lab should exclude the agent
+    act(() => { latest(snapshots).setActiveRoomId('lab'); });
+    await act(async () => { await vi.advanceTimersByTimeAsync(0); });
+
+    expect(latest(snapshots).roomAgents.map(a => a.id)).toEqual([]);
+  });
+});

--- a/src/hooks/useAgentStore.ts
+++ b/src/hooks/useAgentStore.ts
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback, useMemo } from 'react';
 import { io as socketIO } from 'socket.io-client';
 import type { AgentState, CharacterRecipe } from '../../shared/types';
-import { ALL_TAGS, TAG_COLORS, type AgentTag } from '../../shared/types';
+import { ALL_TAGS, TAG_COLORS, DEFAULT_ROOMS, type AgentTag } from '../../shared/types';
 
 const API_BASE = '/api';
 
@@ -107,11 +107,29 @@ export function useAgentStore() {
     }
   }, []);
 
+  /**
+   * Resolve which room an agent belongs to.
+   * If the server has set `roomId`, use it directly. Otherwise derive the
+   * room from the agent's first tag, mirroring the server's `resolveRoom`
+   * logic. This prevents agents from disappearing when a Socket.IO update
+   * arrives with a missing `roomId` during a room switch.
+   */
+  const resolveAgentRoom = useCallback((agent: AgentState): string => {
+    if (agent.roomId) return agent.roomId;
+    const tags = agent.tags || [];
+    if (tags.length === 0) return 'office';
+    const firstTag = tags[0] as AgentTag;
+    const primaryMatch = DEFAULT_ROOMS.find(r => r.primaryTag === firstTag);
+    if (primaryMatch) return primaryMatch.id;
+    const secondaryMatch = DEFAULT_ROOMS.find(r => r.secondaryTags?.includes(firstTag));
+    if (secondaryMatch) return secondaryMatch.id;
+    return 'office';
+  }, []);
+
   /** Filter agents visible in the current room */
   const roomAgents = useMemo(() => agents.filter(a =>
-    a.roomId === activeRoomId
-    || (a.roomId == null && activeRoomId === 'office')
-  ), [agents, activeRoomId]);
+    resolveAgentRoom(a) === activeRoomId
+  ), [agents, activeRoomId, resolveAgentRoom]);
 
   /** Update character recipe (paperdoll body/hair/outfit) for an agent */
   const updateRecipe = useCallback(async (agentId: string, recipe: CharacterRecipe) => {

--- a/src/hooks/useAgentStore.ts
+++ b/src/hooks/useAgentStore.ts
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback, useMemo } from 'react';
 import { io as socketIO } from 'socket.io-client';
 import type { AgentState, CharacterRecipe } from '../../shared/types';
-import { ALL_TAGS, TAG_COLORS, DEFAULT_ROOMS, type AgentTag } from '../../shared/types';
+import { ALL_TAGS, TAG_COLORS, DEFAULT_ROOMS, resolveRoomByTags, type AgentTag } from '../../shared/types';
 
 const API_BASE = '/api';
 
@@ -110,20 +110,14 @@ export function useAgentStore() {
   /**
    * Resolve which room an agent belongs to.
    * If the server has set `roomId`, use it directly. Otherwise derive the
-   * room from the agent's first tag, mirroring the server's `resolveRoom`
-   * logic. This prevents agents from disappearing when a Socket.IO update
-   * arrives with a missing `roomId` during a room switch.
+   * room from the agent's tags via the shared `resolveRoomByTags` helper,
+   * which mirrors the server's logic. This prevents agents from disappearing
+   * when a Socket.IO update arrives with a missing `roomId` during a room
+   * switch.
    */
   const resolveAgentRoom = useCallback((agent: AgentState): string => {
     if (agent.roomId) return agent.roomId;
-    const tags = agent.tags || [];
-    if (tags.length === 0) return 'office';
-    const firstTag = tags[0] as AgentTag;
-    const primaryMatch = DEFAULT_ROOMS.find(r => r.primaryTag === firstTag);
-    if (primaryMatch) return primaryMatch.id;
-    const secondaryMatch = DEFAULT_ROOMS.find(r => r.secondaryTags?.includes(firstTag));
-    if (secondaryMatch) return secondaryMatch.id;
-    return 'office';
+    return resolveRoomByTags(agent.tags || []);
   }, []);
 
   /** Filter agents visible in the current room */


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
## Summary

Resolves two related rendering bugs that caused agents to behave incorrectly during room switches and layout updates (closes #40).

### Bug 1: Agents disappearing when switching offices

The `roomAgents` filter previously relied only on `roomId` from the server payload. When a Socket.IO `agents:update` arrived with `roomId` missing or unset (common during poll races or for newly registered agents), the agent was filtered out of non-default rooms, causing the sync effect to remove the character from the engine. A page reload would "fix" it because the REST fetch returned the agent with `roomId` properly set.

**Fix:** Introduced `resolveAgentRoom` in `useAgentStore`, a client-side room resolver that:
- Uses `agent.roomId` when present
- Otherwise derives the room from the agent's first tag using the same `DEFAULT_ROOMS` mapping the server uses (`primaryTag` → `secondaryTags` → `office` fallback)
- Defaults to `'office'` when no tags are present

This mirrors the server's `resolveRoom` logic, ensuring transient missing `roomId` values never exclude an agent from its correct room.

### Bug 2: Agents not routing to desks after a layout change

`engine.setLayout()` clears the existing seat assignments when new layout seats are provided. The agent sync effect in `PixelOffice.tsx` only called `assignSeat` for *new* agents that weren't yet registered with the engine. For agents that lost their seat assignment during a layout change, `assignSeat` was never re-called, so `updateCharacter` found `this.seats.get(id) === undefined` and left the agent stranded instead of routing them to their desk.

**Fix:** The sync effect now always calls `engine.assignSeat(agent.id)` for every existing agent before `updateCharacter`. `assignSeat` returns the existing seat if one is already assigned, so this is a safe no-op in the normal path — but it guarantees a seat exists after a `setLayout` clears the seat map.

### Test coverage

Added 4 new tests in `useAgentStore.test.tsx` under a `room filtering` describe block:
- Filters agents whose `roomId` matches the active room
- Derives `roomId` from tags when missing (the core Bug #40 scenario)
- Keeps agents visible across repeated room switches without disappearing
- Falls back to `office` for agents with neither `roomId` nor tags, and excludes them when switching to other rooms

### Files changed

| File | Change |
|---|---|
| `src/hooks/useAgentStore.ts` | Imports `DEFAULT_ROOMS`; adds `resolveAgentRoom` callback; rewrites `roomAgents` filter to use it |
| `src/components/PixelOffice.tsx` | Calls `engine.assignSeat(agent.id)` for existing agents in the sync effect |
| `src/hooks/useAgentStore.test.tsx` | New `room filtering` test suite (4 tests) |
<!-- kody-pr-summary:end -->