### PR TITLE
refactor(game): extract SubAgentFSM from GameEngine (Issue #51 Phase 1b)

### DIFF
--- a/src/game/GameEngine.ts
+++ b/src/game/GameEngine.ts
@@ -76,8 +76,7 @@ const AGENT_PALETTES: Record<'cybera' | 'main' | 'shodan' | 'cyberlogis' | 'desc
   chi: 4, cylena: 5, sysauxilia: 3, miku: 0,
 };
 
-const SUBAGENT_LIFETIME = 15000; // ms before sub-agents fade out
-const SUBAGENT_FADE_DURATION = 2000; // fade animation length
+import { tickSubAgent } from './SubAgentFSM';
 
 // ── State Transition Visual Effects ────────────────────
 
@@ -403,19 +402,17 @@ export class GameEngine {
 
   private update(dt: number) {
     for (const char of this.characters.values()) {
-      // Sub-agent lifecycle
+      // Sub-agent lifecycle (planner returns actions for caller to execute)
       if (char.isSubAgent) {
-        const age = this.nowMs - char.spawnTime;
-        if (age > SUBAGENT_LIFETIME && !char.dying) {
-          char.dying = true;
-          sfx.despawn();
+        const tick = tickSubAgent(char, this.nowMs, dt);
+        char.fadeAlpha = tick.fadeAlpha;
+        char.dying = tick.dying;
+        for (const action of tick.actions) {
+          if (action.kind === 'spawn-despawn-sound') sfx.despawn();
         }
-        if (char.dying) {
-          char.fadeAlpha = Math.max(0, char.fadeAlpha - dt / (SUBAGENT_FADE_DURATION / 1000));
-          if (char.fadeAlpha <= 0) {
-            this.characters.delete(char.id);
-            continue;
-          }
+        if (tick.shouldRemove) {
+          this.characters.delete(char.id);
+          continue;
         }
       } else {
         char.fadeAlpha = 1;

--- a/src/game/GameEngine.ts
+++ b/src/game/GameEngine.ts
@@ -21,6 +21,7 @@ import {
 import { buildObstacleMap, bfsPathfind, type Point } from './Pathfinder';
 import { sfx } from '../audio/SoundFX';
 import type { PlacedFurniture } from '../../shared/types';
+import { tickSubAgent } from './SubAgentFSM';
 
 export interface GameConfig {
   tileSize: number;
@@ -75,8 +76,6 @@ const AGENT_PALETTES: Record<'cybera' | 'main' | 'shodan' | 'cyberlogis' | 'desc
   cybera: 0, main: 1, shodan: 1, cyberlogis: 2, descartes: 3,
   chi: 4, cylena: 5, sysauxilia: 3, miku: 0,
 };
-
-import { tickSubAgent } from './SubAgentFSM';
 
 // ── State Transition Visual Effects ────────────────────
 
@@ -408,7 +407,7 @@ export class GameEngine {
         char.fadeAlpha = tick.fadeAlpha;
         char.dying = tick.dying;
         for (const action of tick.actions) {
-          if (action.kind === 'spawn-despawn-sound') sfx.despawn();
+          if (action.kind === 'despawn-sound') sfx.despawn();
         }
         if (tick.shouldRemove) {
           this.characters.delete(char.id);

--- a/src/game/SubAgentFSM.test.ts
+++ b/src/game/SubAgentFSM.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect } from 'vitest';
 import { tickSubAgent, SUBAGENT_LIFETIME, SUBAGENT_FADE_DURATION } from './SubAgentFSM';
-import type { SubAgentTick } from './SubAgentFSM';
 
 describe('tickSubAgent', () => {
   it('returns fadeAlpha=1, dying=false, no actions for young sub-agent', () => {
@@ -18,7 +17,7 @@ describe('tickSubAgent', () => {
       0.016,
     );
     expect(tick.dying).toBe(true);
-    expect(tick.actions).toEqual([{ kind: 'spawn-despawn-sound' }]);
+    expect(tick.actions).toEqual([{ kind: 'despawn-sound' }]);
     // fadeAlpha decreases by dtSec/FADE_DURATION from the moment dying starts
     expect(tick.fadeAlpha).toBeCloseTo(1 - 0.016 / (SUBAGENT_FADE_DURATION / 1000), 5);
     expect(tick.shouldRemove).toBe(false);
@@ -84,6 +83,19 @@ describe('tickSubAgent', () => {
     );
     expect(tick.dying).toBe(false);
     expect(tick.actions).toEqual([]);
+  });
+
+  it('preserves existing fadeAlpha for non-dying sub-agent (no implicit reset)', () => {
+    // The original GameEngine code only set fadeAlpha in the dying branch;
+    // non-dying sub-agents retained their prior value. This regression test
+    // pins that behavior so future changes don't silently override it.
+    const tick = tickSubAgent(
+      { spawnTime: 0, dying: false, fadeAlpha: 0.7 },
+      1_000, // well under LIFETIME
+      0.016,
+    );
+    expect(tick.dying).toBe(false);
+    expect(tick.fadeAlpha).toBe(0.7);
   });
 });
 

--- a/src/game/SubAgentFSM.test.ts
+++ b/src/game/SubAgentFSM.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest';
+import { tickSubAgent, SUBAGENT_LIFETIME, SUBAGENT_FADE_DURATION } from './SubAgentFSM';
+import type { SubAgentTick } from './SubAgentFSM';
+
+describe('tickSubAgent', () => {
+  it('returns fadeAlpha=1, dying=false, no actions for young sub-agent', () => {
+    const tick = tickSubAgent({ spawnTime: 0, dying: false, fadeAlpha: 1 }, 10_000, 0.016);
+    expect(tick.fadeAlpha).toBe(1);
+    expect(tick.dying).toBe(false);
+    expect(tick.actions).toEqual([]);
+    expect(tick.shouldRemove).toBe(false);
+  });
+
+  it('transitions to dying and emits despawn-sound when age crosses LIFETIME', () => {
+    const tick = tickSubAgent(
+      { spawnTime: 0, dying: false, fadeAlpha: 1 },
+      SUBAGENT_LIFETIME + 1,
+      0.016,
+    );
+    expect(tick.dying).toBe(true);
+    expect(tick.actions).toEqual([{ kind: 'spawn-despawn-sound' }]);
+    // fadeAlpha decreases by dtSec/FADE_DURATION from the moment dying starts
+    expect(tick.fadeAlpha).toBeCloseTo(1 - 0.016 / (SUBAGENT_FADE_DURATION / 1000), 5);
+    expect(tick.shouldRemove).toBe(false);
+  });
+
+  it('does NOT re-emit despawn-sound on subsequent dying ticks', () => {
+    const tick = tickSubAgent(
+      { spawnTime: 0, dying: true, fadeAlpha: 0.5 },
+      16_000,
+      0.016,
+    );
+    expect(tick.dying).toBe(true);
+    expect(tick.actions).toEqual([]);
+    expect(tick.fadeAlpha).toBeCloseTo(0.5 - 0.016 / (SUBAGENT_FADE_DURATION / 1000), 3);
+  });
+
+  it('fades at correct rate: full fade in SUBAGENT_FADE_DURATION seconds', () => {
+    const tick = tickSubAgent(
+      { spawnTime: 0, dying: true, fadeAlpha: 1 },
+      SUBAGENT_LIFETIME + 1,
+      SUBAGENT_FADE_DURATION / 1000,
+    );
+    expect(tick.fadeAlpha).toBeCloseTo(0, 5);
+    expect(tick.shouldRemove).toBe(true);
+  });
+
+  it('clamps fadeAlpha at 0 when dt exceeds remaining fade time', () => {
+    const tick = tickSubAgent(
+      { spawnTime: 0, dying: true, fadeAlpha: 0.001 },
+      20_000,
+      1.0,
+    );
+    expect(tick.fadeAlpha).toBe(0);
+    expect(tick.shouldRemove).toBe(true);
+  });
+
+  it('marks shouldRemove when fadeAlpha reaches 0', () => {
+    const tick = tickSubAgent(
+      { spawnTime: 0, dying: true, fadeAlpha: 0 },
+      20_000,
+      0.016,
+    );
+    expect(tick.shouldRemove).toBe(true);
+    expect(tick.fadeAlpha).toBe(0);
+  });
+
+  it('preserves existing dying state (killSubAgent) without re-emitting sound', () => {
+    const tick = tickSubAgent(
+      { spawnTime: 0, dying: true, fadeAlpha: 1 },
+      5_000,
+      0.016,
+    );
+    expect(tick.dying).toBe(true);
+    expect(tick.actions).toEqual([]);
+    expect(tick.fadeAlpha).toBeCloseTo(1 - 0.016 / (SUBAGENT_FADE_DURATION / 1000), 3);
+  });
+
+  it('emits no despawn-sound at exactly LIFETIME boundary (strict > check)', () => {
+    const tick = tickSubAgent(
+      { spawnTime: 0, dying: false, fadeAlpha: 1 },
+      SUBAGENT_LIFETIME,
+      0.016,
+    );
+    expect(tick.dying).toBe(false);
+    expect(tick.actions).toEqual([]);
+  });
+});
+
+describe('SUBAGENT_LIFETIME and SUBAGENT_FADE_DURATION constants', () => {
+  it('SUBAGENT_LIFETIME is 15000ms', () => {
+    expect(SUBAGENT_LIFETIME).toBe(15_000);
+  });
+  it('SUBAGENT_FADE_DURATION is 2000ms', () => {
+    expect(SUBAGENT_FADE_DURATION).toBe(2_000);
+  });
+});

--- a/src/game/SubAgentFSM.ts
+++ b/src/game/SubAgentFSM.ts
@@ -13,7 +13,9 @@ export interface SubAgentInput {
   fadeAlpha: number;
 }
 
-export type SubAgentAction = { kind: 'spawn-despawn-sound' };
+export type SubAgentAction = { kind: 'despawn-sound' };
+
+const EMPTY_ACTIONS: SubAgentAction[] = [];
 
 export interface SubAgentTick {
   fadeAlpha: number;
@@ -32,12 +34,14 @@ export function tickSubAgent(
   const justEnteredDying = dying && !char.dying;
 
   if (!dying) {
-    return { fadeAlpha: 1, dying: false, actions: [], shouldRemove: false };
+    // Preserve existing fadeAlpha — the original `if (char.isSubAgent)` block
+    // in GameEngine had no else that reset it. Only dying agents fade.
+    return { fadeAlpha: char.fadeAlpha, dying: false, actions: EMPTY_ACTIONS, shouldRemove: false };
   }
 
   const fadeAlpha = Math.max(0, char.fadeAlpha - dtSec / (SUBAGENT_FADE_DURATION / 1000));
   const shouldRemove = fadeAlpha <= 0;
-  const actions: SubAgentAction[] = justEnteredDying ? [{ kind: 'spawn-despawn-sound' }] : [];
+  const actions: SubAgentAction[] = justEnteredDying ? [{ kind: 'despawn-sound' }] : EMPTY_ACTIONS;
 
   return { fadeAlpha, dying, actions, shouldRemove };
 }

--- a/src/game/SubAgentFSM.ts
+++ b/src/game/SubAgentFSM.ts
@@ -1,0 +1,43 @@
+/** SubAgentFSM — pure planner for sub-agent lifecycle ticks.
+ * Encapsulates the per-frame state transitions for sub-agent characters
+ * (age check, despawn trigger, fade-out, removal). Side effects (sound,
+ * character deletion) are reported as actions for the caller to execute.
+ */
+
+export const SUBAGENT_LIFETIME = 15_000;
+export const SUBAGENT_FADE_DURATION = 2_000;
+
+export interface SubAgentInput {
+  spawnTime: number;
+  dying: boolean;
+  fadeAlpha: number;
+}
+
+export type SubAgentAction = { kind: 'spawn-despawn-sound' };
+
+export interface SubAgentTick {
+  fadeAlpha: number;
+  dying: boolean;
+  actions: SubAgentAction[];
+  shouldRemove: boolean;
+}
+
+export function tickSubAgent(
+  char: SubAgentInput,
+  nowMs: number,
+  dtSec: number,
+): SubAgentTick {
+  const age = nowMs - char.spawnTime;
+  const dying = char.dying || age > SUBAGENT_LIFETIME;
+  const justEnteredDying = dying && !char.dying;
+
+  if (!dying) {
+    return { fadeAlpha: 1, dying: false, actions: [], shouldRemove: false };
+  }
+
+  const fadeAlpha = Math.max(0, char.fadeAlpha - dtSec / (SUBAGENT_FADE_DURATION / 1000));
+  const shouldRemove = fadeAlpha <= 0;
+  const actions: SubAgentAction[] = justEnteredDying ? [{ kind: 'spawn-despawn-sound' }] : [];
+
+  return { fadeAlpha, dying, actions, shouldRemove };
+}


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
## SubAgentFSM Extraction — Pure Planner Pattern

This PR continues the GameEngine decomposition (Phase 1b of #51) by isolating the sub-agent lifecycle logic into a dedicated, side-effect-free module.

### What Changed

**New module: `src/game/SubAgentFSM.ts`**
A pure planner that computes the per-frame sub-agent state transition. It takes the character's current `spawnTime`, `dying`, and `fadeAlpha`, plus the current time and delta-seconds, and returns:
- `fadeAlpha` — new opacity value (clamped at 0)
- `dying` — new dying flag
- `actions` — list of one-shot side effects to perform (e.g., `spawn-despawn-sound`)
- `shouldRemove` — whether the caller should delete the character

The module also exports the `SUBAGENT_LIFETIME` (15s) and `SUBAGENT_FADE_DURATION` (2s) constants that were previously local to GameEngine.

**`GameEngine.update()` — refactored**
The previous inline lifecycle block (age check, despawn sound trigger, fade-out math, character deletion) is replaced with a call to `tickSubAgent`. The engine now applies the returned values to the character, executes any reported actions via `sfx.despawn()`, and removes the character when `shouldRemove` is true.

### Key Design Choice

The planner is **deliberately pure** — it returns action descriptors rather than mutating state or invoking `sfx` directly. This keeps the FSM unit-testable (no mocks needed) while keeping all side effects consolidated in GameEngine where they belong.

### Behavior Edge Cases Preserved

- **One-shot despawn sound**: The `justEnteredDying` guard ensures the sound fires exactly once on the age threshold crossing, and is *not* re-emitted when dying was set externally via `killSubAgent`.
- **Strict `>` boundary**: The despawn transition triggers only when `age > SUBAGENT_LIFETIME` (not `>=`), matching prior behavior.
- **Fade clamping**: `fadeAlpha` cannot go negative; removal happens exactly when fade reaches 0.
- **Kill-driven death**: When `char.dying` is already `true` (from `killSubAgent`), the sound is suppressed but fade-out proceeds normally.

### Test Coverage

`src/game/SubAgentFSM.test.ts` adds 10 unit tests covering:
- Young (non-dying) sub-agent defaults
- Age-threshold transition into dying with sound emission
- No re-emission of sound on subsequent ticks
- Fade-rate calculation matching `SUBAGENT_FADE_DURATION`
- Clamping at 0 with large `dt`
- Removal flag at zero alpha
- `killSubAgent`-style pre-dying input
- Exact boundary case at `LIFETIME` (no transition)
- Constant value verification

### API Impact

None. `spawnSubAgent` and `killSubAgent` remain public on GameEngine; PixelOffice callers see no change. All 175 tests pass and the build is green.

---

This pull request extracts the sub-agent finite state machine (FSM) logic from `GameEngine` into a dedicated `SubAgentFSM` module, completing **Phase 1b** of Issue #51's refactor plan.

## Key changes:

**1. `SubAgentFSM.ts`**
- Renames the `SubAgentAction` kind from `'spawn-despawn-sound'` → `'despawn-sound'` for clarity (this action only fires on despawn, not spawn).
- Preserves existing `fadeAlpha` for non-dying sub-agents instead of implicitly resetting it to `1`, matching the original `GameEngine` behavior. Previously, a non-dying branch was returning `fadeAlpha: 1`, which would have silently overwritten any partially-faded alpha. A regression test now pins this behavior.
- Introduces a shared `EMPTY_ACTIONS` constant to avoid allocating empty arrays on every tick.
- Adds an explanatory comment documenting the rationale for preserving `fadeAlpha`.

**2. `GameEngine.ts`**
- Updates the import to reference the renamed action kind (`'despawn-sound'`).
- Moves the `tickSubAgent` import to the top of the file alongside other module imports (it was previously imported mid-file).

**3. `SubAgentFSM.test.ts`**
- Updates the existing test to assert the renamed action kind (`'despawn-sound'`).
- Adds a new regression test verifying that `fadeAlpha` is preserved for non-dying sub-agents.
- Fixes the missing trailing newline at end of file.

## Functional impact:
- `SubAgentFSM` is now a self-contained, pure module — `tickSubAgent` takes an input state and returns a `SubAgentTick` result with no side effects beyond the explicit `actions` list.
- `GameEngine` no longer needs to know about sub-agent state-transition details; it simply applies the returned tick to the character.
- The behavior change to preserve `fadeAlpha` for non-dying sub-agents is a no-op against the original code (which also didn't reset it), now codified and protected by a test.

This is a pure refactor — no user-facing behavior changes, but it improves testability, isolates sub-agent lifecycle logic, and sets up further FSM extractions in subsequent phases of Issue #51.
<!-- kody-pr-summary:end -->