### PR TITLE
fix(editor): persist canvas furniture rotation (#86)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -141,7 +141,7 @@ When editor mode is active:
 - Touch: single tap = place/select, double-tap = rotate, drag = move
 - Clicking furniture in delete mode immediately deletes it
 
-The engine fires `EditorCallbacks` (`onPlaceFurniture`, `onSelectFurniture`, `onMoveFurniture`) back to React, which updates the layout store.
+The engine fires `EditorCallbacks` (`onPlaceFurniture`, `onSelectFurniture`, `onMoveFurniture`, `onRotateFurniture`) back to React, which updates the layout store. Rotation callbacks carry the exact post-rotation angle so the canvas and store cannot double-increment while sharing a furniture object.
 
 ## Non-Obvious Gotchas
 

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,0 +1,90 @@
+import React from 'react';
+import { act, render } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { PlacedFurniture } from '../shared/types';
+import { App } from './App';
+
+const testState = vi.hoisted(() => ({
+  updateFurniture: vi.fn(),
+  pixelOfficeProps: null as null | {
+    onRotateFurniture: (id: string, rotation: number) => void;
+  },
+}));
+
+vi.mock('./hooks/useAgentStore', () => ({
+  useAgentStore: () => ({
+    agents: [],
+    connected: true,
+    toggleAgent: vi.fn(),
+    toggleAll: vi.fn(),
+    updateTags: vi.fn(),
+    updateRecipe: vi.fn(),
+    activeRoomId: 'default',
+    setActiveRoomId: vi.fn(),
+    roomAgents: [],
+  }),
+}));
+
+vi.mock('./hooks/useLayoutStore', () => ({
+  useLayoutStore: () => ({
+    layouts: [],
+    activeLayout: {
+      id: 'default',
+      name: 'Default',
+      width: 24,
+      height: 16,
+      furniture: [{ id: 'desk-1', type: 'DESK', x: 3, y: 4, rotation: 0 }],
+      seats: {},
+    },
+    isDirty: false,
+    catalog: [],
+    loadLayoutById: vi.fn(),
+    saveActiveLayout: vi.fn(),
+    createLayout: vi.fn(),
+    deleteLayout: vi.fn(),
+    updateFurniture: testState.updateFurniture,
+  }),
+}));
+
+vi.mock('./components/PixelOffice', () => ({
+  PixelOffice: (props: NonNullable<typeof testState.pixelOfficeProps>) => {
+    testState.pixelOfficeProps = props;
+    return null;
+  },
+}));
+vi.mock('./components/AgentSidebar', () => ({ AgentSidebar: () => null }));
+vi.mock('./components/AgentDetailPanel', () => ({ AgentDetailPanel: () => null }));
+vi.mock('./components/LayoutEditor', () => ({ LayoutEditor: () => null }));
+vi.mock('./components/SoundControls', () => ({ SoundControls: () => null }));
+vi.mock('./components/RoomSwitcher', () => ({ RoomSwitcher: () => null }));
+vi.mock('./components/MessageTicker', () => ({ default: () => null }));
+
+describe('App furniture rotation persistence', () => {
+  beforeEach(() => {
+    testState.updateFurniture.mockReset();
+    testState.pixelOfficeProps = null;
+  });
+
+  it('applies the exact engine rotation through the layout-store updater', () => {
+    render(<App />);
+
+    act(() => {
+      testState.pixelOfficeProps?.onRotateFurniture('desk-1', 90);
+    });
+
+    expect(testState.updateFurniture).toHaveBeenCalledOnce();
+    const update = testState.updateFurniture.mock.calls[0][0] as (
+      furniture: PlacedFurniture[],
+    ) => PlacedFurniture[];
+
+    // GameEngine already mutated the shared object to 90°. The React boundary
+    // must persist that exact angle instead of adding another quarter turn.
+    const engineOwnedFurniture: PlacedFurniture[] = [
+      { id: 'desk-1', type: 'DESK', x: 3, y: 4, rotation: 90 },
+    ];
+    expect(update(engineOwnedFurniture)).toEqual([
+      { id: 'desk-1', type: 'DESK', x: 3, y: 4, rotation: 90 },
+    ]);
+  });
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -64,14 +64,16 @@ export const App: React.FC = () => {
     setSelectedFurnitureType(null);
   }, [deleteMode, updateFurniture]);
 
-  // Rotate selected furniture
-  const handleRotateFurniture = useCallback((id: string) => {
-    if (!activeLayout) return;
-    const newFurniture = activeLayout.furniture.map(f =>
-      f.id === id ? { ...f, rotation: ((f.rotation || 0) + 90) % 360 } : f
-    );
-    updateFurniture(newFurniture);
-  }, [activeLayout, updateFurniture]);
+  // Toolbar rotations increment the latest store value. Canvas rotations pass
+  // the exact angle already applied by GameEngine, avoiding a second 90° turn
+  // when the engine and React temporarily share the same furniture object.
+  const handleRotateFurniture = useCallback((id: string, rotation?: number) => {
+    updateFurniture(furniture => furniture.map(f =>
+      f.id === id
+        ? { ...f, rotation: rotation ?? ((f.rotation || 0) + 90) % 360 }
+        : f
+    ));
+  }, [updateFurniture]);
 
   // Delete furniture
   const handleDeleteFurniture = useCallback((id: string) => {
@@ -159,6 +161,7 @@ export const App: React.FC = () => {
             onPlaceFurniture={handlePlaceFurniture}
             onSelectFurniture={handleSelectFurniture}
             onMoveFurniture={handleMoveFurniture}
+            onRotateFurniture={handleRotateFurniture}
             onCharacterClick={handleCharacterClick}
           />
         </div>

--- a/src/components/PixelOffice.tsx
+++ b/src/components/PixelOffice.tsx
@@ -15,13 +15,14 @@ interface Props {
   onPlaceFurniture: (type: string, gridX: number, gridY: number) => void;
   onSelectFurniture: (id: string | null) => void;
   onMoveFurniture: (id: string, gridX: number, gridY: number) => void;
+  onRotateFurniture: (id: string, rotation: number) => void;
   onCharacterClick?: (agentId: string) => void;
 }
 
 export const PixelOffice: React.FC<Props> = ({
   agents, editorMode, deleteMode, activeLayout,
   selectedFurnitureType,
-  onPlaceFurniture, onSelectFurniture, onMoveFurniture,
+  onPlaceFurniture, onSelectFurniture, onMoveFurniture, onRotateFurniture,
   onCharacterClick,
 }) => {
   const canvasRef = useRef<HTMLCanvasElement>(null);
@@ -51,8 +52,13 @@ export const PixelOffice: React.FC<Props> = ({
   useEffect(() => {
     const engine = engineRef.current;
     if (!engine) return;
-    engine.setEditorCallbacks({ onPlaceFurniture, onSelectFurniture, onMoveFurniture });
-  }, [onPlaceFurniture, onSelectFurniture, onMoveFurniture]);
+    engine.setEditorCallbacks({
+      onPlaceFurniture,
+      onSelectFurniture,
+      onMoveFurniture,
+      onRotateFurniture,
+    });
+  }, [onPlaceFurniture, onSelectFurniture, onMoveFurniture, onRotateFurniture]);
 
   // Wire game callbacks (character click)
   useEffect(() => {

--- a/src/game/EditorController.test.ts
+++ b/src/game/EditorController.test.ts
@@ -31,7 +31,9 @@ describe('EditorController', () => {
       screenToGrid: vi.fn((x: number, y: number) => ({ gridX: x, gridY: y })),
       findFurnitureAt: vi.fn(() => furniture),
       previewFurnitureMove: vi.fn(),
-      rotateFurnitureAt: vi.fn(() => furniture !== null),
+      rotateFurnitureAt: vi.fn(() => furniture
+        ? { id: furniture.id, rotation: 90 }
+        : null),
       findCharacterAt: vi.fn(() => null),
       hasSelectedAgent: vi.fn(() => false),
       handleTouchGridTap: vi.fn(),
@@ -41,6 +43,7 @@ describe('EditorController', () => {
       onPlaceFurniture: vi.fn(),
       onSelectFurniture: vi.fn(),
       onMoveFurniture: vi.fn(),
+      onRotateFurniture: vi.fn(),
     };
     controller = new EditorController(
       canvas,
@@ -115,12 +118,14 @@ describe('EditorController', () => {
     expect(sounds.place).toHaveBeenCalledOnce();
   });
 
-  it('rotates furniture on editor context menu without adding sound', () => {
+  it('reports the resulting context-menu rotation without adding sound', () => {
+    furniture = { id: 'desk-1', x: 3, y: 4 };
     controller.attach();
     controller.setEditorMode(true);
     canvas.dispatchEvent(new MouseEvent('contextmenu', { clientX: 4, clientY: 5, cancelable: true }));
 
     expect(host.rotateFurnitureAt).toHaveBeenCalledWith(4, 5);
+    expect(callbacks.onRotateFurniture).toHaveBeenCalledWith('desk-1', 90);
     expect(sounds.place).not.toHaveBeenCalled();
   });
 
@@ -151,6 +156,7 @@ describe('EditorController', () => {
     canvas.dispatchEvent(touchEvent('touchend', []));
 
     expect(host.rotateFurnitureAt).toHaveBeenCalledWith(4, 5);
+    expect(callbacks.onRotateFurniture).toHaveBeenCalledWith('desk-1', 90);
     expect(sounds.place).toHaveBeenCalledOnce();
   });
 

--- a/src/game/EditorController.ts
+++ b/src/game/EditorController.ts
@@ -4,6 +4,7 @@ export interface EditorCallbacks {
   onPlaceFurniture: (type: string, gridX: number, gridY: number) => void;
   onSelectFurniture: (id: string | null) => void;
   onMoveFurniture: (id: string, gridX: number, gridY: number) => void;
+  onRotateFurniture: (id: string, rotation: number) => void;
 }
 
 export interface FurnitureHit {
@@ -12,11 +13,16 @@ export interface FurnitureHit {
   y: number;
 }
 
+export interface FurnitureRotation {
+  id: string;
+  rotation: number;
+}
+
 export interface EditorControllerHost {
   screenToGrid: (clientX: number, clientY: number) => { gridX: number; gridY: number } | null;
   findFurnitureAt: (gridX: number, gridY: number) => FurnitureHit | null;
   previewFurnitureMove: (id: string, gridX: number, gridY: number) => void;
-  rotateFurnitureAt: (gridX: number, gridY: number) => boolean;
+  rotateFurnitureAt: (gridX: number, gridY: number) => FurnitureRotation | null;
   findCharacterAt: (gridX: number, gridY: number) => string | null;
   hasSelectedAgent: () => boolean;
   handleTouchGridTap: (gridX: number, gridY: number) => void;
@@ -212,7 +218,8 @@ export class EditorController {
     event.preventDefault();
     const result = this.host.screenToGrid(event.clientX, event.clientY);
     if (!result) return;
-    this.host.rotateFurnitureAt(result.gridX, result.gridY);
+    const rotated = this.host.rotateFurnitureAt(result.gridX, result.gridY);
+    if (rotated) this.callbacks?.onRotateFurniture(rotated.id, rotated.rotation);
   };
 
   private handleTouchStart = (event: TouchEvent): void => {
@@ -323,7 +330,9 @@ export class EditorController {
 
         const now = this.now();
         if (now - this.lastTapTime < EditorController.DOUBLE_TAP_MS) {
-          if (this.host.rotateFurnitureAt(result.gridX, result.gridY)) {
+          const rotated = this.host.rotateFurnitureAt(result.gridX, result.gridY);
+          if (rotated) {
+            this.callbacks?.onRotateFurniture(rotated.id, rotated.rotation);
             this.sounds.place();
             this.lastTapTime = 0;
             this.touchStartPos = null;

--- a/src/game/GameEngine.integration.test.ts
+++ b/src/game/GameEngine.integration.test.ts
@@ -209,6 +209,7 @@ describe('GameEngine integration: editor adapters', () => {
       onPlaceFurniture: vi.fn(),
       onSelectFurniture: vi.fn(),
       onMoveFurniture: vi.fn(),
+      onRotateFurniture: vi.fn(),
     };
     gameCallbacks = { onCharacterClick: vi.fn() };
 
@@ -289,6 +290,7 @@ describe('GameEngine integration: editor adapters', () => {
       }),
     );
     expect(engine.getPlacedFurniture()[0].rotation).toBe(90);
+    expect(editorCallbacks.onRotateFurniture).toHaveBeenCalledWith('desk-1', 90);
   });
 });
 

--- a/src/game/GameEngine.ts
+++ b/src/game/GameEngine.ts
@@ -232,9 +232,9 @@ export class GameEngine {
         },
         rotateFurnitureAt: (gridX, gridY) => {
           const item = this.findFurnitureAt(gridX, gridY);
-          if (!item) return false;
+          if (!item) return null;
           item.rotation = ((item.rotation || 0) + 90) % 360;
-          return true;
+          return { id: item.id, rotation: item.rotation };
         },
         findCharacterAt: (gridX, gridY) => this.findCharacterAt(gridX, gridY),
         hasSelectedAgent: () => this.selectedAgentId !== null,


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
## Summary

This PR fixes a furniture rotation bug where canvas-initiated rotations (via right-click or touch double-tap) were being doubled — once by the game engine and again by the React store — causing persisted rotations to drift from what the user actually saw on canvas.

### Root Cause
The `GameEngine.rotateFurnitureAt` adapter mutated the shared furniture object to its final angle, then returned `true`. The React layer (via `App.handleRotateFurniture`) blindly added another `+90°` on top of the now-already-rotated object, producing a 180° turn from a single right-click.

### Functional Changes

- **`GameEngine.rotateFurnitureAt`** now returns the post-rotation `{ id, rotation }` instead of a boolean, so the React boundary can persist the exact angle the engine already applied.
- **`EditorController`** accepts a new `onRotateFurniture(id, rotation)` callback and invokes it from both the right-click (`contextmenu`) and touch double-tap paths using the engine-reported result.
- **`PixelOffice`** exposes the new callback through its props and forwards it to `engine.setEditorCallbacks`.
- **`App.handleRotateFurniture`** is rewritten as a functional store updater. When `rotation` is provided it uses that value verbatim; when omitted (toolbar button) it still increments the latest store value by 90°.

### Tests Added/Modified
- `EditorController.test.ts` — asserts both context-menu and touch double-tap paths fire `onRotateFurniture` with the exact 90° result.
- `GameEngine.integration.test.ts` — confirms the editor adapter reports rotation back through the callback.
- `App.test.tsx` (new) — verifies the layout-store updater persists the engine's 90° angle without adding a second quarter turn.
<!-- kody-pr-summary:end -->