### PR TITLE
refactor(game): extract input geometry helpers (#51)

### DIFF
--- a/src/game/GameEngine.ts
+++ b/src/game/GameEngine.ts
@@ -22,6 +22,7 @@ import { buildObstacleMap, bfsPathfind, type Point } from './Pathfinder';
 import { sfx } from '../audio/SoundFX';
 import type { PlacedFurniture } from '../../shared/types';
 import { tickSubAgent } from './SubAgentFSM';
+import { screenToGrid as mapScreenToGrid, touchDistance } from './inputGeometry';
 
 export interface GameConfig {
   tileSize: number;
@@ -1302,46 +1303,15 @@ export class GameEngine {
   private screenToGrid(clientX: number, clientY: number): { gridX: number; gridY: number } | null;
   private screenToGrid(eOrX: MouseEvent | number, maybeY?: number): { gridX: number; gridY: number } | null {
     const rect = this.canvas.getBoundingClientRect();
-    const canvas = this.canvas;
-
-    // When object-fit: contain is used, the CSS box (rect) may be larger than
-    // the actual rendered canvas area due to pillarboxing/letterboxing.
-    // We need to compute the actual rendered dimensions to get correct scales.
-    const cssRatio = rect.width / rect.height;
-    const canvasRatio = canvas.width / canvas.height;
-
-    let renderedWidth: number, renderedHeight: number, offsetX: number, offsetY: number;
-
-    if (cssRatio > canvasRatio) {
-      // Pillarboxing: bars on left/right
-      renderedWidth = (canvas.width / canvas.height) * rect.height;
-      renderedHeight = rect.height;
-      offsetX = rect.left + (rect.width - renderedWidth) / 2;
-      offsetY = rect.top;
-    } else {
-      // Letterboxing: bars on top/bottom
-      renderedWidth = rect.width;
-      renderedHeight = (canvas.height / canvas.width) * rect.width;
-      offsetX = rect.left;
-      offsetY = rect.top + (rect.height - renderedHeight) / 2;
-    }
-
-    // Use unified scale - both dimensions should have the same ratio with object-fit: contain
-    const scale = canvas.width / renderedWidth;
-
     const clientX = typeof eOrX === 'number' ? eOrX : eOrX.clientX;
     const clientY = typeof eOrX === 'number' ? maybeY! : eOrX.clientY;
 
-    // Check if click falls within the rendered canvas area (not in letterbox/pillarbox)
-    if (clientX < offsetX || clientX > offsetX + renderedWidth ||
-      clientY < offsetY || clientY > offsetY + renderedHeight) {
-      return null;
-    }
-
-    return {
-      gridX: Math.floor((clientX - offsetX) * scale / this.config.tileSize),
-      gridY: Math.floor((clientY - offsetY) * scale / this.config.tileSize),
-    };
+    return mapScreenToGrid(clientX, clientY, {
+      rect: { left: rect.left, top: rect.top, width: rect.width, height: rect.height },
+      canvasWidth: this.canvas.width,
+      canvasHeight: this.canvas.height,
+      tileSize: this.config.tileSize,
+    });
   }
 
   private findFurnitureAt(gridX: number, gridY: number): PlacedFurniture | null {
@@ -1516,7 +1486,7 @@ export class GameEngine {
       this.touchStartPos = null;
       this.touchCurrentPos = null;
       this.touchMoved = true;
-      this.pinchStartDist = this.touchDistance(e.touches[0], e.touches[1]);
+      this.pinchStartDist = touchDistance(e.touches[0], e.touches[1]);
       this.pinchStartZoom = this.cameraZoom;
       return;
     }
@@ -1557,7 +1527,7 @@ export class GameEngine {
 
     // Pinch-to-zoom
     if (e.touches.length === 2) {
-      const dist = this.touchDistance(e.touches[0], e.touches[1]);
+      const dist = touchDistance(e.touches[0], e.touches[1]);
 
       // Guard against zero/invalid starting distance (e.g., both fingers started at the
       // same pixel): reinitialize from the first valid distance seen during move.
@@ -1716,13 +1686,6 @@ export class GameEngine {
     this.mouseGridX = -1;
     this.mouseGridY = -1;
   };
-
-  /** Euclidean distance between two touch points */
-  private touchDistance(a: Touch, b: Touch): number {
-    const dx = a.clientX - b.clientX;
-    const dy = a.clientY - b.clientY;
-    return Math.sqrt(dx * dx + dy * dy);
-  }
 
   // ── Helpers ──────────────────────────────────────────
 

--- a/src/game/inputGeometry.test.ts
+++ b/src/game/inputGeometry.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+
+import { screenToGrid, touchDistance, type CanvasMetrics } from './inputGeometry';
+
+const BASE_METRICS: CanvasMetrics = {
+  rect: { left: 10, top: 20, width: 240, height: 160 },
+  canvasWidth: 240,
+  canvasHeight: 160,
+  tileSize: 10,
+};
+
+describe('screenToGrid', () => {
+  it('maps client coordinates when the CSS box matches the canvas aspect ratio', () => {
+    expect(screenToGrid(35, 55, BASE_METRICS)).toEqual({ gridX: 2, gridY: 3 });
+  });
+
+  it('accounts for CSS scaling', () => {
+    const metrics: CanvasMetrics = {
+      ...BASE_METRICS,
+      rect: { left: 10, top: 20, width: 480, height: 320 },
+    };
+
+    expect(screenToGrid(110, 80, metrics)).toEqual({ gridX: 5, gridY: 3 });
+  });
+
+  it('rejects points in pillarbox bars', () => {
+    const metrics: CanvasMetrics = {
+      ...BASE_METRICS,
+      rect: { left: 10, top: 20, width: 300, height: 160 },
+    };
+
+    expect(screenToGrid(39, 40, metrics)).toBeNull();
+    expect(screenToGrid(40, 40, metrics)).toEqual({ gridX: 0, gridY: 2 });
+  });
+
+  it('rejects points in letterbox bars', () => {
+    const metrics: CanvasMetrics = {
+      ...BASE_METRICS,
+      rect: { left: 10, top: 20, width: 240, height: 200 },
+    };
+
+    expect(screenToGrid(30, 39, metrics)).toBeNull();
+    expect(screenToGrid(30, 40, metrics)).toEqual({ gridX: 2, gridY: 0 });
+  });
+
+  it('preserves the inclusive right and bottom rendered-edge behavior', () => {
+    expect(screenToGrid(250, 180, BASE_METRICS)).toEqual({ gridX: 24, gridY: 16 });
+  });
+});
+
+describe('touchDistance', () => {
+  it('returns Euclidean distance between client points', () => {
+    expect(touchDistance({ clientX: 1, clientY: 2 }, { clientX: 4, clientY: 6 })).toBe(5);
+  });
+});

--- a/src/game/inputGeometry.ts
+++ b/src/game/inputGeometry.ts
@@ -1,0 +1,74 @@
+export interface ClientPoint {
+  clientX: number;
+  clientY: number;
+}
+
+export interface ScreenRect {
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+}
+
+export interface CanvasMetrics {
+  rect: ScreenRect;
+  canvasWidth: number;
+  canvasHeight: number;
+  tileSize: number;
+}
+
+export interface GridPoint {
+  gridX: number;
+  gridY: number;
+}
+
+/** Map client coordinates into the canvas grid, accounting for object-fit bars. */
+export function screenToGrid(
+  clientX: number,
+  clientY: number,
+  metrics: CanvasMetrics,
+): GridPoint | null {
+  const { rect, canvasWidth, canvasHeight, tileSize } = metrics;
+  const cssRatio = rect.width / rect.height;
+  const canvasRatio = canvasWidth / canvasHeight;
+
+  let renderedWidth: number;
+  let renderedHeight: number;
+  let offsetX: number;
+  let offsetY: number;
+
+  if (cssRatio > canvasRatio) {
+    renderedWidth = (canvasWidth / canvasHeight) * rect.height;
+    renderedHeight = rect.height;
+    offsetX = rect.left + (rect.width - renderedWidth) / 2;
+    offsetY = rect.top;
+  } else {
+    renderedWidth = rect.width;
+    renderedHeight = (canvasHeight / canvasWidth) * rect.width;
+    offsetX = rect.left;
+    offsetY = rect.top + (rect.height - renderedHeight) / 2;
+  }
+
+  const scale = canvasWidth / renderedWidth;
+
+  if (
+    clientX < offsetX
+    || clientX > offsetX + renderedWidth
+    || clientY < offsetY
+    || clientY > offsetY + renderedHeight
+  ) {
+    return null;
+  }
+
+  return {
+    gridX: Math.floor((clientX - offsetX) * scale / tileSize),
+    gridY: Math.floor((clientY - offsetY) * scale / tileSize),
+  };
+}
+
+/** Euclidean distance between two client-coordinate points. */
+export function touchDistance(a: ClientPoint, b: ClientPoint): number {
+  const dx = a.clientX - b.clientX;
+  const dy = a.clientY - b.clientY;
+  return Math.sqrt(dx * dx + dy * dy);
+}


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
## What Changed

This PR extracts two pieces of geometry logic out of `GameEngine` into a new pure helper module so the engine class no longer owns stateless math.

### New module: `src/game/inputGeometry.ts`
- **`screenToGrid(clientX, clientY, metrics)`** — Pure function that takes a `CanvasMetrics` bundle (rect, canvas dimensions, tile size) and returns either `{ gridX, gridY }` or `null` if the point lands in a letterbox/pillarbox bar. All the object-fit-aware math (aspect ratio comparison, offset computation, scale, hit rejection, floor conversion, inclusive right/bottom edge) moved here verbatim.
- **`touchDistance(a, b)`** — Pure Euclidean distance between two `{ clientX, clientY }` points, extracted from the previous private method.
- Exports supporting interfaces: `ClientPoint`, `ScreenRect`, `CanvasMetrics`, `GridPoint`.

### `src/game/GameEngine.ts`
- Imports `screenToGrid` (renamed locally to `mapScreenToGrid`) and `touchDistance`.
- `screenToGrid` is now a thin compatibility wrapper: it pulls the live `getBoundingClientRect()` and `canvas.width/height`/`config.tileSize`, then delegates to the pure function. Both call signatures (`MouseEvent` and `(number, number)`) are preserved.
- The two pinch-zoom call sites (`touchstart` and `touchmove`) now call `touchDistance(...)` from the module instead of the instance method.
- The private `touchDistance` method body is deleted.

### New tests: `src/game/inputGeometry.test.ts`
Six tests pinning behavior so future refactors can't silently regress:
- **Aspect-match mapping** — baseline `(35, 55) → (2, 3)`.
- **CSS scaling** — 2x CSS box still maps `(110, 80) → (5, 3)`.
- **Pillarbox rejection** — extra-wide CSS box rejects points inside left bar but accepts the boundary point at the bar edge.
- **Letterbox rejection** — extra-tall CSS box rejects points inside top bar but accepts the boundary point at the bar edge.
- **Inclusive right/bottom edge** — `(250, 180)` (exactly on rendered rect) returns `(24, 16)`, documenting the `≤` (not `<`) boundary semantics.
- **`touchDistance`** — `(1,2)` to `(4,6)` returns `5`.

### Why
Phase 2-lite of the larger editor-controller refactor (#51). These are the zero-risk stateless helpers — the stateful `EditorController` move is deferred because its handlers touch canvas, furniture, character, pathfinding, and callback state. Extracting the pure geometry seam first establishes the pattern and a tested module boundary that the controller work can build on later.
<!-- kody-pr-summary:end -->