### PR TITLE
refactor(game): extract EditorController (Issue #51 Phase 2-full)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -186,7 +186,7 @@ The engine fires `EditorCallbacks` (`onPlaceFurniture`, `onSelectFurniture`, `on
 
 1. Add sprites to `public/assets/furniture/<TYPE>/`
 2. Create `manifest.json` with `id`, `name`, `category`, `type`, and `members` array
-3. Add type name to the furniture catalog array in `server/index.ts` (line ~932)
+3. Add type name to the furniture catalog array in `server/index.ts` (line ~1091)
 4. It appears in the editor palette automatically via `/api/furniture-catalog`
 
 ## Socket.IO Events

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,11 @@ src/
     TagEditor.tsx       # Tag management
     SoundControls.tsx    # Mute/volume UI
   game/
-    GameEngine.ts       # Canvas 2D rendering loop, animation, pathfinding, editor mode
+    GameEngine.ts       # Canvas 2D rendering loop, animation, pathfinding, host façade
+    EditorController.ts # Mouse/touch editor state and canvas listener lifecycle
+    Schedule.ts         # Pure day/night phase interpolation
+    SubAgentFSM.ts      # Pure sub-agent lifetime/fade planner
+    inputGeometry.ts    # Pure screen/grid and touch-distance geometry
     SpriteLoader.ts     # Sprite sheet loading, frame extraction
     CharacterComposer.ts # Paperdoll compositor (body+hair+outfit layering)
     Pathfinder.ts        # BFS pathfinding
@@ -126,9 +130,12 @@ Output is in the same 3×7 format as legacy sprites (16×32 frames). If source s
 
 `SoundFX.ts` is a **Web Audio API synthesizer** — no audio files. All sounds (typing clicks, footsteps, spawn/despawn chimes, etc.) are generated procedurally via oscillators and gain envelopes. Muted state and volume persist in the singleton.
 
-### Editor Mode (GameEngine)
+### Editor Mode (EditorController via GameEngine)
 
-Editor mode is a mode on `GameEngine` (not a separate component). When active:
+React continues to use the stable editor methods on `GameEngine`, which delegate to
+`EditorController`. The controller owns mouse/touch state and canvas listener lifecycle;
+`GameEngine` supplies a narrow host adapter for furniture mutation and non-editor agent taps.
+When editor mode is active:
 - Canvas cursor changes to indicate placement/drag/delete modes
 - Right-click rotates furniture 90°
 - Touch: single tap = place/select, double-tap = rotate, drag = move
@@ -138,7 +145,7 @@ The engine fires `EditorCallbacks` (`onPlaceFurniture`, `onSelectFurniture`, `on
 
 ## Non-Obvious Gotchas
 
-1. **Auto-save was intentionally removed.** The `useLayoutStore` comment explains: furniture is persisted only via explicit **Save button** to avoid race conditions on initial load and React StrictMode double-mounts that caused furniture to reset. The `updateFurniture` function accepts a functional updater form specifically for rapid delete-mode clicks.
+1. **Layout auto-save is guarded.** Furniture edits mark the active layout dirty and schedule a 2-second debounced save. Programmatic load/create/save-response changes use `skipAutoSaveRef` so React StrictMode or initial loading cannot write stale layouts back. Saves are serialized through `savePromiseRef`; the explicit **Save** button remains available.
 
 2. **`furnitureKey` detection.** `PixelOffice` uses `JSON.stringify` of furniture positions/rotations as a React effect dependency to detect layout changes. If you add new fields to `PlacedFurniture` that the engine reads but don't include them in this string, the engine won't re-sync.
 
@@ -150,7 +157,7 @@ The engine fires `EditorCallbacks` (`onPlaceFurniture`, `onSelectFurniture`, `on
 
 6. **Socket.IO `changeOrigin: true`.** The Vite proxy config sets `changeOrigin: true` for both `/api` and `/socket.io`. Without it, WebSocket upgrades fail because the `Host` header doesn't match what the backend expects.
 
-7. **`screenToGrid` has overloads.** `screenToGrid(e: MouseEvent)` and `screenToGrid(clientX: number, clientY: number)` — used by both mouse and touch handlers. Don't merge them naively.
+7. **`screenToGrid` has overloads.** The compatibility wrapper remains on `GameEngine` as `screenToGrid(e: MouseEvent)` and `screenToGrid(clientX: number, clientY: number)`, while pure letterbox/pillarbox math lives in `inputGeometry.ts`. `EditorController` uses the numeric overload. Don't merge or change the edge semantics naively.
 
 8. **`stateJustChanged` is one-frame-only.** Set to `true` in `updateCharacter` when state changes, consumed once in `update()` to trigger sounds/VFX, then reset. If you add more state-change side effects, add them before the reset.
 
@@ -158,7 +165,7 @@ The engine fires `EditorCallbacks` (`onPlaceFurniture`, `onSelectFurniture`, `on
 
 10. **Demo mode.** If no agents are active (no CLI and no ingest data), `spawnDemoAgents()` creates 8 hardcoded demo characters. The backend always initializes these in the engine, so the office is never empty.
 
-11. **Sub-agent lifecycle.** Sub-agents spawn near their parent, live for 15 seconds (`SUBAGENT_LIFETIME`), then enter a 2-second fade-out. The `subAgents` array on `AgentState` drives spawn/kill via `engine.spawnSubAgent()` / `engine.killSubAgent()`. Session completion/abort sets sub-agent status, which triggers the kill.
+11. **Sub-agent lifecycle.** `SubAgentFSM.tickSubAgent()` plans the 15-second lifetime, one-shot despawn event, and 2-second fade; `GameEngine` applies the plan and sound side effect. The `subAgents` array on `AgentState` drives spawn/kill via `engine.spawnSubAgent()` / `engine.killSubAgent()`.
 
 12. **Duplicate type definition.** `CharacterRecipe` is defined in both `shared/types.ts` (line ~64) and `CharacterComposer.ts` (line ~54). They are identical. The one in `shared/types.ts` is used by the network layer; `CharacterComposer.ts` exports its own for the compositor.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,8 +21,11 @@ The dev server runs on `http://localhost:3000` and proxies API requests to the b
 ├── src/
 │   ├── components/      # React components (PixelOffice, AgentSidebar, LayoutEditor)
 │   ├── game/            # Canvas 2D game engine
-│   │   ├── GameEngine.ts    # Main rendering loop, editor mode, mouse handling
-│   │   └── SpriteLoader.ts  # Asset loading, sprite sheet slicing, frame extraction
+│   │   ├── GameEngine.ts       # Rendering loop, pathfinding, host façade
+│   │   ├── EditorController.ts # Mouse/touch editor input and listener lifecycle
+│   │   ├── Schedule.ts         # Day/night interpolation
+│   │   ├── SubAgentFSM.ts      # Sub-agent lifetime/fade planner
+│   │   └── SpriteLoader.ts     # Asset loading, sprite slicing, frame extraction
 │   ├── hooks/           # React hooks (useAgentStore, useLayoutStore)
 │   └── App.tsx          # Root component
 ├── public/assets/       # Pixel art sprites and tilesets

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Click **✏️ Edit** in the header to enter editor mode:
 | Delete furniture | Use 🗑️ button in the info bar, or press Delete |
 | Save layout | Click 💾 Save |
 
-Layouts auto-save 1 second after any change.
+Layouts auto-save 2 seconds after the last furniture change; the explicit Save button remains available.
 
 ### Layout Manager
 
@@ -136,7 +136,8 @@ See [collector/README.md](collector/README.md) for full setup instructions.
 
 | Component | Purpose |
 |-----------|---------|
-| `GameEngine` | Canvas 2D rendering loop, sprite animation, editor mode, mouse handling |
+| `GameEngine` | Canvas 2D rendering loop, sprite animation, pathfinding, and host façade |
+| `EditorController` | Mouse/touch editor state and canvas listener lifecycle |
 | `SpriteLoader` | Loads and slices sprite sheets into individual frame canvases |
 | `LayoutEditor` | Toolbar, furniture palette, layout manager UI |
 | `PixelOffice` | Canvas wrapper, wires agent/layout data to GameEngine |

--- a/src/game/EditorController.test.ts
+++ b/src/game/EditorController.test.ts
@@ -1,0 +1,229 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { EditorController } from './EditorController';
+import type {
+  EditorCallbacks,
+  EditorControllerHost,
+  EditorControllerSounds,
+  FurnitureHit,
+} from './EditorController';
+
+function touchEvent(type: string, points: Array<{ clientX: number; clientY: number }>): TouchEvent {
+  const event = new Event(type, { bubbles: true, cancelable: true }) as TouchEvent;
+  Object.defineProperty(event, 'touches', { value: points });
+  return event;
+}
+
+describe('EditorController', () => {
+  let canvas: HTMLCanvasElement;
+  let furniture: FurnitureHit | null;
+  let host: EditorControllerHost;
+  let sounds: EditorControllerSounds;
+  let callbacks: EditorCallbacks;
+  let nowMs: number;
+  let controller: EditorController;
+
+  beforeEach(() => {
+    canvas = document.createElement('canvas');
+    furniture = null;
+    nowMs = 1_000;
+    host = {
+      screenToGrid: vi.fn((x: number, y: number) => ({ gridX: x, gridY: y })),
+      findFurnitureAt: vi.fn(() => furniture),
+      previewFurnitureMove: vi.fn(),
+      rotateFurnitureAt: vi.fn(() => furniture !== null),
+      findCharacterAt: vi.fn(() => null),
+      hasSelectedAgent: vi.fn(() => false),
+      handleTouchGridTap: vi.fn(),
+    };
+    sounds = { place: vi.fn(), pickup: vi.fn() };
+    callbacks = {
+      onPlaceFurniture: vi.fn(),
+      onSelectFurniture: vi.fn(),
+      onMoveFurniture: vi.fn(),
+    };
+    controller = new EditorController(
+      canvas,
+      { gridWidth: 24, gridHeight: 16 },
+      host,
+      sounds,
+      () => nowMs,
+    );
+    controller.setEditorCallbacks(callbacks);
+  });
+
+  it('attaches and detaches canvas listeners as one lifecycle unit', () => {
+    controller.attach();
+    canvas.dispatchEvent(new MouseEvent('mousemove', { clientX: 4, clientY: 5 }));
+    expect(host.screenToGrid).toHaveBeenCalledTimes(1);
+
+    controller.detach();
+    canvas.dispatchEvent(new MouseEvent('mousemove', { clientX: 8, clientY: 9 }));
+    expect(host.screenToGrid).toHaveBeenCalledTimes(1);
+  });
+
+  it('preserves GameEngine setter reset semantics', () => {
+    controller.setSelectedFurnitureType('DESK');
+    controller.setSelectedFurnitureId('desk-1');
+    expect(controller.selectedFurnitureType).toBeNull();
+    expect(controller.selectedFurnitureId).toBe('desk-1');
+
+    controller.setEditorMode(true);
+    expect(controller.editorMode).toBe(true);
+    expect(controller.selectedFurnitureType).toBeNull();
+    expect(controller.selectedFurnitureId).toBeNull();
+    expect(canvas.style.cursor).toBe('default');
+  });
+
+  it('places selected furniture on primary mouse down', () => {
+    controller.attach();
+    controller.setEditorMode(true);
+    controller.setSelectedFurnitureType('DESK');
+
+    canvas.dispatchEvent(new MouseEvent('mousedown', { button: 0, clientX: 5, clientY: 6 }));
+
+    expect(callbacks.onPlaceFurniture).toHaveBeenCalledWith('DESK', 5, 6);
+    expect(sounds.place).toHaveBeenCalledOnce();
+  });
+
+  it('selects for deletion without starting a drag', () => {
+    furniture = { id: 'desk-1', x: 3, y: 4 };
+    controller.attach();
+    controller.setEditorMode(true);
+    controller.setDeleteMode(true);
+
+    canvas.dispatchEvent(new MouseEvent('mousedown', { button: 0, clientX: 4, clientY: 5 }));
+    canvas.dispatchEvent(new MouseEvent('mouseup', { button: 0, clientX: 8, clientY: 9 }));
+
+    expect(callbacks.onSelectFurniture).toHaveBeenCalledWith('desk-1');
+    expect(callbacks.onMoveFurniture).not.toHaveBeenCalled();
+    expect(sounds.pickup).not.toHaveBeenCalled();
+  });
+
+  it('preserves mouse drag clamping and its no-offset behavior', () => {
+    furniture = { id: 'desk-1', x: 3, y: 4 };
+    controller.attach();
+    controller.setEditorMode(true);
+
+    canvas.dispatchEvent(new MouseEvent('mousedown', { button: 0, clientX: 5, clientY: 7 }));
+    canvas.dispatchEvent(new MouseEvent('mousemove', { clientX: 99, clientY: 99 }));
+    canvas.dispatchEvent(new MouseEvent('mouseup', { button: 0, clientX: 99, clientY: 99 }));
+
+    expect(host.previewFurnitureMove).toHaveBeenCalledWith('desk-1', 21, 13);
+    expect(callbacks.onMoveFurniture).toHaveBeenCalledWith('desk-1', 21, 13);
+    expect(sounds.pickup).toHaveBeenCalledOnce();
+    expect(sounds.place).toHaveBeenCalledOnce();
+  });
+
+  it('rotates furniture on editor context menu without adding sound', () => {
+    controller.attach();
+    controller.setEditorMode(true);
+    canvas.dispatchEvent(new MouseEvent('contextmenu', { clientX: 4, clientY: 5, cancelable: true }));
+
+    expect(host.rotateFurnitureAt).toHaveBeenCalledWith(4, 5);
+    expect(sounds.place).not.toHaveBeenCalled();
+  });
+
+  it('preserves touch drag grab offsets for preview and final placement', () => {
+    furniture = { id: 'desk-1', x: 3, y: 4 };
+    controller.attach();
+    controller.setEditorMode(true);
+
+    canvas.dispatchEvent(touchEvent('touchstart', [{ clientX: 5, clientY: 6 }]));
+    canvas.dispatchEvent(touchEvent('touchmove', [{ clientX: 10, clientY: 12 }]));
+    canvas.dispatchEvent(touchEvent('touchend', []));
+
+    expect(host.previewFurnitureMove).toHaveBeenCalledWith('desk-1', 8, 10);
+    expect(callbacks.onMoveFurniture).toHaveBeenCalledWith('desk-1', 8, 10);
+    expect(sounds.place).toHaveBeenCalledOnce();
+  });
+
+  it('rotates furniture on a double tap and emits the existing place sound', () => {
+    furniture = { id: 'desk-1', x: 3, y: 4 };
+    controller.attach();
+    controller.setEditorMode(true);
+    controller.setDeleteMode(true);
+
+    canvas.dispatchEvent(touchEvent('touchstart', [{ clientX: 4, clientY: 5 }]));
+    canvas.dispatchEvent(touchEvent('touchend', []));
+    nowMs = 1_200;
+    canvas.dispatchEvent(touchEvent('touchstart', [{ clientX: 4, clientY: 5 }]));
+    canvas.dispatchEvent(touchEvent('touchend', []));
+
+    expect(host.rotateFurnitureAt).toHaveBeenCalledWith(4, 5);
+    expect(sounds.place).toHaveBeenCalledOnce();
+  });
+
+  it('reinitializes a zero pinch distance and clamps zoom to four', () => {
+    controller.attach();
+    canvas.dispatchEvent(touchEvent('touchstart', [
+      { clientX: 0, clientY: 0 },
+      { clientX: 0, clientY: 0 },
+    ]));
+    canvas.dispatchEvent(touchEvent('touchmove', [
+      { clientX: 0, clientY: 0 },
+      { clientX: 100, clientY: 0 },
+    ]));
+    canvas.dispatchEvent(touchEvent('touchmove', [
+      { clientX: 0, clientY: 0 },
+      { clientX: 500, clientY: 0 },
+    ]));
+
+    expect(canvas.style.transform).toBe('scale(4)');
+    expect(canvas.style.transformOrigin).toBe('center center');
+  });
+
+  it('delegates non-editor taps to the GameEngine host', () => {
+    controller.attach();
+    canvas.dispatchEvent(touchEvent('touchstart', [{ clientX: 7, clientY: 8 }]));
+    canvas.dispatchEvent(touchEvent('touchend', []));
+
+    expect(host.handleTouchGridTap).toHaveBeenCalledWith(7, 8);
+  });
+
+  it('cancels an active touch drag without finalizing placement', () => {
+    furniture = { id: 'desk-1', x: 3, y: 4 };
+    controller.attach();
+    controller.setEditorMode(true);
+
+    canvas.dispatchEvent(touchEvent('touchstart', [{ clientX: 5, clientY: 6 }]));
+    canvas.dispatchEvent(touchEvent('touchmove', [{ clientX: 10, clientY: 12 }]));
+    canvas.dispatchEvent(touchEvent('touchcancel', []));
+    canvas.dispatchEvent(touchEvent('touchend', []));
+
+    expect(host.previewFurnitureMove).toHaveBeenCalled();
+    expect(callbacks.onMoveFurniture).not.toHaveBeenCalled();
+  });
+
+  it('keeps the exact 300ms interval outside the double-tap window', () => {
+    furniture = { id: 'desk-1', x: 3, y: 4 };
+    controller.attach();
+    controller.setEditorMode(true);
+    controller.setDeleteMode(true);
+
+    canvas.dispatchEvent(touchEvent('touchstart', [{ clientX: 4, clientY: 5 }]));
+    canvas.dispatchEvent(touchEvent('touchend', []));
+    nowMs = 1_300;
+    canvas.dispatchEvent(touchEvent('touchstart', [{ clientX: 4, clientY: 5 }]));
+    canvas.dispatchEvent(touchEvent('touchend', []));
+
+    expect(host.rotateFurnitureAt).not.toHaveBeenCalled();
+    expect(sounds.place).not.toHaveBeenCalled();
+  });
+
+  it('preserves non-editor cursor precedence', () => {
+    controller.attach();
+    vi.mocked(host.hasSelectedAgent).mockReturnValue(true);
+    canvas.dispatchEvent(new MouseEvent('mousemove', { clientX: 4, clientY: 5 }));
+    expect(canvas.style.cursor).toBe('crosshair');
+
+    vi.mocked(host.hasSelectedAgent).mockReturnValue(false);
+    vi.mocked(host.findCharacterAt).mockReturnValue('agent-1');
+    canvas.dispatchEvent(new MouseEvent('mousemove', { clientX: 4, clientY: 5 }));
+    expect(canvas.style.cursor).toBe('pointer');
+
+    vi.mocked(host.findCharacterAt).mockReturnValue(null);
+    canvas.dispatchEvent(new MouseEvent('mousemove', { clientX: 4, clientY: 5 }));
+    expect(canvas.style.cursor).toBe('default');
+  });
+});

--- a/src/game/EditorController.test.ts
+++ b/src/game/EditorController.test.ts
@@ -226,4 +226,51 @@ describe('EditorController', () => {
     canvas.dispatchEvent(new MouseEvent('mousemove', { clientX: 4, clientY: 5 }));
     expect(canvas.style.cursor).toBe('default');
   });
+
+  it('aborts an active mouse drag if mouseleave fires before mouseup', () => {
+    furniture = { id: 'desk-1', x: 3, y: 4 };
+    controller.attach();
+    controller.setEditorMode(true);
+
+    canvas.dispatchEvent(new MouseEvent('mousedown', { button: 0, clientX: 5, clientY: 7 }));
+    canvas.dispatchEvent(new MouseEvent('mousemove', { clientX: 99, clientY: 99 }));
+    canvas.dispatchEvent(new MouseEvent('mouseleave'));
+
+    expect(callbacks.onMoveFurniture).not.toHaveBeenCalled();
+    expect(sounds.place).not.toHaveBeenCalled();
+
+    canvas.dispatchEvent(new MouseEvent('mouseup', { button: 0, clientX: 99, clientY: 99 }));
+
+    expect(callbacks.onMoveFurniture).not.toHaveBeenCalled();
+    expect(sounds.place).not.toHaveBeenCalled();
+  });
+
+  it('does not finalize a drag on right-click mouseup', () => {
+    furniture = { id: 'desk-1', x: 3, y: 4 };
+    controller.attach();
+    controller.setEditorMode(true);
+
+    canvas.dispatchEvent(new MouseEvent('mousedown', { button: 0, clientX: 5, clientY: 7 }));
+    canvas.dispatchEvent(new MouseEvent('mousemove', { clientX: 99, clientY: 99 }));
+    canvas.dispatchEvent(new MouseEvent('mouseup', { button: 2, clientX: 99, clientY: 99 }));
+
+    expect(callbacks.onMoveFurniture).not.toHaveBeenCalled();
+    expect(sounds.place).not.toHaveBeenCalled();
+
+    canvas.dispatchEvent(new MouseEvent('mouseup', { button: 0, clientX: 99, clientY: 99 }));
+    expect(callbacks.onMoveFurniture).toHaveBeenCalledWith('desk-1', 21, 13);
+    expect(sounds.place).toHaveBeenCalledOnce();
+  });
+
+  it('places selected furniture on a single touch tap with no drag', () => {
+    controller.attach();
+    controller.setEditorMode(true);
+    controller.setSelectedFurnitureType('DESK');
+
+    canvas.dispatchEvent(touchEvent('touchstart', [{ clientX: 5, clientY: 6 }]));
+    canvas.dispatchEvent(touchEvent('touchend', []));
+
+    expect(callbacks.onPlaceFurniture).toHaveBeenCalledWith('DESK', 5, 6);
+    expect(sounds.place).toHaveBeenCalledOnce();
+  });
 });

--- a/src/game/EditorController.ts
+++ b/src/game/EditorController.ts
@@ -1,0 +1,362 @@
+import { touchDistance } from './inputGeometry';
+
+export interface EditorCallbacks {
+  onPlaceFurniture: (type: string, gridX: number, gridY: number) => void;
+  onSelectFurniture: (id: string | null) => void;
+  onMoveFurniture: (id: string, gridX: number, gridY: number) => void;
+}
+
+export interface FurnitureHit {
+  id: string;
+  x: number;
+  y: number;
+}
+
+export interface EditorControllerHost {
+  screenToGrid: (clientX: number, clientY: number) => { gridX: number; gridY: number } | null;
+  findFurnitureAt: (gridX: number, gridY: number) => FurnitureHit | null;
+  previewFurnitureMove: (id: string, gridX: number, gridY: number) => void;
+  rotateFurnitureAt: (gridX: number, gridY: number) => boolean;
+  findCharacterAt: (gridX: number, gridY: number) => string | null;
+  hasSelectedAgent: () => boolean;
+  handleTouchGridTap: (gridX: number, gridY: number) => void;
+}
+
+export interface EditorControllerSounds {
+  place: () => void;
+  pickup: () => void;
+}
+
+export interface EditorControllerConfig {
+  gridWidth: number;
+  gridHeight: number;
+}
+
+interface DragState {
+  id: string;
+  offsetX: number;
+  offsetY: number;
+}
+
+export class EditorController {
+  private static readonly TAP_THRESHOLD = 12;
+  private static readonly DOUBLE_TAP_MS = 300;
+
+  private _editorMode = false;
+  private deleteMode = false;
+  private _selectedFurnitureType: string | null = null;
+  private _selectedFurnitureId: string | null = null;
+  private dragging: DragState | null = null;
+  private callbacks: EditorCallbacks | null = null;
+  private _mouseGridX = -1;
+  private _mouseGridY = -1;
+  private touchStartPos: { x: number; y: number } | null = null;
+  private touchCurrentPos: { x: number; y: number } | null = null;
+  private lastTapTime = 0;
+  private pinchStartDist = 0;
+  private pinchStartZoom = 1;
+  private cameraZoom = 1;
+  private touchDragging: DragState | null = null;
+  private touchMoved = false;
+  private attached = false;
+
+  constructor(
+    private readonly canvas: HTMLCanvasElement,
+    private readonly config: EditorControllerConfig,
+    private readonly host: EditorControllerHost,
+    private readonly sounds: EditorControllerSounds,
+    private readonly now: () => number = Date.now,
+  ) {}
+
+  get editorMode(): boolean { return this._editorMode; }
+  get selectedFurnitureType(): string | null { return this._selectedFurnitureType; }
+  get selectedFurnitureId(): string | null { return this._selectedFurnitureId; }
+  get mouseGridX(): number { return this._mouseGridX; }
+  get mouseGridY(): number { return this._mouseGridY; }
+
+  attach(): void {
+    if (this.attached) return;
+    this.attached = true;
+    this.canvas.addEventListener('mousemove', this.handleMouseMove);
+    this.canvas.addEventListener('mousedown', this.handleMouseDown);
+    this.canvas.addEventListener('mouseup', this.handleMouseUp);
+    this.canvas.addEventListener('mouseleave', this.handleMouseLeave);
+    this.canvas.addEventListener('contextmenu', this.handleContextMenu);
+    this.canvas.addEventListener('touchstart', this.handleTouchStart, { passive: false });
+    this.canvas.addEventListener('touchmove', this.handleTouchMove, { passive: false });
+    this.canvas.addEventListener('touchend', this.handleTouchEnd, { passive: false });
+    this.canvas.addEventListener('touchcancel', this.handleTouchCancel, { passive: false });
+  }
+
+  detach(): void {
+    if (!this.attached) return;
+    this.attached = false;
+    this.canvas.removeEventListener('mousemove', this.handleMouseMove);
+    this.canvas.removeEventListener('mousedown', this.handleMouseDown);
+    this.canvas.removeEventListener('mouseup', this.handleMouseUp);
+    this.canvas.removeEventListener('mouseleave', this.handleMouseLeave);
+    this.canvas.removeEventListener('contextmenu', this.handleContextMenu);
+    this.canvas.removeEventListener('touchstart', this.handleTouchStart);
+    this.canvas.removeEventListener('touchmove', this.handleTouchMove);
+    this.canvas.removeEventListener('touchend', this.handleTouchEnd);
+    this.canvas.removeEventListener('touchcancel', this.handleTouchCancel);
+  }
+
+  setEditorMode(enabled: boolean): void {
+    this._editorMode = enabled;
+    this._selectedFurnitureType = null;
+    this._selectedFurnitureId = null;
+    this.canvas.style.cursor = 'default';
+  }
+
+  setEditorCallbacks(callbacks: EditorCallbacks): void { this.callbacks = callbacks; }
+  setDeleteMode(enabled: boolean): void { this.deleteMode = enabled; }
+
+  setSelectedFurnitureType(type: string | null): void {
+    this._selectedFurnitureType = type;
+    this._selectedFurnitureId = null;
+  }
+
+  setSelectedFurnitureId(id: string | null): void {
+    this._selectedFurnitureId = id;
+    this._selectedFurnitureType = null;
+  }
+
+  private clampX(gridX: number): number {
+    return Math.max(1, Math.min(this.config.gridWidth - 3, gridX));
+  }
+
+  private clampY(gridY: number): number {
+    return Math.max(1, Math.min(this.config.gridHeight - 3, gridY));
+  }
+
+  private handleMouseMove = (event: MouseEvent): void => {
+    const result = this.host.screenToGrid(event.clientX, event.clientY);
+    if (!result) return;
+    const { gridX, gridY } = result;
+    this._mouseGridX = gridX;
+    this._mouseGridY = gridY;
+
+    if (this.dragging) {
+      this.host.previewFurnitureMove(this.dragging.id, this.clampX(gridX), this.clampY(gridY));
+    }
+
+    if (this._editorMode) {
+      if (this._selectedFurnitureType) {
+        this.canvas.style.cursor = 'crosshair';
+      } else {
+        const overFurniture = this.host.findFurnitureAt(gridX, gridY);
+        this.canvas.style.cursor = overFurniture
+          ? (this.deleteMode ? 'pointer' : this.dragging ? 'grabbing' : 'grab')
+          : 'default';
+      }
+    } else if (this.host.hasSelectedAgent()) {
+      this.canvas.style.cursor = 'crosshair';
+    } else {
+      this.canvas.style.cursor = this.host.findCharacterAt(gridX, gridY) ? 'pointer' : 'default';
+    }
+  };
+
+  private handleMouseDown = (event: MouseEvent): void => {
+    if (!this._editorMode) return;
+    const result = this.host.screenToGrid(event.clientX, event.clientY);
+    if (!result) return;
+    const { gridX, gridY } = result;
+
+    if (event.button !== 0) return;
+    if (this._selectedFurnitureType) {
+      this.callbacks?.onPlaceFurniture(this._selectedFurnitureType, gridX, gridY);
+      this.sounds.place();
+      return;
+    }
+
+    const hit = this.host.findFurnitureAt(gridX, gridY);
+    if (hit) {
+      if (this.deleteMode) {
+        this.callbacks?.onSelectFurniture(hit.id);
+        return;
+      }
+      this._selectedFurnitureId = hit.id;
+      this.callbacks?.onSelectFurniture(hit.id);
+      this.dragging = { id: hit.id, offsetX: gridX - hit.x, offsetY: gridY - hit.y };
+      this.sounds.pickup();
+    } else {
+      this._selectedFurnitureId = null;
+      this.callbacks?.onSelectFurniture(null);
+    }
+  };
+
+  private handleMouseUp = (event: MouseEvent): void => {
+    if (!this._editorMode || !this.dragging) return;
+    const result = this.host.screenToGrid(event.clientX, event.clientY);
+    if (!result) return;
+    this.callbacks?.onMoveFurniture(
+      this.dragging.id,
+      this.clampX(result.gridX),
+      this.clampY(result.gridY),
+    );
+    this.sounds.place();
+    this.dragging = null;
+  };
+
+  private handleMouseLeave = (): void => {
+    this._mouseGridX = -1;
+    this._mouseGridY = -1;
+    this.dragging = null;
+    this.canvas.style.cursor = 'default';
+  };
+
+  private handleContextMenu = (event: MouseEvent): void => {
+    if (!this._editorMode) return;
+    event.preventDefault();
+    const result = this.host.screenToGrid(event.clientX, event.clientY);
+    if (!result) return;
+    this.host.rotateFurnitureAt(result.gridX, result.gridY);
+  };
+
+  private handleTouchStart = (event: TouchEvent): void => {
+    event.preventDefault();
+    if (event.touches.length === 2) {
+      this.touchDragging = null;
+      this.touchStartPos = null;
+      this.touchCurrentPos = null;
+      this.touchMoved = true;
+      this.pinchStartDist = touchDistance(event.touches[0], event.touches[1]);
+      this.pinchStartZoom = this.cameraZoom;
+      return;
+    }
+
+    const touch = event.touches[0];
+    this.touchStartPos = { x: touch.clientX, y: touch.clientY };
+    this.touchCurrentPos = { x: touch.clientX, y: touch.clientY };
+    this.touchMoved = false;
+
+    const result = this.host.screenToGrid(touch.clientX, touch.clientY);
+    if (!result) return;
+    this._mouseGridX = result.gridX;
+    this._mouseGridY = result.gridY;
+
+    if (this._editorMode && event.touches.length === 1 && !this._selectedFurnitureType) {
+      const hit = this.host.findFurnitureAt(result.gridX, result.gridY);
+      if (hit) {
+        if (this.deleteMode) {
+          this.callbacks?.onSelectFurniture(hit.id);
+        } else {
+          this.touchDragging = {
+            id: hit.id,
+            offsetX: result.gridX - hit.x,
+            offsetY: result.gridY - hit.y,
+          };
+          this._selectedFurnitureId = hit.id;
+          this.callbacks?.onSelectFurniture(hit.id);
+        }
+      }
+    }
+  };
+
+  private handleTouchMove = (event: TouchEvent): void => {
+    event.preventDefault();
+    if (event.touches.length === 2) {
+      const distance = touchDistance(event.touches[0], event.touches[1]);
+      if (!this.pinchStartDist || this.pinchStartDist <= 0) {
+        if (distance <= 0) return;
+        this.pinchStartDist = distance;
+        this.pinchStartZoom = this.cameraZoom;
+      }
+      const scale = distance / this.pinchStartDist;
+      this.cameraZoom = Math.max(1, Math.min(4, this.pinchStartZoom * scale));
+      this.canvas.style.transform = `scale(${this.cameraZoom})`;
+      this.canvas.style.transformOrigin = 'center center';
+      return;
+    }
+
+    if (!this.touchStartPos) return;
+    const touch = event.touches[0];
+    const dx = touch.clientX - this.touchStartPos.x;
+    const dy = touch.clientY - this.touchStartPos.y;
+    if (Math.abs(dx) > EditorController.TAP_THRESHOLD || Math.abs(dy) > EditorController.TAP_THRESHOLD) {
+      this.touchMoved = true;
+    }
+    this.touchCurrentPos = { x: touch.clientX, y: touch.clientY };
+
+    const result = this.host.screenToGrid(touch.clientX, touch.clientY);
+    if (!result) return;
+    this._mouseGridX = result.gridX;
+    this._mouseGridY = result.gridY;
+
+    if (this._editorMode && this.touchDragging) {
+      this.host.previewFurnitureMove(
+        this.touchDragging.id,
+        this.clampX(result.gridX - this.touchDragging.offsetX),
+        this.clampY(result.gridY - this.touchDragging.offsetY),
+      );
+    }
+  };
+
+  private handleTouchEnd = (event: TouchEvent): void => {
+    event.preventDefault();
+    if (event.touches.length > 0) return;
+
+    if (this._editorMode) {
+      if (this.touchDragging) {
+        const result = this.host.screenToGrid(this.touchCurrentPos!.x, this.touchCurrentPos!.y);
+        if (result) {
+          this.callbacks?.onMoveFurniture(
+            this.touchDragging.id,
+            this.clampX(result.gridX - this.touchDragging.offsetX),
+            this.clampY(result.gridY - this.touchDragging.offsetY),
+          );
+          this.sounds.place();
+        }
+        this.touchDragging = null;
+      } else if (!this.touchMoved && this.touchStartPos) {
+        const result = this.host.screenToGrid(this.touchStartPos.x, this.touchStartPos.y);
+        if (!result) {
+          this.touchStartPos = null;
+          this.touchCurrentPos = null;
+          return;
+        }
+
+        const now = this.now();
+        if (now - this.lastTapTime < EditorController.DOUBLE_TAP_MS) {
+          if (this.host.rotateFurnitureAt(result.gridX, result.gridY)) {
+            this.sounds.place();
+            this.lastTapTime = 0;
+            this.touchStartPos = null;
+            this.touchCurrentPos = null;
+            return;
+          }
+        }
+        this.lastTapTime = now;
+
+        if (this._selectedFurnitureType) {
+          this.callbacks?.onPlaceFurniture(this._selectedFurnitureType, result.gridX, result.gridY);
+          this.sounds.place();
+        }
+      }
+      this.touchStartPos = null;
+      this.touchCurrentPos = null;
+      return;
+    }
+
+    if (this.touchMoved || !this.touchStartPos) {
+      this.touchStartPos = null;
+      this.touchCurrentPos = null;
+      return;
+    }
+
+    const result = this.host.screenToGrid(this.touchStartPos.x, this.touchStartPos.y);
+    if (result) this.host.handleTouchGridTap(result.gridX, result.gridY);
+    this.touchStartPos = null;
+    this.touchCurrentPos = null;
+  };
+
+  private handleTouchCancel = (): void => {
+    this.touchStartPos = null;
+    this.touchCurrentPos = null;
+    this.touchDragging = null;
+    this.touchMoved = false;
+    this._mouseGridX = -1;
+    this._mouseGridY = -1;
+  };
+}

--- a/src/game/EditorController.ts
+++ b/src/game/EditorController.ts
@@ -188,6 +188,7 @@ export class EditorController {
 
   private handleMouseUp = (event: MouseEvent): void => {
     if (!this._editorMode || !this.dragging) return;
+    if (event.button !== 0) return;
     const result = this.host.screenToGrid(event.clientX, event.clientY);
     if (!result) return;
     this.callbacks?.onMoveFurniture(

--- a/src/game/EditorController.ts
+++ b/src/game/EditorController.ts
@@ -32,7 +32,7 @@ export interface EditorControllerConfig {
   gridHeight: number;
 }
 
-interface DragState {
+interface TouchDragState {
   id: string;
   offsetX: number;
   offsetY: number;
@@ -46,7 +46,7 @@ export class EditorController {
   private deleteMode = false;
   private _selectedFurnitureType: string | null = null;
   private _selectedFurnitureId: string | null = null;
-  private dragging: DragState | null = null;
+  private dragging: { id: string } | null = null;
   private callbacks: EditorCallbacks | null = null;
   private _mouseGridX = -1;
   private _mouseGridY = -1;
@@ -56,7 +56,7 @@ export class EditorController {
   private pinchStartDist = 0;
   private pinchStartZoom = 1;
   private cameraZoom = 1;
-  private touchDragging: DragState | null = null;
+  private touchDragging: TouchDragState | null = null;
   private touchMoved = false;
   private attached = false;
 
@@ -178,7 +178,7 @@ export class EditorController {
       }
       this._selectedFurnitureId = hit.id;
       this.callbacks?.onSelectFurniture(hit.id);
-      this.dragging = { id: hit.id, offsetX: gridX - hit.x, offsetY: gridY - hit.y };
+      this.dragging = { id: hit.id };
       this.sounds.pickup();
     } else {
       this._selectedFurnitureId = null;
@@ -299,16 +299,19 @@ export class EditorController {
 
     if (this._editorMode) {
       if (this.touchDragging) {
-        const result = this.host.screenToGrid(this.touchCurrentPos!.x, this.touchCurrentPos!.y);
-        if (result) {
-          this.callbacks?.onMoveFurniture(
-            this.touchDragging.id,
-            this.clampX(result.gridX - this.touchDragging.offsetX),
-            this.clampY(result.gridY - this.touchDragging.offsetY),
-          );
-          this.sounds.place();
-        }
+        const dragging = this.touchDragging;
         this.touchDragging = null;
+        if (this.touchCurrentPos) {
+          const result = this.host.screenToGrid(this.touchCurrentPos.x, this.touchCurrentPos.y);
+          if (result) {
+            this.callbacks?.onMoveFurniture(
+              dragging.id,
+              this.clampX(result.gridX - dragging.offsetX),
+              this.clampY(result.gridY - dragging.offsetY),
+            );
+            this.sounds.place();
+          }
+        }
       } else if (!this.touchMoved && this.touchStartPos) {
         const result = this.host.screenToGrid(this.touchStartPos.x, this.touchStartPos.y);
         if (!result) {

--- a/src/game/GameEngine.ts
+++ b/src/game/GameEngine.ts
@@ -22,7 +22,11 @@ import { buildObstacleMap, bfsPathfind, type Point } from './Pathfinder';
 import { sfx } from '../audio/SoundFX';
 import type { PlacedFurniture } from '../../shared/types';
 import { tickSubAgent } from './SubAgentFSM';
-import { screenToGrid as mapScreenToGrid, touchDistance } from './inputGeometry';
+import { EditorController } from './EditorController';
+import type { EditorCallbacks } from './EditorController';
+import { screenToGrid as mapScreenToGrid } from './inputGeometry';
+
+export type { EditorCallbacks } from './EditorController';
 
 export interface GameConfig {
   tileSize: number;
@@ -61,12 +65,6 @@ interface Character extends CharacterData {
   lastFootstepTile: number; // tile index of last footstep sound
   typingSoundTimer: number; // cooldown for typing sounds
   stateJustChanged: boolean; // true for one frame after state change
-}
-
-export interface EditorCallbacks {
-  onPlaceFurniture: (type: string, gridX: number, gridY: number) => void;
-  onSelectFurniture: (id: string | null) => void;
-  onMoveFurniture: (id: string, gridX: number, gridY: number) => void;
 }
 
 export interface GameCallbacks {
@@ -189,16 +187,9 @@ export class GameEngine {
   private _obstacleRebuildScheduled = false;
   private _obstacleRebuildRafId: number | null = null;
 
-  // Editor state
-  private editorMode = false;
-  private deleteMode = false;
-  private selectedFurnitureType: string | null = null;
-  private selectedFurnitureId: string | null = null;
-  private dragging: { id: string; offsetX: number; offsetY: number } | null = null;
-  private editorCallbacks: EditorCallbacks | null = null;
+  // Input/editor controller
+  private editor: EditorController;
   private gameCallbacks: GameCallbacks | null = null;
-  private mouseGridX = -1;
-  private mouseGridY = -1;
 
   // Speech bubbles
   private speechBubbles: Map<string, { text: string; timer: number; alpha: number }> = new Map();
@@ -207,16 +198,6 @@ export class GameEngine {
   // Click-to-move selection
   private selectedAgentId: string | null = null;
   private selectionPulse = 0; // for animated ring
-
-  // Touch state
-  private touchStartPos: { x: number; y: number } | null = null;
-  private touchCurrentPos: { x: number; y: number } | null = null;
-  private lastTapTime = 0;
-  private pinchStartDist = 0;
-  private pinchStartZoom = 1;
-  private cameraZoom = 1; // view-only zoom applied via CSS transform (independent of render zoom)
-  private touchDragging: { id: string; offsetX: number; offsetY: number } | null = null;
-  private touchMoved = false; // true once finger moves > threshold
 
   // Day/night cycle
   private dayPhase = 0; // 0-1, loops continuously
@@ -245,19 +226,33 @@ export class GameEngine {
     canvas.style.imageRendering = 'pixelated';
     canvas.tabIndex = 0; // enable keyboard focus for Escape key
 
-    this.canvas.addEventListener('mousemove', this.handleMouseMove);
-    this.canvas.addEventListener('mousedown', this.handleMouseDown);
-    this.canvas.addEventListener('mouseup', this.handleMouseUp);
-    this.canvas.addEventListener('mouseleave', this.handleMouseLeave);
-    this.canvas.addEventListener('contextmenu', this.handleContextMenu);
+    this.editor = new EditorController(
+      canvas,
+      { gridWidth: config.gridWidth, gridHeight: config.gridHeight },
+      {
+        screenToGrid: (clientX, clientY) => this.screenToGrid(clientX, clientY),
+        findFurnitureAt: (gridX, gridY) => this.findFurnitureAt(gridX, gridY),
+        previewFurnitureMove: (id, gridX, gridY) => {
+          const item = this.placedFurniture.find(furniture => furniture.id === id);
+          if (item) { item.x = gridX; item.y = gridY; }
+        },
+        rotateFurnitureAt: (gridX, gridY) => {
+          const item = this.findFurnitureAt(gridX, gridY);
+          if (!item) return false;
+          item.rotation = ((item.rotation || 0) + 90) % 360;
+          return true;
+        },
+        findCharacterAt: (gridX, gridY) => this.findCharacterAt(gridX, gridY),
+        hasSelectedAgent: () => this.selectedAgentId !== null,
+        handleTouchGridTap: (gridX, gridY) => this.handleTouchGridTap(gridX, gridY),
+      },
+      sfx,
+    );
+    this.editor.attach();
+
     // Character click (non-editor mode)
     this.canvas.addEventListener('click', this.handleClick);
     this.canvas.addEventListener('keydown', this.handleKeyDown);
-    // Touch support
-    this.canvas.addEventListener('touchstart', this.handleTouchStart, { passive: false });
-    this.canvas.addEventListener('touchmove', this.handleTouchMove, { passive: false });
-    this.canvas.addEventListener('touchend', this.handleTouchEnd, { passive: false });
-    this.canvas.addEventListener('touchcancel', this.handleTouchCancel, { passive: false });
   }
 
   async init(signal?: AbortSignal, debugDemo: boolean = false) {
@@ -328,17 +323,9 @@ export class GameEngine {
       this._obstacleRebuildRafId = null;
       this._obstacleRebuildScheduled = false;
     }
-    this.canvas.removeEventListener('mousemove', this.handleMouseMove);
-    this.canvas.removeEventListener('mousedown', this.handleMouseDown);
-    this.canvas.removeEventListener('mouseup', this.handleMouseUp);
-    this.canvas.removeEventListener('mouseleave', this.handleMouseLeave);
-    this.canvas.removeEventListener('contextmenu', this.handleContextMenu);
+    this.editor.detach();
     this.canvas.removeEventListener('click', this.handleClick);
     this.canvas.removeEventListener('keydown', this.handleKeyDown);
-    this.canvas.removeEventListener('touchstart', this.handleTouchStart);
-    this.canvas.removeEventListener('touchmove', this.handleTouchMove);
-    this.canvas.removeEventListener('touchend', this.handleTouchEnd);
-    this.canvas.removeEventListener('touchcancel', this.handleTouchCancel);
   }
 
   private loop = () => {
@@ -833,7 +820,7 @@ export class GameEngine {
     this.renderSpeechBubbles(tileSize);
     this.renderDayNight(tileSize);
 
-    if (this.editorMode) this.renderEditorOverlay(tileSize);
+    if (this.editor.editorMode) this.renderEditorOverlay(tileSize);
   }
 
   private renderFloor(gridW: number, gridH: number, tileSize: number, zoom: number) {
@@ -918,7 +905,7 @@ export class GameEngine {
       for (const item of this.placedFurniture) {
         const px = item.x * tileSize;
         const py = item.y * tileSize;
-        const isSelected = this.editorMode && this.selectedFurnitureId === item.id;
+        const isSelected = this.editor.editorMode && this.editor.selectedFurnitureId === item.id;
 
         ctx.save();
         if (item.rotation) {
@@ -1283,9 +1270,9 @@ export class GameEngine {
     for (let y = 0; y <= this.config.gridHeight; y++) {
       ctx.beginPath(); ctx.moveTo(0, y * tileSize); ctx.lineTo(this.canvas.width, y * tileSize); ctx.stroke();
     }
-    if (this.mouseGridX >= 0 && this.mouseGridY >= 0) {
-      const px = this.mouseGridX * tileSize, py = this.mouseGridY * tileSize;
-      if (this.selectedFurnitureType) {
+    if (this.editor.mouseGridX >= 0 && this.editor.mouseGridY >= 0) {
+      const px = this.editor.mouseGridX * tileSize, py = this.editor.mouseGridY * tileSize;
+      if (this.editor.selectedFurnitureType) {
         ctx.fillStyle = 'rgba(78, 204, 163, 0.25)';
         ctx.fillRect(px, py, tileSize * 2, tileSize);
         ctx.strokeStyle = '#4ecca3'; ctx.lineWidth = 2;
@@ -1336,100 +1323,8 @@ export class GameEngine {
     return null;
   }
 
-  private handleMouseMove = (e: MouseEvent) => {
-    const result = this.screenToGrid(e);
-    if (!result) return;
-    const { gridX, gridY } = result;
-    this.mouseGridX = gridX;
-    this.mouseGridY = gridY;
-    if (this.dragging) {
-      const item = this.placedFurniture.find(f => f.id === this.dragging!.id);
-      if (item) {
-        item.x = Math.max(1, Math.min(this.config.gridWidth - 3, gridX));
-        item.y = Math.max(1, Math.min(this.config.gridHeight - 3, gridY));
-      }
-    }
-    if (this.editorMode) {
-      if (this.selectedFurnitureType) {
-        this.canvas.style.cursor = 'crosshair';
-      } else {
-        const overFurniture = this.findFurnitureAt(gridX, gridY);
-        this.canvas.style.cursor = overFurniture
-          ? (this.deleteMode ? 'pointer' : this.dragging ? 'grabbing' : 'grab')
-          : 'default';
-      }
-    } else {
-      // Non-editor: pointer on character hover, crosshair if agent is selected
-      if (this.selectedAgentId) {
-        this.canvas.style.cursor = 'crosshair';
-      } else {
-        this.canvas.style.cursor = this.findCharacterAt(gridX, gridY) ? 'pointer' : 'default';
-      }
-    }
-  };
-
-  private handleMouseDown = (e: MouseEvent) => {
-    if (!this.editorMode) return;
-    const result = this.screenToGrid(e);
-    if (!result) return;
-    const { gridX, gridY } = result;
-    if (e.button === 0) {
-      if (this.selectedFurnitureType) {
-        this.editorCallbacks?.onPlaceFurniture(this.selectedFurnitureType, gridX, gridY);
-        sfx.place();
-        return;
-      }
-      const hit = this.findFurnitureAt(gridX, gridY);
-      if (hit) {
-        if (this.deleteMode) {
-          // In delete mode: just notify React, skip drag/pickup
-          this.editorCallbacks?.onSelectFurniture(hit.id);
-          return;
-        }
-        this.selectedFurnitureId = hit.id;
-        this.editorCallbacks?.onSelectFurniture(hit.id);
-        this.dragging = { id: hit.id, offsetX: gridX - hit.x, offsetY: gridY - hit.y };
-        sfx.pickup();
-      } else {
-        this.selectedFurnitureId = null;
-        this.editorCallbacks?.onSelectFurniture(null);
-      }
-    }
-  };
-
-  private handleMouseUp = (e: MouseEvent) => {
-    if (!this.editorMode) return;
-    if (this.dragging) {
-      const result = this.screenToGrid(e);
-      if (!result) return;
-      const { gridX, gridY } = result;
-      this.editorCallbacks?.onMoveFurniture(
-        this.dragging.id,
-        Math.max(1, Math.min(this.config.gridWidth - 3, gridX)),
-        Math.max(1, Math.min(this.config.gridHeight - 3, gridY)),
-      );
-      sfx.place();
-      this.dragging = null;
-    }
-  };
-
-  private handleMouseLeave = () => {
-    this.mouseGridX = -1; this.mouseGridY = -1; this.dragging = null;
-    this.canvas.style.cursor = 'default';
-  };
-
-  private handleContextMenu = (e: MouseEvent) => {
-    if (!this.editorMode) return;
-    e.preventDefault();
-    const result = this.screenToGrid(e);
-    if (!result) return;
-    const { gridX, gridY } = result;
-    const hit = this.findFurnitureAt(gridX, gridY);
-    if (hit) hit.rotation = ((hit.rotation || 0) + 90) % 360;
-  };
-
   private handleClick = (e: MouseEvent) => {
-    if (this.editorMode) return;
+    if (this.editor.editorMode) return;
     const result = this.screenToGrid(e);
     if (!result) return;
     const { gridX, gridY } = result;
@@ -1471,190 +1366,15 @@ export class GameEngine {
     }
   };
 
-  // ── Touch Event Handlers ─────────────────────────────
-
-  private static readonly TAP_THRESHOLD = 12; // px movement before it's a drag, not a tap
-  private static readonly DOUBLE_TAP_MS = 300; // max interval between double-tap
-
-  private handleTouchStart = (e: TouchEvent) => {
-    e.preventDefault(); // prevent mouse event synthesis & scroll
-
-    if (e.touches.length === 2) {
-      // Pinch-to-zoom start: cancel any active one-finger drag/tap state so that
-      // lifting all fingers after a pinch cannot accidentally finalize a furniture drag.
-      this.touchDragging = null;
-      this.touchStartPos = null;
-      this.touchCurrentPos = null;
-      this.touchMoved = true;
-      this.pinchStartDist = touchDistance(e.touches[0], e.touches[1]);
-      this.pinchStartZoom = this.cameraZoom;
-      return;
-    }
-
-    const t = e.touches[0];
-    this.touchStartPos = { x: t.clientX, y: t.clientY };
-    this.touchCurrentPos = { x: t.clientX, y: t.clientY };
-    this.touchMoved = false;
-
-    const result1 = this.screenToGrid(t.clientX, t.clientY);
-    if (!result1) return;
-    const { gridX: gridX1, gridY: gridY1 } = result1;
-    this.mouseGridX = gridX1;
-    this.mouseGridY = gridY1;
-
-    // Editor mode: start dragging furniture immediately on touch
-    if (this.editorMode && e.touches.length === 1) {
-      if (this.selectedFurnitureType) {
-        // Will place on touchend if not moved
-      } else {
-        const hit = this.findFurnitureAt(gridX1, gridY1);
-        if (hit) {
-          if (this.deleteMode) {
-            // In delete mode: just notify React, skip drag
-            this.editorCallbacks?.onSelectFurniture(hit.id);
-          } else {
-            this.touchDragging = { id: hit.id, offsetX: gridX1 - hit.x, offsetY: gridY1 - hit.y };
-            this.selectedFurnitureId = hit.id;
-            this.editorCallbacks?.onSelectFurniture(hit.id);
-          }
-        }
-      }
-    }
-  };
-
-  private handleTouchMove = (e: TouchEvent) => {
-    e.preventDefault();
-
-    // Pinch-to-zoom
-    if (e.touches.length === 2) {
-      const dist = touchDistance(e.touches[0], e.touches[1]);
-
-      // Guard against zero/invalid starting distance (e.g., both fingers started at the
-      // same pixel): reinitialize from the first valid distance seen during move.
-      if (!this.pinchStartDist || this.pinchStartDist <= 0) {
-        if (dist <= 0) return;
-        this.pinchStartDist = dist;
-        this.pinchStartZoom = this.cameraZoom;
-      }
-
-      const scale = dist / this.pinchStartDist;
-      const newZoom = Math.max(1, Math.min(4, this.pinchStartZoom * scale));
-      this.cameraZoom = newZoom;
-      this.canvas.style.transform = `scale(${this.cameraZoom})`;
-      this.canvas.style.transformOrigin = 'center center';
-      return;
-    }
-
-    if (!this.touchStartPos) return;
-    const t = e.touches[0];
-    const dx = t.clientX - this.touchStartPos.x;
-    const dy = t.clientY - this.touchStartPos.y;
-
-    if (Math.abs(dx) > GameEngine.TAP_THRESHOLD || Math.abs(dy) > GameEngine.TAP_THRESHOLD) {
-      this.touchMoved = true;
-    }
-
-    // Track the latest finger position so handleTouchEnd can use the drop location
-    this.touchCurrentPos = { x: t.clientX, y: t.clientY };
-
-    const result2 = this.screenToGrid(t.clientX, t.clientY);
-    if (!result2) return;
-    const { gridX: gridX2, gridY: gridY2 } = result2;
-    this.mouseGridX = gridX2;
-    this.mouseGridY = gridY2;
-
-    // Editor mode: drag furniture (subtract grab offset to keep furniture under finger)
-    if (this.editorMode && this.touchDragging) {
-      const item = this.placedFurniture.find(f => f.id === this.touchDragging!.id);
-      if (item) {
-        item.x = Math.max(1, Math.min(this.config.gridWidth - 3, gridX2 - this.touchDragging.offsetX));
-        item.y = Math.max(1, Math.min(this.config.gridHeight - 3, gridY2 - this.touchDragging.offsetY));
-      }
-    }
-  };
-
-  private handleTouchEnd = (e: TouchEvent) => {
-    e.preventDefault();
-
-    // Pinch-to-zoom end — nothing extra to do
-    if (e.touches.length > 0) return;
-
-    // Editor mode: finish furniture drag, place, or double-tap rotate
-    if (this.editorMode) {
-      if (this.touchDragging) {
-        // touchCurrentPos is always set alongside touchStartPos in handleTouchStart and kept
-        // up-to-date in handleTouchMove, so it reliably reflects the finger's final position.
-        // Subtract the grab offset so the drop position matches what was shown during the drag.
-        const resultDrag = this.screenToGrid(this.touchCurrentPos!.x, this.touchCurrentPos!.y);
-        if (resultDrag) {
-          this.editorCallbacks?.onMoveFurniture(
-            this.touchDragging.id,
-            Math.max(1, Math.min(this.config.gridWidth - 3, resultDrag.gridX - this.touchDragging.offsetX)),
-            Math.max(1, Math.min(this.config.gridHeight - 3, resultDrag.gridY - this.touchDragging.offsetY)),
-          );
-          sfx.place();
-        }
-        this.touchDragging = null;
-      } else if (!this.touchMoved && this.touchStartPos) {
-        const resultTap = this.screenToGrid(this.touchStartPos.x, this.touchStartPos.y);
-        if (!resultTap) {
-          this.touchStartPos = null;
-          this.touchCurrentPos = null;
-          return;
-        }
-        const { gridX, gridY } = resultTap;
-        const now = Date.now();
-
-        // Double-tap furniture → rotate (mirrors desktop right-click in editor mode)
-        if (now - this.lastTapTime < GameEngine.DOUBLE_TAP_MS) {
-          const hit = this.findFurnitureAt(gridX, gridY);
-          if (hit) {
-            hit.rotation = ((hit.rotation || 0) + 90) % 360;
-            sfx.place();
-            this.lastTapTime = 0;
-            this.touchStartPos = null;
-            this.touchCurrentPos = null;
-            return;
-          }
-        }
-        this.lastTapTime = now;
-
-        // Single tap to place furniture
-        if (this.selectedFurnitureType) {
-          this.editorCallbacks?.onPlaceFurniture(this.selectedFurnitureType, gridX, gridY);
-          sfx.place();
-        }
-      }
-      this.touchStartPos = null;
-      this.touchCurrentPos = null;
-      return;
-    }
-
-    // ── Non-editor: tap interactions ──
-    if (this.touchMoved || !this.touchStartPos) {
-      this.touchStartPos = null;
-      this.touchCurrentPos = null;
-      return; // was a drag or pinch, not a tap
-    }
-
-    const resultTap2 = this.screenToGrid(this.touchStartPos.x, this.touchStartPos.y);
-    if (!resultTap2) {
-      this.touchStartPos = null;
-      this.touchCurrentPos = null;
-      return;
-    }
-    const { gridX, gridY } = resultTap2;
-
+  private handleTouchGridTap(gridX: number, gridY: number): void {
     const charId = this.findCharacterAt(gridX, gridY);
 
     if (charId && !charId.startsWith('sub-')) {
-      // Tap agent → select
       this.selectedAgentId = charId;
       this.selectionPulse = 0;
       sfx.click();
       this.gameCallbacks?.onCharacterClick(charId);
     } else if (this.selectedAgentId) {
-      // Tap empty tile → move selected agent
       const char = this.characters.get(this.selectedAgentId);
       if (char) {
         this.ensureObstacles();
@@ -1670,22 +1390,9 @@ export class GameEngine {
       }
       this.selectedAgentId = null;
     } else {
-      // Tap empty tile, no agent selected → deselect
       this.selectedAgentId = null;
     }
-
-    this.touchStartPos = null;
-    this.touchCurrentPos = null;
-  };
-
-  private handleTouchCancel = () => {
-    this.touchStartPos = null;
-    this.touchCurrentPos = null;
-    this.touchDragging = null;
-    this.touchMoved = false;
-    this.mouseGridX = -1;
-    this.mouseGridY = -1;
-  };
+  }
 
   // ── Helpers ──────────────────────────────────────────
 
@@ -2016,17 +1723,14 @@ export class GameEngine {
   // ── Editor API ──────────────────────────────────────────
 
   setEditorMode(enabled: boolean) {
-    this.editorMode = enabled;
-    this.selectedFurnitureType = null;
-    this.selectedFurnitureId = null;
-    this.canvas.style.cursor = 'default';
+    this.editor.setEditorMode(enabled);
   }
 
-  setEditorCallbacks(cb: EditorCallbacks) { this.editorCallbacks = cb; }
+  setEditorCallbacks(cb: EditorCallbacks) { this.editor.setEditorCallbacks(cb); }
   setGameCallbacks(cb: GameCallbacks) { this.gameCallbacks = cb; }
-  setDeleteMode(enabled: boolean) { this.deleteMode = enabled; }
-  setSelectedFurnitureType(type: string | null) { this.selectedFurnitureType = type; this.selectedFurnitureId = null; }
-  setSelectedFurnitureId(id: string | null) { this.selectedFurnitureId = id; this.selectedFurnitureType = null; }
+  setDeleteMode(enabled: boolean) { this.editor.setDeleteMode(enabled); }
+  setSelectedFurnitureType(type: string | null) { this.editor.setSelectedFurnitureType(type); }
+  setSelectedFurnitureId(id: string | null) { this.editor.setSelectedFurnitureId(id); }
 
   setLayout(furniture: PlacedFurniture[], seats?: Record<string, { x: number; y: number }>) {
     this.placedFurniture = furniture;


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
## Summary

This PR extracts editor and touch interaction logic from `GameEngine` into a dedicated `EditorController` class, reducing `GameEngine` complexity while preserving all existing input behavior through a delegating façade.

## What Changed

### New `src/game/EditorController.ts` (362 lines)
- Owns all editor/touch input state: `editorMode`, `deleteMode`, `selectedFurnitureType/Id`, mouse grid coordinates, drag state, touch start/current positions, pinch zoom state, and double-tap timing
- Exposes `attach()`/`detach()` lifecycle methods that register canvas listeners as a single unit
- Provides getters (`editorMode`, `selectedFurnitureType`, `selectedFurnitureId`, `mouseGridX`, `mouseGridY`) for the host to read state without exposing mutators
- Defines `EditorControllerHost` port with 7 narrow callbacks for furniture mutation/queries and non-editor touch tap delegation
- Receives a `screenToGrid` adapter and `sfx` sound functions via constructor injection

### `src/game/GameEngine.ts` reductions (2,044 → 1,723 lines, -321)
- Removed all private editor/touch state fields (dragging, touch positions, pinch state, tap timing, mouse grid coords)
- Removed 5 mouse handlers (`handleMouseMove/Down/Up/Leave`, `handleContextMenu`) — fully replaced by controller
- Removed 4 touch handlers (`handleTouchStart/Move/End/Cancel`) — replaced by controller's logic
- Extracted non-editor tap logic into `handleTouchGridTap(gridX, gridY)` method invoked via the host port
- Constructor instantiates `EditorController` with adapter functions that bind to engine methods (`findFurnitureAt`, `screenToGrid`, `findCharacterAt`)
- `dispose()` simplified to a single `editor.detach()` call
- `setEditorMode`, `setEditorCallbacks`, `setDeleteMode`, `setSelectedFurnitureType/Id` now one-line delegators
- Rendering paths updated to read `editor.editorMode`, `editor.selectedFurnitureId`, `editor.mouseGridX/Y`, `editor.selectedFurnitureType`

### New `src/game/EditorController.test.ts` (229 lines, 13 tests)
Pins behavior before migration:
- Lifecycle: `attach`/`detach` register/unregister all listeners atomically
- `setEditorMode(true)` resets selected type/id and cursor
- Mouse primary-down places selected furniture with place sound
- Mouse down/up in delete mode selects without starting drag or pickup sound
- Mouse drag clamping (clamps to `gridWidth-3`/`gridHeight-3`) without offset subtraction, emits pickup+place
- Context menu rotates silently (no place sound)
- Touch drag subtracts grab offset for both preview and final placement
- Double-tap (<300ms) rotates with place sound
- Pinch zoom reinitializes from zero start distance and clamps to `1..4`
- Non-editor single taps delegate to `handleTouchGridTap`
- `touchcancel` aborts active drag without finalizing placement
- Exact 300ms threshold boundary — 300ms elapsed does NOT trigger rotate
- Non-editor cursor precedence: `crosshair` (selected agent) > `pointer` (character) > `default`

## Notable Implementation Details

- **Grab offset asymmetry preserved**: mouse drag ignores offset (preview uses raw grid coords), touch drag subtracts offset (preview uses `gridX - offsetX`) — a deliberate behavioral quirk now covered by tests
- **Pinch zero-distance guard**: `pinchStartDist <= 0` triggers reinitialization from the first valid distance during move events
- **Touch cancel safety**: clears `touchDragging` and `touchMoved` flags so a subsequent `touchend` cannot finalize a cancelled drag
- **Double-tap reset on rotate**: `lastTapTime = 0` after successful rotation prevents triple-tap chain reactions
- **Host port design**: `findCharacterAt`/`hasSelectedAgent`/`handleTouchGridTap` keep non-editor selection/pathfinding in `GameEngine`, avoiding cross-cutting concerns in the controller

## Impact
- `GameEngine.ts`: 2,044 → 1,723 lines (-321)
- Controller coverage: 86.2% statements / 73.1% branches / 91.7% lines
- All validation passes: `typecheck`, `test`, `test:coverage`, `build`, `git diff --check`

---

refactor(game): extract EditorController (Issue #51 Phase 2-full)

---

## Summary

This pull request completes Phase 2-full of Issue #51 by extracting the editor input logic from `GameEngine` into a dedicated `EditorController` module.

### Changes

**Documentation updates**
- **`CONTRIBUTING.md`**: Updated the `game/` directory structure documentation to reflect the new module layout. `GameEngine` is now described as the "rendering loop, pathfinding, and host façade," and three new files are documented:
  - `EditorController.ts` — mouse/touch editor input and listener lifecycle
  - `Schedule.ts` — day/night interpolation
  - `SubAgentFSM.ts` — sub-agent lifetime/fade planner
- **`README.md`**:
  - Clarified the auto-save behavior in the editor section: layouts now auto-save **2 seconds after the last furniture change**, while the explicit Save button remains available.
  - Updated the architecture table to describe `GameEngine`'s role more accurately (rendering loop, sprite animation, pathfinding, and host façade) and added a new row for `EditorController` describing it as the module responsible for mouse/touch editor state and canvas listener lifecycle.

### Notes

This PR contains only documentation changes corresponding to the Phase 2-full extraction. The actual code refactor (moving editor logic from `GameEngine.ts` into `EditorController.ts`, along with the separate extraction of `Schedule.ts` and `SubAgentFSM.ts`) is presumably already merged or tracked separately — only the doc updates are included in this diff.

---

## Summary

This PR addresses Issue #51 Phase 2-full by completing the extraction of the `EditorController` with additional robustness fixes and test coverage.

### Changes

**`src/game/EditorController.ts`**
- Added a guard in `handleMouseUp` so that only left-button (`button === 0`) mouseups finalize a drag. Right-button mouseups are now ignored, preventing unintended furniture commits when a drag is cancelled via the context menu.

**`src/game/EditorController.test.ts`**
- New test: aborts an active mouse drag if `mouseleave` fires before `mouseup`, ensuring no `onMoveFurniture` callback or place sound is emitted until a valid left-button mouseup completes the drag.
- New test: verifies that a right-click `mouseup` does not finalize a drag, and a subsequent left-button `mouseup` correctly commits the move.
- New test: verifies that a single touch tap (touchstart followed by touchend with no movement) places the selected furniture type at the tapped location and plays the place sound.
<!-- kody-pr-summary:end -->