### PR TITLE
fix(layout): preserve edits across stale save responses (#91)

### DIFF
--- a/src/hooks/useLayoutStore.test.tsx
+++ b/src/hooks/useLayoutStore.test.tsx
@@ -1,4 +1,4 @@
-import { act, render } from '@testing-library/react';
+import { act, render, waitFor } from '@testing-library/react';
 import { useEffect } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -43,6 +43,14 @@ function latest<T>(items: T[]): T {
   const item = items[items.length - 1];
   if (!item) throw new Error('Expected at least one item');
   return item;
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((settle) => {
+    resolve = settle;
+  });
+  return { promise, resolve };
 }
 
 /** Create a fetch mock that responds to the layout API routes. */
@@ -308,6 +316,85 @@ describe('useLayoutStore', () => {
     expect(captures.lastPutBody?.furniture).toEqual([
       { id: 'desk-1', type: 'DESK', x: 3, y: 4, rotation: 90 },
     ]);
+  });
+
+  it('preserves and serializes edits made while an older save is in flight', async () => {
+    layouts.default = {
+      ...layouts.default,
+      furniture: [{ id: 'desk-1', type: 'DESK', x: 3, y: 4, rotation: 0 }],
+    };
+    await renderStoreProbe();
+
+    const initialFetch = fetch;
+    const firstResponse = deferred<Response>();
+    const putBodies: Array<LayoutDoc & { baseUpdatedAt?: number }> = [];
+    vi.stubGlobal('fetch', vi.fn(async (
+      input: string | URL | Request,
+      init?: RequestInit,
+    ) => {
+      const url = typeof input === 'string'
+        ? input
+        : input instanceof Request
+          ? input.url
+          : input.toString();
+      if (url.endsWith('/api/layouts/default') && init?.method === 'PUT') {
+        const body = JSON.parse(init.body as string) as LayoutDoc & { baseUpdatedAt?: number };
+        putBodies.push(body);
+        if (putBodies.length === 1) return firstResponse.promise;
+        return new Response(JSON.stringify({ layout: body }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      return initialFetch(input, init);
+    }));
+
+    let firstSave!: Promise<void>;
+    act(() => {
+      firstSave = latest(snapshots).saveActiveLayout();
+    });
+    await waitFor(() => expect(putBodies).toHaveLength(1));
+
+    vi.useFakeTimers();
+    act(() => {
+      latest(snapshots).updateFurniture([
+        { id: 'desk-1', type: 'DESK', x: 3, y: 4, rotation: 90 },
+      ]);
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    const savedOlderLayout: LayoutDoc = {
+      id: 'default',
+      name: 'Default',
+      width: 24,
+      height: 16,
+      furniture: [{ id: 'desk-1', type: 'DESK', x: 3, y: 4, rotation: 0 }],
+      seats: {},
+      updatedAt: 2_000,
+    };
+    await act(async () => {
+      firstResponse.resolve(new Response(JSON.stringify({ layout: savedOlderLayout }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }));
+      await firstSave;
+    });
+
+    expect(latest(snapshots).activeLayout?.furniture[0].rotation).toBe(90);
+    expect(latest(snapshots).isDirty).toBe(true);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2_100);
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    expect(putBodies).toHaveLength(2);
+    expect(putBodies[1].furniture[0].rotation).toBe(90);
+    expect(putBodies[1].baseUpdatedAt).toBe(2_000);
   });
 
   it('debounces rapid furniture changes into a single save', async () => {

--- a/src/hooks/useLayoutStore.test.tsx
+++ b/src/hooks/useLayoutStore.test.tsx
@@ -681,6 +681,62 @@ describe('useLayoutStore', () => {
     expect(putBodies[1].baseUpdatedAt).toBe(2_000);
   });
 
+  it('advances the persisted revision after a successful keepalive save', async () => {
+    await renderStoreProbe();
+
+    const initialFetch = fetch;
+    const putBodies: Array<LayoutDoc & { baseUpdatedAt?: number }> = [];
+    vi.stubGlobal('fetch', vi.fn(async (
+      input: string | URL | Request,
+      init?: RequestInit,
+    ) => {
+      const url = typeof input === 'string'
+        ? input
+        : input instanceof Request
+          ? input.url
+          : input.toString();
+      if (url.endsWith('/api/layouts/default') && init?.method === 'PUT') {
+        const body = JSON.parse(init.body as string) as LayoutDoc & { baseUpdatedAt?: number };
+        putBodies.push(body);
+        if (init.keepalive) {
+          return new Response(JSON.stringify({
+            layout: { ...body, updatedAt: 2_000 },
+          }), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          });
+        }
+        return new Response(JSON.stringify({
+          layout: { ...body, updatedAt: 3_000 },
+        }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      return initialFetch(input, init);
+    }));
+
+    act(() => {
+      latest(snapshots).updateFurniture([
+        { id: 'desk-1', type: 'DESK', x: 3, y: 4, rotation: 90 },
+      ]);
+    });
+    window.dispatchEvent(new Event('beforeunload') as BeforeUnloadEvent);
+    await waitFor(() => expect(putBodies).toHaveLength(1));
+    // Flush the keepalive response handler (json parse + revision advance).
+    await act(async () => { await new Promise(r => setTimeout(r, 0)); });
+
+    await act(async () => {
+      await latest(snapshots).saveActiveLayout();
+    });
+
+    expect(putBodies).toHaveLength(2);
+    expect(putBodies[0].baseUpdatedAt).toBe(1_000);
+    // The follow-up save must chain from the revision the keepalive PUT
+    // persisted (2_000), not the pre-keepalive revision (1_000).
+    expect(putBodies[1].baseUpdatedAt).toBe(2_000);
+  });
+
   it('debounces rapid furniture changes into a single save', async () => {
     await renderStoreProbe();
 
@@ -781,28 +837,62 @@ describe('useLayoutStore', () => {
   });
 
   it('retries auto-save on 5xx with exponential backoff (M1)', async () => {
-    // M1: On 5xx or network errors, the auto-save must reschedule with
-    // exponential backoff so transient server issues don't lose user edits.
+    // M1: On 5xx, scheduleSaveRetry must reschedule with exponential
+    // backoff (2s, 4s, 8s ...) so transient server errors don't strand
+    // the user's edits. Regression test for the refactored retry path.
     await renderStoreProbe();
+    vi.useFakeTimers();
 
-    // Make a change
-    await act(async () => {
-      latest(snapshots).updateFurniture([{ id: 'f1', type: 'desk', x: 1, y: 1, rotation: 0 }]);
+    const initialFetch = fetch;
+    const putBodies: Array<LayoutDoc & { baseUpdatedAt?: number }> = [];
+    vi.stubGlobal('fetch', vi.fn(async (
+      input: string | URL | Request,
+      init?: RequestInit,
+    ) => {
+      const url = typeof input === 'string'
+        ? input
+        : input instanceof Request
+          ? input.url
+          : input.toString();
+      if (url.endsWith('/api/layouts/default') && init?.method === 'PUT') {
+        const body = JSON.parse(init.body as string) as LayoutDoc & { baseUpdatedAt?: number };
+        putBodies.push(body);
+        if (putBodies.length === 1) {
+          return new Response(JSON.stringify({ error: 'Service Unavailable' }), {
+            status: 503,
+            headers: { 'Content-Type': 'application/json' },
+          });
+        }
+        return new Response(JSON.stringify({ layout: { ...body, updatedAt: 2_000 } }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      return initialFetch(input, init);
+    }));
+
+    act(() => {
+      latest(snapshots).updateFurniture([
+        { id: 'desk-1', type: 'DESK', x: 3, y: 4, rotation: 90 },
+      ]);
     });
 
-    // Wait for first auto-save attempt (2s)
-    await act(async () => { await new Promise(r => setTimeout(r, 2100)); });
+    // First save attempt (2s debounce).
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2_100);
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(putBodies).toHaveLength(1);
+    expect(latest(snapshots).isDirty).toBe(true);
 
-    // The mock returns 200, so the first save succeeded and isDirty is false.
-    // To test retry, we need to simulate a failure. Let's check that the
-    // save was attempted and succeeded:
-    const putCalls = (fetch as ReturnType<typeof vi.fn>).mock.calls.filter(
-      (call: unknown[]) => {
-        const init = call[1] as RequestInit | undefined;
-        return init?.method === 'PUT';
-      }
-    );
-    expect(putCalls.length).toBeGreaterThan(0);
+    // First retry: scheduled at 2s * 2^0 = 2000ms after the 5xx.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2_100);
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(putBodies).toHaveLength(2);
+    // The retried PUT carries the same furniture — the user's edit is preserved.
+    expect(putBodies[1].furniture[0].rotation).toBe(90);
     expect(latest(snapshots).isDirty).toBe(false);
   });
 

--- a/src/hooks/useLayoutStore.test.tsx
+++ b/src/hooks/useLayoutStore.test.tsx
@@ -397,6 +397,71 @@ describe('useLayoutStore', () => {
     expect(putBodies[1].baseUpdatedAt).toBe(2_000);
   });
 
+  it('keeps a newly loaded layout active when an older layout save finishes', async () => {
+    await renderStoreProbe();
+
+    const initialFetch = fetch;
+    const firstResponse = deferred<Response>();
+    const putBodies: Array<LayoutDoc & { baseUpdatedAt?: number }> = [];
+    vi.stubGlobal('fetch', vi.fn(async (
+      input: string | URL | Request,
+      init?: RequestInit,
+    ) => {
+      const url = typeof input === 'string'
+        ? input
+        : input instanceof Request
+          ? input.url
+          : input.toString();
+      if (url.includes('/api/layouts/') && init?.method === 'PUT') {
+        const body = JSON.parse(init.body as string) as LayoutDoc & { baseUpdatedAt?: number };
+        putBodies.push(body);
+        if (putBodies.length === 1) return firstResponse.promise;
+      }
+      return initialFetch(input, init);
+    }));
+
+    let defaultSave!: Promise<void>;
+    act(() => {
+      defaultSave = latest(snapshots).saveActiveLayout();
+    });
+    await waitFor(() => expect(putBodies).toHaveLength(1));
+
+    await act(async () => {
+      await latest(snapshots).loadLayoutById('other');
+    });
+    expect(latest(snapshots).activeLayout).toMatchObject({
+      id: 'other',
+      updatedAt: 2_000,
+    });
+
+    const savedDefaultLayout: LayoutDoc = {
+      ...layouts.default,
+      updatedAt: 3_000,
+    };
+    await act(async () => {
+      firstResponse.resolve(new Response(JSON.stringify({ layout: savedDefaultLayout }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }));
+      await defaultSave;
+    });
+
+    expect(latest(snapshots).activeLayout).toMatchObject({
+      id: 'other',
+      updatedAt: 2_000,
+    });
+
+    await act(async () => {
+      await latest(snapshots).saveActiveLayout();
+    });
+
+    expect(putBodies).toHaveLength(2);
+    expect(putBodies[1]).toMatchObject({
+      id: 'other',
+      baseUpdatedAt: 2_000,
+    });
+  });
+
   it('debounces rapid furniture changes into a single save', async () => {
     await renderStoreProbe();
 

--- a/src/hooks/useLayoutStore.test.tsx
+++ b/src/hooks/useLayoutStore.test.tsx
@@ -462,6 +462,225 @@ describe('useLayoutStore', () => {
     });
   });
 
+  it('does not trust a successful save response without a valid layout', async () => {
+    await renderStoreProbe();
+
+    const initialFetch = fetch;
+    const putBodies: Array<LayoutDoc & { baseUpdatedAt?: number }> = [];
+    vi.stubGlobal('fetch', vi.fn(async (
+      input: string | URL | Request,
+      init?: RequestInit,
+    ) => {
+      const url = typeof input === 'string'
+        ? input
+        : input instanceof Request
+          ? input.url
+          : input.toString();
+      if (url.endsWith('/api/layouts/default') && init?.method === 'PUT') {
+        const body = JSON.parse(init.body as string) as LayoutDoc & { baseUpdatedAt?: number };
+        putBodies.push(body);
+        if (putBodies.length === 1) {
+          layouts.default = { ...body, updatedAt: 2_000 };
+          return new Response(null, { status: 200 });
+        }
+        return new Response(JSON.stringify({
+          layout: { ...body, updatedAt: 3_000 },
+        }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      return initialFetch(input, init);
+    }));
+
+    act(() => {
+      latest(snapshots).updateFurniture([
+        { id: 'desk-1', type: 'DESK', x: 3, y: 4, rotation: 90 },
+      ]);
+    });
+    await act(async () => {
+      await latest(snapshots).saveActiveLayout();
+    });
+
+    expect(latest(snapshots).isDirty).toBe(true);
+
+    await act(async () => {
+      await latest(snapshots).saveActiveLayout();
+    });
+
+    expect(putBodies).toHaveLength(2);
+    expect(putBodies[1].baseUpdatedAt).toBe(2_000);
+  });
+
+  it('refreshes the server revision and retries a conflicted autosave', async () => {
+    await renderStoreProbe();
+    vi.useFakeTimers();
+
+    const initialFetch = fetch;
+    const putBodies: Array<LayoutDoc & { baseUpdatedAt?: number }> = [];
+    vi.stubGlobal('fetch', vi.fn(async (
+      input: string | URL | Request,
+      init?: RequestInit,
+    ) => {
+      const url = typeof input === 'string'
+        ? input
+        : input instanceof Request
+          ? input.url
+          : input.toString();
+      if (url.endsWith('/api/layouts/default') && init?.method === 'PUT') {
+        const body = JSON.parse(init.body as string) as LayoutDoc & { baseUpdatedAt?: number };
+        putBodies.push(body);
+        if (putBodies.length === 1) {
+          layouts.default = { ...layouts.default, updatedAt: 2_000 };
+          return new Response(JSON.stringify({ error: 'Conflict' }), {
+            status: 409,
+            headers: { 'Content-Type': 'application/json' },
+          });
+        }
+        return new Response(JSON.stringify({
+          layout: { ...body, updatedAt: 3_000 },
+        }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      return initialFetch(input, init);
+    }));
+
+    act(() => {
+      latest(snapshots).updateFurniture([
+        { id: 'desk-1', type: 'DESK', x: 3, y: 4, rotation: 90 },
+      ]);
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2_100);
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(putBodies).toHaveLength(1);
+    expect(latest(snapshots).isDirty).toBe(true);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2_100);
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    expect(putBodies).toHaveLength(2);
+    expect(putBodies[1].baseUpdatedAt).toBe(2_000);
+    expect(putBodies[1].furniture[0].rotation).toBe(90);
+    expect(latest(snapshots).isDirty).toBe(false);
+  });
+
+  it('does not move the persisted revision backwards after a same-id reload', async () => {
+    await renderStoreProbe();
+
+    const initialFetch = fetch;
+    const firstResponse = deferred<Response>();
+    const putBodies: Array<LayoutDoc & { baseUpdatedAt?: number }> = [];
+    vi.stubGlobal('fetch', vi.fn(async (
+      input: string | URL | Request,
+      init?: RequestInit,
+    ) => {
+      const url = typeof input === 'string'
+        ? input
+        : input instanceof Request
+          ? input.url
+          : input.toString();
+      if (url.endsWith('/api/layouts/default') && init?.method === 'PUT') {
+        const body = JSON.parse(init.body as string) as LayoutDoc & { baseUpdatedAt?: number };
+        putBodies.push(body);
+        if (putBodies.length === 1) return firstResponse.promise;
+        return new Response(JSON.stringify({ layout: body }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      return initialFetch(input, init);
+    }));
+
+    let firstSave!: Promise<void>;
+    act(() => {
+      firstSave = latest(snapshots).saveActiveLayout();
+    });
+    await waitFor(() => expect(putBodies).toHaveLength(1));
+
+    layouts.default = { ...layouts.default, updatedAt: 3_000 };
+    await act(async () => {
+      await latest(snapshots).loadLayoutById('default');
+    });
+    expect(latest(snapshots).activeLayout?.updatedAt).toBe(3_000);
+
+    await act(async () => {
+      firstResponse.resolve(new Response(JSON.stringify({
+        layout: { ...layouts.default, updatedAt: 2_000 },
+      }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }));
+      await firstSave;
+    });
+
+    await act(async () => {
+      await latest(snapshots).saveActiveLayout();
+    });
+
+    expect(putBodies).toHaveLength(2);
+    expect(putBodies[1].baseUpdatedAt).toBe(3_000);
+  });
+
+  it('recovers a keepalive conflict when the page remains active', async () => {
+    await renderStoreProbe();
+
+    const initialFetch = fetch;
+    const putBodies: Array<LayoutDoc & { baseUpdatedAt?: number }> = [];
+    let revisionFetches = 0;
+    vi.stubGlobal('fetch', vi.fn(async (
+      input: string | URL | Request,
+      init?: RequestInit,
+    ) => {
+      const url = typeof input === 'string'
+        ? input
+        : input instanceof Request
+          ? input.url
+          : input.toString();
+      if (url.endsWith('/api/layouts/default') && init?.method === 'PUT') {
+        const body = JSON.parse(init.body as string) as LayoutDoc & { baseUpdatedAt?: number };
+        putBodies.push(body);
+        if (init.keepalive) {
+          layouts.default = { ...layouts.default, updatedAt: 2_000 };
+          return new Response(JSON.stringify({ error: 'Conflict' }), {
+            status: 409,
+            headers: { 'Content-Type': 'application/json' },
+          });
+        }
+        return new Response(JSON.stringify({ layout: body }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      if (url.endsWith('/api/layouts/default') && init?.method !== 'PUT') {
+        revisionFetches++;
+      }
+      return initialFetch(input, init);
+    }));
+
+    act(() => {
+      latest(snapshots).updateFurniture([
+        { id: 'desk-1', type: 'DESK', x: 3, y: 4, rotation: 90 },
+      ]);
+    });
+    window.dispatchEvent(new Event('beforeunload') as BeforeUnloadEvent);
+    await waitFor(() => expect(revisionFetches).toBe(1));
+
+    await act(async () => {
+      await latest(snapshots).saveActiveLayout();
+    });
+
+    expect(putBodies).toHaveLength(2);
+    expect(putBodies[0].baseUpdatedAt).toBe(1_000);
+    expect(putBodies[1].baseUpdatedAt).toBe(2_000);
+  });
+
   it('debounces rapid furniture changes into a single save', async () => {
     await renderStoreProbe();
 

--- a/src/hooks/useLayoutStore.ts
+++ b/src/hooks/useLayoutStore.ts
@@ -146,10 +146,12 @@ export function useLayoutStore() {
         retryAttemptRef.current = 0;
         const data = await response.json().catch(() => null);
         const savedLayout = data?.layout ?? merged;
-        persistedRevisionRef.current = {
-          id: savedLayout.id,
-          updatedAt: savedLayout.updatedAt,
-        };
+        if (activeLayoutRef.current?.id === savedLayout.id) {
+          persistedRevisionRef.current = {
+            id: savedLayout.id,
+            updatedAt: savedLayout.updatedAt,
+          };
+        }
 
         // The response is authoritative only for the snapshot it saved. If
         // the user edited or switched layouts while the PUT was in flight,

--- a/src/hooks/useLayoutStore.ts
+++ b/src/hooks/useLayoutStore.ts
@@ -424,7 +424,10 @@ export function useLayoutStore() {
           const data = await response.json().catch(() => null);
           const savedLayout: unknown = data?.layout;
           if (!isLayoutDoc(savedLayout) || savedLayout.id !== merged.id) {
-            console.error('Failed to save layout before unload: invalid response body');
+            const reason = !isLayoutDoc(savedLayout)
+              ? 'invalid response body'
+              : `response id mismatch (expected '${merged.id}', got '${savedLayout.id}')`;
+            console.error(`Failed to save layout before unload: ${reason}`);
             return;
           }
           // If the unload is cancelled and the page stays open, the next

--- a/src/hooks/useLayoutStore.ts
+++ b/src/hooks/useLayoutStore.ts
@@ -45,6 +45,11 @@ export function useLayoutStore() {
 
   const [catalog, setCatalog] = useState<string[]>([]);
   const savePromiseRef = useRef<Promise<void>>(Promise.resolve());
+  // Tracks the last server revision independently from the optimistic local
+  // document. A stale response may advance this revision without being
+  // allowed to replace newer furniture edits in the UI.
+  const persistedRevisionRef = useRef<{ id: string; updatedAt: number } | null>(null);
+  const furnitureEditVersionRef = useRef(0);
 
   // --- Auto-save state ---
   // isDirty: true when furniture has been changed but not yet persisted.
@@ -67,6 +72,9 @@ export function useLayoutStore() {
   const setActiveLayoutProgrammatic = useCallback((layout: LayoutDoc | null) => {
     skipAutoSaveRef.current = true;
     setIsDirty(false);
+    persistedRevisionRef.current = layout
+      ? { id: layout.id, updatedAt: layout.updatedAt }
+      : null;
     setActiveLayout(layout);
   }, []);
 
@@ -108,8 +116,13 @@ export function useLayoutStore() {
       // the ref sync.
       const currentLayout = activeLayoutRef.current;
       if (!currentLayout) return;
+      const editVersionAtSaveStart = furnitureEditVersionRef.current;
+      const persistedRevision = persistedRevisionRef.current;
+      const baseUpdatedAt = persistedRevision?.id === currentLayout.id
+        ? persistedRevision.updatedAt
+        : currentLayout.updatedAt;
 
-      const merged = { ...currentLayout, ...updates, baseUpdatedAt: currentLayout.updatedAt, updatedAt: Date.now() };
+      const merged = { ...currentLayout, ...updates, baseUpdatedAt, updatedAt: Date.now() };
 
       try {
         const response = await fetch(`${API_BASE}/layouts/${merged.id}`, {
@@ -132,7 +145,21 @@ export function useLayoutStore() {
         // Success — reset retry counter
         retryAttemptRef.current = 0;
         const data = await response.json().catch(() => null);
-        setActiveLayoutProgrammatic(data?.layout ?? merged);
+        const savedLayout = data?.layout ?? merged;
+        persistedRevisionRef.current = {
+          id: savedLayout.id,
+          updatedAt: savedLayout.updatedAt,
+        };
+
+        // The response is authoritative only for the snapshot it saved. If
+        // the user edited or switched layouts while the PUT was in flight,
+        // retain that newer local state and let its queued auto-save proceed.
+        if (
+          furnitureEditVersionRef.current === editVersionAtSaveStart
+          && activeLayoutRef.current === currentLayout
+        ) {
+          setActiveLayoutProgrammatic(savedLayout);
+        }
         fetchLayouts();
       } catch (err: any) {
         console.error('Failed to save layout:', err);
@@ -199,6 +226,8 @@ export function useLayoutStore() {
   const updateFurniture = useCallback((
     furnitureOrUpdater: PlacedFurniture[] | ((prev: PlacedFurniture[]) => PlacedFurniture[]),
   ) => {
+    if (!activeLayoutRef.current) return;
+    furnitureEditVersionRef.current++;
     setActiveLayout(prev => {
       if (!prev) return null;
       const furniture = typeof furnitureOrUpdater === 'function'
@@ -262,9 +291,12 @@ export function useLayoutStore() {
 
       const currentLayout = activeLayoutRef.current;
       if (currentLayout) {
+        const persistedRevision = persistedRevisionRef.current;
         const merged = {
           ...currentLayout,
-          baseUpdatedAt: currentLayout.updatedAt,
+          baseUpdatedAt: persistedRevision?.id === currentLayout.id
+            ? persistedRevision.updatedAt
+            : currentLayout.updatedAt,
           updatedAt: Date.now(),
         };
         fetch(`${API_BASE}/layouts/${merged.id}`, {

--- a/src/hooks/useLayoutStore.ts
+++ b/src/hooks/useLayoutStore.ts
@@ -13,6 +13,45 @@ export interface LayoutDoc {
   updatedAt: number;
 }
 
+type PersistedRevision = { id: string; updatedAt: number };
+
+function isLayoutDoc(value: unknown): value is LayoutDoc {
+  if (!value || typeof value !== 'object') return false;
+  const layout = value as Record<string, unknown>;
+  return typeof layout.id === 'string' && layout.id.length > 0
+    && typeof layout.name === 'string' && layout.name.trim().length > 0
+    && Number.isSafeInteger(layout.width) && (layout.width as number) > 0
+    && Number.isSafeInteger(layout.height) && (layout.height as number) > 0
+    && Number.isSafeInteger(layout.updatedAt) && (layout.updatedAt as number) >= 0
+    && Array.isArray(layout.furniture)
+    && layout.furniture.every(item => {
+      if (!item || typeof item !== 'object') return false;
+      const furniture = item as Record<string, unknown>;
+      return typeof furniture.id === 'string'
+        && typeof furniture.type === 'string'
+        && Number.isSafeInteger(furniture.x)
+        && Number.isSafeInteger(furniture.y)
+        && [0, 90, 180, 270].includes(furniture.rotation as number);
+    })
+    && !!layout.seats
+    && typeof layout.seats === 'object'
+    && !Array.isArray(layout.seats)
+    && Object.values(layout.seats as Record<string, unknown>).every(seat => {
+      if (!seat || typeof seat !== 'object') return false;
+      const position = seat as Record<string, unknown>;
+      return Number.isSafeInteger(position.x) && Number.isSafeInteger(position.y);
+    });
+}
+
+function pickBaseUpdatedAt(
+  currentLayout: LayoutDoc,
+  persistedRevision: PersistedRevision | null,
+): number {
+  return persistedRevision?.id === currentLayout.id
+    ? persistedRevision.updatedAt
+    : currentLayout.updatedAt;
+}
+
 /**
  * Dispatched action: a new layout value, or a functional updater.
  * Every mutation flows through the reducer, which guarantees the ref
@@ -48,7 +87,7 @@ export function useLayoutStore() {
   // Tracks the last server revision independently from the optimistic local
   // document. A stale response may advance this revision without being
   // allowed to replace newer furniture edits in the UI.
-  const persistedRevisionRef = useRef<{ id: string; updatedAt: number } | null>(null);
+  const persistedRevisionRef = useRef<PersistedRevision | null>(null);
   const furnitureEditVersionRef = useRef(0);
 
   // --- Auto-save state ---
@@ -65,6 +104,40 @@ export function useLayoutStore() {
   // retryAttemptRef: tracks consecutive failed auto-saves for backoff.
   const retryAttemptRef = useRef(0);
 
+  const scheduleSaveRetry = useCallback((retry: () => void) => {
+    const delay = Math.min(2000 * Math.pow(2, retryAttemptRef.current), 30000);
+    retryAttemptRef.current++;
+    if (autoSaveTimerRef.current) clearTimeout(autoSaveTimerRef.current);
+    autoSaveTimerRef.current = setTimeout(() => {
+      autoSaveTimerRef.current = null;
+      retry();
+    }, delay);
+  }, []);
+
+  const advancePersistedRevision = useCallback((id: string, updatedAt: number) => {
+    if (activeLayoutRef.current?.id !== id || !Number.isSafeInteger(updatedAt)) return false;
+    const current = persistedRevisionRef.current;
+    if (!current || current.id !== id || updatedAt > current.updatedAt) {
+      persistedRevisionRef.current = { id, updatedAt };
+    }
+    return true;
+  }, []);
+
+  const refreshPersistedRevision = useCallback(async (id: string) => {
+    try {
+      const response = await fetch(`${API_BASE}/layouts/${id}`);
+      if (!response.ok) throw new Error(`HTTP ${response.status}`);
+      const layout: unknown = await response.json();
+      if (!isLayoutDoc(layout) || layout.id !== id) {
+        throw new Error('Invalid layout response');
+      }
+      return advancePersistedRevision(id, layout.updatedAt);
+    } catch (err) {
+      console.error('Failed to refresh layout revision:', err);
+      return false;
+    }
+  }, [advancePersistedRevision]);
+
   // Wrapper for programmatic layout changes. Always sets skipAutoSaveRef
   // before setActiveLayout so the auto-save effect skips these changes.
   // Also clears isDirty. This makes the skip-auto-save invariant
@@ -72,9 +145,14 @@ export function useLayoutStore() {
   const setActiveLayoutProgrammatic = useCallback((layout: LayoutDoc | null) => {
     skipAutoSaveRef.current = true;
     setIsDirty(false);
-    persistedRevisionRef.current = layout
-      ? { id: layout.id, updatedAt: layout.updatedAt }
-      : null;
+    if (!layout) {
+      persistedRevisionRef.current = null;
+    } else {
+      const current = persistedRevisionRef.current;
+      if (!current || current.id !== layout.id || layout.updatedAt >= current.updatedAt) {
+        persistedRevisionRef.current = { id: layout.id, updatedAt: layout.updatedAt };
+      }
+    }
     setActiveLayout(layout);
   }, []);
 
@@ -118,9 +196,7 @@ export function useLayoutStore() {
       if (!currentLayout) return;
       const editVersionAtSaveStart = furnitureEditVersionRef.current;
       const persistedRevision = persistedRevisionRef.current;
-      const baseUpdatedAt = persistedRevision?.id === currentLayout.id
-        ? persistedRevision.updatedAt
-        : currentLayout.updatedAt;
+      const baseUpdatedAt = pickBaseUpdatedAt(currentLayout, persistedRevision);
 
       const merged = { ...currentLayout, ...updates, baseUpdatedAt, updatedAt: Date.now() };
 
@@ -133,31 +209,39 @@ export function useLayoutStore() {
         if (!response.ok) {
           const errorBody = await response.json().catch(() => null);
           console.error('Failed to save layout:', errorBody?.error ?? `HTTP ${response.status}`);
-          // Retry on 5xx (server error) but not 4xx (client error won't succeed)
-          if (response.status >= 500) {
-            const delay = Math.min(2000 * Math.pow(2, retryAttemptRef.current), 30000);
-            retryAttemptRef.current++;
-            if (autoSaveTimerRef.current) clearTimeout(autoSaveTimerRef.current);
-            autoSaveTimerRef.current = setTimeout(() => { saveActiveLayout(); }, delay);
+          if (response.status === 409) {
+            await refreshPersistedRevision(merged.id);
+            if (activeLayoutRef.current?.id === merged.id) {
+              scheduleSaveRetry(() => { void saveActiveLayout(); });
+            }
+          } else if (response.status >= 500) {
+            scheduleSaveRetry(() => { void saveActiveLayout(); });
           }
           return;
         }
-        // Success — reset retry counter
-        retryAttemptRef.current = 0;
         const data = await response.json().catch(() => null);
-        const savedLayout = data?.layout ?? merged;
-        if (activeLayoutRef.current?.id === savedLayout.id) {
-          persistedRevisionRef.current = {
-            id: savedLayout.id,
-            updatedAt: savedLayout.updatedAt,
-          };
+        const savedLayout: unknown = data?.layout;
+        if (!isLayoutDoc(savedLayout) || savedLayout.id !== merged.id) {
+          console.error('Failed to save layout: invalid response body');
+          await refreshPersistedRevision(merged.id);
+          if (activeLayoutRef.current?.id === merged.id) {
+            scheduleSaveRetry(() => { void saveActiveLayout(); });
+          }
+          return;
         }
+        // Success — reset retry counter and advance the revision monotonically.
+        retryAttemptRef.current = 0;
+        const currentRevision = persistedRevisionRef.current;
+        const responseIsCurrent = currentRevision?.id !== savedLayout.id
+          || savedLayout.updatedAt >= currentRevision.updatedAt;
+        advancePersistedRevision(savedLayout.id, savedLayout.updatedAt);
 
         // The response is authoritative only for the snapshot it saved. If
         // the user edited or switched layouts while the PUT was in flight,
         // retain that newer local state and let its queued auto-save proceed.
         if (
-          furnitureEditVersionRef.current === editVersionAtSaveStart
+          responseIsCurrent
+          && furnitureEditVersionRef.current === editVersionAtSaveStart
           && activeLayoutRef.current === currentLayout
         ) {
           setActiveLayoutProgrammatic(savedLayout);
@@ -166,14 +250,17 @@ export function useLayoutStore() {
       } catch (err: any) {
         console.error('Failed to save layout:', err);
         // Network error — retry with backoff
-        const delay = Math.min(2000 * Math.pow(2, retryAttemptRef.current), 30000);
-        retryAttemptRef.current++;
-        if (autoSaveTimerRef.current) clearTimeout(autoSaveTimerRef.current);
-        autoSaveTimerRef.current = setTimeout(() => { saveActiveLayout(); }, delay);
+        scheduleSaveRetry(() => { void saveActiveLayout(); });
       }
     });
     return savePromiseRef.current;
-  }, [fetchLayouts, setActiveLayoutProgrammatic]);
+  }, [
+    advancePersistedRevision,
+    fetchLayouts,
+    refreshPersistedRevision,
+    scheduleSaveRetry,
+    setActiveLayoutProgrammatic,
+  ]);
 
   const createLayout = useCallback(async (name: string) => {
     try {
@@ -296,17 +383,27 @@ export function useLayoutStore() {
         const persistedRevision = persistedRevisionRef.current;
         const merged = {
           ...currentLayout,
-          baseUpdatedAt: persistedRevision?.id === currentLayout.id
-            ? persistedRevision.updatedAt
-            : currentLayout.updatedAt,
+          baseUpdatedAt: pickBaseUpdatedAt(currentLayout, persistedRevision),
           updatedAt: Date.now(),
         };
-        fetch(`${API_BASE}/layouts/${merged.id}`, {
+        void fetch(`${API_BASE}/layouts/${merged.id}`, {
           method: 'PUT',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify(merged),
           keepalive: true,
-        }).catch(() => {});
+        }).then(async response => {
+          if (response.status === 409) {
+            console.warn('Layout changed elsewhere while leaving; retrying if the page remains open.');
+            await refreshPersistedRevision(merged.id);
+            if (activeLayoutRef.current?.id === merged.id) {
+              scheduleSaveRetry(() => { void saveActiveLayout(); });
+            }
+          } else if (!response.ok) {
+            console.error(`Failed to save layout before unload: HTTP ${response.status}`);
+          }
+        }).catch(err => {
+          console.error('Failed to save layout before unload:', err);
+        });
       }
 
       e.preventDefault();
@@ -314,7 +411,7 @@ export function useLayoutStore() {
 
     window.addEventListener('beforeunload', handleBeforeUnload);
     return () => window.removeEventListener('beforeunload', handleBeforeUnload);
-  }, []);
+  }, [refreshPersistedRevision, saveActiveLayout, scheduleSaveRetry]);
 
   // Initial load
   useEffect(() => {

--- a/src/hooks/useLayoutStore.ts
+++ b/src/hooks/useLayoutStore.ts
@@ -145,6 +145,10 @@ export function useLayoutStore() {
   const setActiveLayoutProgrammatic = useCallback((layout: LayoutDoc | null) => {
     skipAutoSaveRef.current = true;
     setIsDirty(false);
+    // Reset the retry counter so the first failure on a freshly-loaded
+    // layout starts from the base 2s backoff, not the previous layout's
+    // inflated exponent.
+    retryAttemptRef.current = 0;
     if (!layout) {
       persistedRevisionRef.current = null;
     } else {
@@ -177,7 +181,16 @@ export function useLayoutStore() {
     }
     try {
       const res = await fetch(`${API_BASE}/layouts/${id}`);
-      const data = await res.json();
+      if (!res.ok) {
+        const errBody = await res.json().catch(() => ({ error: `HTTP ${res.status}` }));
+        console.error('Failed to load layout:', errBody.error ?? `HTTP ${res.status}`);
+        return null;
+      }
+      const data: unknown = await res.json();
+      if (!isLayoutDoc(data)) {
+        console.error('Failed to load layout: invalid response body');
+        return null;
+      }
       setActiveLayoutProgrammatic(data);
       return data;
     } catch (err) {
@@ -222,7 +235,10 @@ export function useLayoutStore() {
         const data = await response.json().catch(() => null);
         const savedLayout: unknown = data?.layout;
         if (!isLayoutDoc(savedLayout) || savedLayout.id !== merged.id) {
-          console.error('Failed to save layout: invalid response body');
+          const reason = !isLayoutDoc(savedLayout)
+            ? 'invalid response body'
+            : `response id mismatch (expected '${merged.id}', got '${savedLayout.id}')`;
+          console.error(`Failed to save layout: ${reason}`);
           await refreshPersistedRevision(merged.id);
           if (activeLayoutRef.current?.id === merged.id) {
             scheduleSaveRetry(() => { void saveActiveLayout(); });
@@ -371,7 +387,8 @@ export function useLayoutStore() {
   }, [isDirty]);
 
   // --- beforeunload: emergency save + browser confirmation ---
-  // Registered once with empty deps; reads isDirtyRef for current state.
+  // Reads isDirtyRef/activeLayoutRef for current state; re-registers when
+  // the (stable) save/refresh callbacks change identity.
   // If there are unsaved changes, attempt a keepalive PUT and show the
   // browser's "Leave site?" dialog.
   useEffect(() => {
@@ -398,9 +415,25 @@ export function useLayoutStore() {
             if (activeLayoutRef.current?.id === merged.id) {
               scheduleSaveRetry(() => { void saveActiveLayout(); });
             }
-          } else if (!response.ok) {
-            console.error(`Failed to save layout before unload: HTTP ${response.status}`);
+            return;
           }
+          if (!response.ok) {
+            console.error(`Failed to save layout before unload: HTTP ${response.status}`);
+            return;
+          }
+          const data = await response.json().catch(() => null);
+          const savedLayout: unknown = data?.layout;
+          if (!isLayoutDoc(savedLayout) || savedLayout.id !== merged.id) {
+            console.error('Failed to save layout before unload: invalid response body');
+            return;
+          }
+          // If the unload is cancelled and the page stays open, the next
+          // save must chain from the revision this keepalive PUT actually
+          // persisted — otherwise it 409s on a stale baseUpdatedAt.
+          // isDirty/activeLayout are deliberately untouched: edits landing
+          // after beforeunload are not covered by this save.
+          retryAttemptRef.current = 0;
+          advancePersistedRevision(savedLayout.id, savedLayout.updatedAt);
         }).catch(err => {
           console.error('Failed to save layout before unload:', err);
         });


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This change fixes a concurrency bug where a slow or out-of-order layout save response could overwrite more recent local furniture edits. The fix introduces tracking of the last successfully persisted layout revision and a furniture edit version, and only applies the authoritative server response if no newer local edits occurred while the request was in flight; otherwise, the newer optimistic state is kept and its follow-up save uses the correct base revision.

---

Add a test that ensures a newly loaded layout stays active when an older in-flight save response returns, preventing stale data from overwriting the user's current edit context.

---

## Summary

This pull request fixes a bug where successful but stale save responses could silently overwrite newer local layout edits (issue #91). It also improves handling of conflict (HTTP 409) responses and stale auto-save retries.

## Changes

### Save response validation
- Added an `isLayoutDoc` type guard that verifies a save response payload has the correct shape (valid id/name, positive integer width/height, well-formed furniture array with allowed rotations, and valid seats map).
- If the save response returns a 2xx status but the body is missing or malformed, the save is now treated as a failure: the persisted revision is refreshed and a retry is scheduled, instead of silently advancing the local revision or discarding the pending edits.
- When a response is valid, the persisted revision only advances if the returned `updatedAt` is **not older** than the current persisted revision (monotonic guard), preventing a stale response from rewinding the local state.

### Conflict (HTTP 409) handling on auto-save
- A 409 response no longer silently leaves the document dirty. The hook now refreshes the persisted revision from the server and schedules a backoff retry (using the existing exponential backoff helper) so the user's edit is saved with the correct `baseUpdatedAt`.
- The conflict path is also applied to the `beforeunload` keepalive save so a 409 during page unload triggers a revision refresh and a retry if the page stays open.

### Cleanup of shared helpers
- Extracted the `baseUpdatedAt` selection (current persisted revision vs. layout's own `updatedAt`) into a `pickBaseUpdatedAt` helper, used by both `saveActiveLayout` and the keepalive unload save.
- Extracted the exponential-backoff retry scheduling into a shared `scheduleSaveRetry` callback, used by all retry paths (5xx, network error, 409, and invalid response).
- Extracted a `refreshPersistedRevision` callback that fetches the current layout from the server, validates it with `isLayoutDoc`, and advances the persisted revision only when the response is newer.
- Extracted `advancePersistedRevision` so all revision mutations go through one place that enforces the same-id + monotonic-updateAt invariant.

### Programmatic layout loading
- `setActiveLayoutProgrammatic` no longer blindly resets the persisted revision to the loaded layout's `updatedAt`. It now only advances the revision when the new layout's `updatedAt` is greater than or equal to the current one, so reloading the same layout can't roll back the revision.

## Tests
Added four new test cases to `useLayoutStore.test.tsx`:
1. A successful save response without a valid layout body leaves `isDirty` true and a subsequent save re-sends with the correct `baseUpdatedAt`.
2. An autosave that hits a 409 conflict refreshes the server revision, retries with that newer base, and clears `isDirty`.
3. A stale successful save response from a previous PUT does not roll back the persisted revision after the same layout has been reloaded, and the next save uses the newer `baseUpdatedAt`.
4. A 409 on the `beforeunload` keepalive save refreshes the revision and the follow-up save goes out with the new `baseUpdatedAt`.

---

### Summary

Fixes the layout store so that an emergency keepalive save (fired on `beforeunload`) correctly advances the persisted revision, allowing the next auto-save to chain from the keepalive's `updatedAt` instead of 409-ing on a stale base.

### Problem

When the user closed the tab (or the `beforeunload` handler fired) while edits were unsaved, the keepalive PUT would persist them, but the in-memory `persistedRevisionRef` was never updated. If the unload was cancelled and the page stayed open, the next `saveActiveLayout` re-sent the original `baseUpdatedAt` from before the keepalive ran. The server then rejected the follow-up save with a conflict, and a previously-added "stale-response refresh + retry" path kicked in, surfacing the error and re-issuing retries against a now-conflicting base — risking further 409s and user-visible retry churn.

### Changes

- **`beforeunload` handler (`useLayoutStore.ts`)** — After a successful keepalive PUT, parse the response and, when valid, advance `persistedRevisionRef` via `advancePersistedRevision(savedLayout.id, savedLayout.updatedAt)`. This is the core fix: the next save chains from the keepalive's persisted revision.
- **Existing error handling preserved** — On HTTP error or invalid/mismatched response body during keepalive, the existing `scheduleSaveRetry` / `console.error` paths still fire; the success branch is additive.
- **`setActiveLayoutProgrammatic`** — Resets `retryAttemptRef` to `0` so a newly loaded layout starts retry backoff from the base 2s, not from a previous layout's inflated exponent.
- **Defensive response parsing in `loadActiveLayout`** — Treat non-OK responses and malformed bodies as load failures (logs and returns `null`) rather than crashing in `setState` on unexpected shapes.

### Tests

- **`advances the persisted revision after a successful keepalive save`** — New regression test: fires a keepalive PUT, then triggers a follow-up `saveActiveLayout()`, and asserts the second PUT's `baseUpdatedAt` matches the keepalive response (`2_000`), not the pre-keepalive revision (`1_000`).
- **`retries auto-save on 5xx with exponential backoff (M1)`** — Rewritten with fake timers and a stubbed fetch that 503s the first PUT then 200s the retry, asserting: a 2s debounced first attempt, a 2s backoff retry that preserves the user's edit (`rotation: 90`), and that `isDirty` clears after the successful retry.

---

This PR improves error messaging in the layout store when a save request returns an unexpected or stale response.

### What changed

In `src/hooks/useLayoutStore.ts`, the `beforeunload` save handler logs an error if the server response doesn't match what was sent. Previously, the error message was a single generic string ("invalid response body") regardless of the actual cause.

The error message is now split into two specific cases:
- **Invalid response body**: logged when the response JSON doesn't conform to a valid layout document.
- **Response id mismatch**: logged when the response is well-formed but its `id` doesn't match the merged layout's `id`, indicating a stale or out-of-order response. The message includes both the expected and received IDs for easier debugging.

### Why

This addresses issue #91, where a stale save response (e.g., from a previously canceled or superseded request) was being treated identically to a malformed response, making it harder to diagnose why a save appeared to fail. By distinguishing these cases and surfacing the ID mismatch, the cause of discarded edits is now immediately visible in the console.

Notably, the behavior is unchanged in both branches — the save is still rejected (`return`) when the response is invalid or doesn't match. Only the diagnostic message was made more informative.
<!-- kody-pr-summary:end -->