### PR TITLE
test(infra): exclude .worktrees/** from Vitest discovery (#81)

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,6 +5,6 @@ export default defineConfig({
     environment: 'jsdom',
     setupFiles: ['./src/test/setup.ts'],
     clearMocks: true,
-    exclude: [...configDefaults.exclude, '**/dist/**'],
+    exclude: [...configDefaults.exclude, '**/dist/**', '**/.worktrees/**'],
   },
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,6 +5,6 @@ export default defineConfig({
     environment: 'jsdom',
     setupFiles: ['./src/test/setup.ts'],
     clearMocks: true,
-    exclude: [...configDefaults.exclude, '**/dist/**', '**/.worktrees/**'],
+    exclude: [...configDefaults.exclude, '**/dist/**', '.worktrees/**'],
   },
 });


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Exclude `.worktrees/**` from Vitest file discovery so sandboxed worktree checkouts (used by OMO workflows) are not treated as additional test roots. This prevents duplicate discovery of `src/` and `server/` test files from any leftover `.worktrees/*` directory, ensuring only the canonical checkout's tests are collected and run.

---

## Description

Fixed Vitest configuration to correctly exclude `.worktrees/**` from test discovery.

The exclude pattern was changed from `'**/.worktrees/**'` to `'.worktrees/**'` in `vitest.config.ts`. This ensures that git worktree directories are properly excluded from Vitest's test discovery, preventing test execution in worktree directories that may be created during development.

This is an infrastructure/configuration fix to prevent test runners from picking up files in `.worktrees` directories.
<!-- kody-pr-summary:end -->