### PR TITLE
fix(editor): clear room switcher overlap on mobile

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -21,6 +21,11 @@
   --shadow-neon-cyan: 0 0 10px rgba(0, 240, 255, 0.2), inset 0 0 5px rgba(0, 240, 255, 0.1);
   --shadow-neon-pink: 0 0 10px rgba(255, 0, 85, 0.2), inset 0 0 5px rgba(255, 0, 85, 0.1);
   --glass-blur: blur(12px);
+
+  /* Shared mobile HUD geometry keeps independently positioned controls apart. */
+  --mobile-room-switcher-top: 64px;
+  --mobile-room-switcher-height: 46px;
+  --mobile-editor-toolbar-gap: 10px;
 }
 
 body {

--- a/src/App.css
+++ b/src/App.css
@@ -26,6 +26,7 @@
   --mobile-room-switcher-top: 64px;
   --mobile-room-switcher-height: 46px;
   --mobile-editor-toolbar-gap: 10px;
+  --desktop-agent-sidebar-reserved-width: 316px;
 }
 
 body {

--- a/src/components/LayoutEditor.css
+++ b/src/components/LayoutEditor.css
@@ -251,7 +251,9 @@
 .furniture-palette::-webkit-scrollbar-thumb, .layout-list::-webkit-scrollbar-thumb { background: var(--acc-cyan); border-radius: 4px; }
 
 @media (max-width: 768px) {
-  .editor-toolbar { margin-top: 60px; flex-wrap: wrap; justify-content: center; width: 90%; }
+  /* Room switcher occupies top: 64px + ~44px height = ~108px vertical band. */
+  /* Editor toolbar must clear that band to avoid hit-testing overlap. */
+  .editor-toolbar { margin-top: 120px; flex-wrap: wrap; justify-content: center; width: 90%; }
   .furniture-palette, .layout-manager { position: static; width: auto; max-height: 250px; margin: 12px; }
   .layout-manager { right: auto; }
 }

--- a/src/components/LayoutEditor.css
+++ b/src/components/LayoutEditor.css
@@ -251,9 +251,17 @@
 .furniture-palette::-webkit-scrollbar-thumb, .layout-list::-webkit-scrollbar-thumb { background: var(--acc-cyan); border-radius: 4px; }
 
 @media (max-width: 768px) {
-  /* Room switcher occupies top: 64px + ~44px height = ~108px vertical band. */
-  /* Editor toolbar must clear that band to avoid hit-testing overlap. */
-  .editor-toolbar { margin-top: 120px; flex-wrap: wrap; justify-content: center; width: 90%; }
+  /* Keep the toolbar below the complete room switcher hit-target band. */
+  .editor-toolbar {
+    margin-top: calc(
+      var(--mobile-room-switcher-top)
+      + var(--mobile-room-switcher-height)
+      + var(--mobile-editor-toolbar-gap)
+    );
+    flex-wrap: wrap;
+    justify-content: center;
+    width: 90%;
+  }
   .furniture-palette, .layout-manager { position: static; width: auto; max-height: 250px; margin: 12px; }
   .layout-manager { right: auto; }
 }

--- a/src/components/LayoutEditor.css
+++ b/src/components/LayoutEditor.css
@@ -6,12 +6,15 @@
   right: 0;
   z-index: 90; /* Below Header, above Canvas */
   pointer-events: none;
+  padding-right: var(--desktop-agent-sidebar-reserved-width);
 }
 .layout-editor > * { pointer-events: auto; }
 
 /* Toolbar */
 .editor-toolbar {
   display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
   align-items: center;
   gap: 12px;
   padding: 8px 16px;
@@ -251,6 +254,8 @@
 .furniture-palette::-webkit-scrollbar-thumb, .layout-list::-webkit-scrollbar-thumb { background: var(--acc-cyan); border-radius: 4px; }
 
 @media (max-width: 768px) {
+  .layout-editor { padding-right: 0; }
+
   /* Keep the toolbar below the complete room switcher hit-target band. */
   .editor-toolbar {
     margin-top: calc(
@@ -258,8 +263,6 @@
       + var(--mobile-room-switcher-height)
       + var(--mobile-editor-toolbar-gap)
     );
-    flex-wrap: wrap;
-    justify-content: center;
     width: 90%;
   }
   .furniture-palette, .layout-manager { position: static; width: auto; max-height: 250px; margin: 12px; }

--- a/src/components/LayoutEditor.mobile.test.tsx
+++ b/src/components/LayoutEditor.mobile.test.tsx
@@ -1,50 +1,99 @@
 import React from 'react';
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { readFileSync } from 'node:fs';
-import { resolve } from 'node:path';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 import { LayoutEditor } from './LayoutEditor';
 import type { LayoutDoc } from '../hooks/useLayoutStore';
+
+const MOBILE_MEDIA_QUERY = '(max-width: 768px)';
+const COMPONENT_DIR = dirname(fileURLToPath(import.meta.url));
+const appCss = readFileSync(resolve(COMPONENT_DIR, '../App.css'), 'utf-8');
+const layoutEditorCss = readFileSync(resolve(COMPONENT_DIR, 'LayoutEditor.css'), 'utf-8');
+const roomSwitcherCss = readFileSync(resolve(COMPONENT_DIR, 'RoomSwitcher.css'), 'utf-8');
+
+function getRuleDeclarations(css: string, selector: string, mediaQuery?: string) {
+  const styleElement = document.createElement('style');
+  styleElement.textContent = css;
+  document.head.append(styleElement);
+
+  try {
+    const sheet = styleElement.sheet;
+    expect(sheet, 'CSS must produce a stylesheet').not.toBeNull();
+
+    let rules = Array.from(sheet!.cssRules);
+    if (mediaQuery) {
+      const mediaRule = rules.find(
+        (rule): rule is CSSMediaRule =>
+          'conditionText' in rule && rule.conditionText === mediaQuery,
+      );
+      expect(mediaRule, `${mediaQuery} block must exist`).toBeDefined();
+      rules = Array.from(mediaRule!.cssRules);
+    }
+
+    const styleRule = rules.find(
+      (rule): rule is CSSStyleRule =>
+        'selectorText' in rule && rule.selectorText === selector,
+    );
+    expect(styleRule, `${selector} rule must exist`).toBeDefined();
+
+    const declarations = new Map<string, string>();
+    for (let index = 0; index < styleRule!.style.length; index += 1) {
+      const property = styleRule!.style.item(index);
+      declarations.set(property, styleRule!.style.getPropertyValue(property).trim());
+    }
+    return declarations;
+  } finally {
+    styleElement.remove();
+  }
+}
 
 /**
  * Regression test for issue #87: mobile toolbar overlap with room switcher.
  *
  * Root cause: at ≤768px the room switcher sits at top:64px with z-index:100
- * and a height of ~44px (bottom edge ≈108px). The editor toolbar was at
+ * and a height of 46px (bottom edge 110px). The editor toolbar was at
  * margin-top:60px inside a z-index:90 container — so it occupied the same
  * vertical band and lost hit-testing to the room switcher.
  *
- * Fix: bump mobile toolbar margin-top to 120px so it clears the switcher.
+ * Fix: derive both elements from shared mobile HUD geometry so future room
+ * switcher changes cannot silently reintroduce the overlap.
  */
 describe('Issue #87 — mobile toolbar / room switcher overlap', () => {
   afterEach(cleanup);
-
   // ── CSS regression: catch anyone reverting the offset ──────────────
 
-  it('mobile editor-toolbar margin-top clears the room switcher bottom edge (≥108px)', () => {
-    const css = readFileSync(
-      resolve(__dirname, 'LayoutEditor.css'),
-      'utf-8',
+  it('derives the mobile toolbar offset from the room switcher geometry', () => {
+    const root = getRuleDeclarations(appCss, ':root');
+    expect(root.get('--mobile-room-switcher-top')).toBe('64px');
+    expect(root.get('--mobile-room-switcher-height')).toBe('46px');
+    expect(root.get('--mobile-editor-toolbar-gap')).toBe('10px');
+
+    const roomSwitcher = getRuleDeclarations(
+      roomSwitcherCss,
+      '.room-switcher',
+      MOBILE_MEDIA_QUERY,
     );
 
-    // Extract the mobile media query block
-    const mobileBlock = css.match(/@media\s*\(max-width:\s*768px\)\s*\{([^}]*\{[^}]*\}[^}]*)\}/s);
-    expect(mobileBlock, 'mobile @media block must exist').not.toBeNull();
-    const rules = mobileBlock![1];
+    expect(roomSwitcher.get('top')).toBe('var(--mobile-room-switcher-top)');
+    expect(roomSwitcher.get('height')).toBe('var(--mobile-room-switcher-height)');
 
-    const toolbarMatch = rules.match(/\.editor-toolbar\s*\{([^}]*)\}/s);
-    expect(toolbarMatch, '.editor-toolbar rule in mobile media query').not.toBeNull();
-
-    const marginTopMatch = toolbarMatch![1].match(/margin-top:\s*(\d+)px/);
-    expect(marginTopMatch, 'margin-top must be a pixel value').not.toBeNull();
-
-    const marginTop = parseInt(marginTopMatch![1], 10);
-    // Room switcher bottom edge ≈ top(64) + padding(4+4) + min-height(36) + border(2) = ~110px
-    // Use 108 as the floor — anything below overlaps.
-    expect(marginTop).toBeGreaterThanOrEqual(108);
+    const editorToolbar = getRuleDeclarations(
+      layoutEditorCss,
+      '.editor-toolbar',
+      MOBILE_MEDIA_QUERY,
+    );
+    const toolbarOffset = editorToolbar
+      .get('margin-top')
+      ?.replace(/\s+/g, ' ')
+      .replace(/\(\s+/g, '(')
+      .replace(/\s+\)/g, ')');
+    expect(toolbarOffset).toBe(
+      'calc(var(--mobile-room-switcher-top) + var(--mobile-room-switcher-height) + var(--mobile-editor-toolbar-gap))',
+    );
   });
-
   // ── Functional regression: toolbar buttons render and fire ──────────
 
   const mockLayout: LayoutDoc = {
@@ -79,12 +128,6 @@ describe('Issue #87 — mobile toolbar / room switcher overlap', () => {
     onDeleteLayout: vi.fn(),
     onToggleEditor: vi.fn(),
   };
-
-  beforeEach(() => {
-    Object.values(props).forEach(fn => {
-      if (typeof fn === 'function' && 'mockClear' in fn) (fn as ReturnType<typeof vi.fn>).mockClear();
-    });
-  });
 
   it('renders all five toolbar controls in editor mode', () => {
     render(<LayoutEditor {...props} />);
@@ -122,7 +165,7 @@ describe('Issue #87 — mobile toolbar / room switcher overlap', () => {
     expect(screen.getByText('Plants')).toBeTruthy();
   });
 
-  it('fires onLoad manager toggle when Layouts is clicked', () => {
+  it('opens the layout manager when Layouts is clicked', () => {
     render(<LayoutEditor {...props} />);
     fireEvent.click(screen.getByTitle('Layout manager'));
     // Layouts toggle is internal state; the panel opens

--- a/src/components/LayoutEditor.mobile.test.tsx
+++ b/src/components/LayoutEditor.mobile.test.tsx
@@ -70,6 +70,7 @@ describe('Issue #87 — mobile toolbar / room switcher overlap', () => {
     expect(root.get('--mobile-room-switcher-top')).toBe('64px');
     expect(root.get('--mobile-room-switcher-height')).toBe('46px');
     expect(root.get('--mobile-editor-toolbar-gap')).toBe('10px');
+    expect(root.get('--desktop-agent-sidebar-reserved-width')).toBe('316px');
 
     const roomSwitcher = getRuleDeclarations(
       roomSwitcherCss,
@@ -93,6 +94,20 @@ describe('Issue #87 — mobile toolbar / room switcher overlap', () => {
     expect(toolbarOffset).toBe(
       'calc(var(--mobile-room-switcher-top) + var(--mobile-room-switcher-height) + var(--mobile-editor-toolbar-gap))',
     );
+  });
+
+  it('reserves the desktop agent sidebar band and releases it on mobile', () => {
+    const desktopEditor = getRuleDeclarations(layoutEditorCss, '.layout-editor');
+    expect(desktopEditor.get('padding-right')).toBe(
+      'var(--desktop-agent-sidebar-reserved-width)',
+    );
+
+    const mobileEditor = getRuleDeclarations(
+      layoutEditorCss,
+      '.layout-editor',
+      MOBILE_MEDIA_QUERY,
+    );
+    expect(mobileEditor.get('padding-right')).toBe('0px');
   });
   // ── Functional regression: toolbar buttons render and fire ──────────
 

--- a/src/components/LayoutEditor.mobile.test.tsx
+++ b/src/components/LayoutEditor.mobile.test.tsx
@@ -1,0 +1,132 @@
+import React from 'react';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { LayoutEditor } from './LayoutEditor';
+import type { LayoutDoc } from '../hooks/useLayoutStore';
+
+/**
+ * Regression test for issue #87: mobile toolbar overlap with room switcher.
+ *
+ * Root cause: at ≤768px the room switcher sits at top:64px with z-index:100
+ * and a height of ~44px (bottom edge ≈108px). The editor toolbar was at
+ * margin-top:60px inside a z-index:90 container — so it occupied the same
+ * vertical band and lost hit-testing to the room switcher.
+ *
+ * Fix: bump mobile toolbar margin-top to 120px so it clears the switcher.
+ */
+describe('Issue #87 — mobile toolbar / room switcher overlap', () => {
+  afterEach(cleanup);
+
+  // ── CSS regression: catch anyone reverting the offset ──────────────
+
+  it('mobile editor-toolbar margin-top clears the room switcher bottom edge (≥108px)', () => {
+    const css = readFileSync(
+      resolve(__dirname, 'LayoutEditor.css'),
+      'utf-8',
+    );
+
+    // Extract the mobile media query block
+    const mobileBlock = css.match(/@media\s*\(max-width:\s*768px\)\s*\{([^}]*\{[^}]*\}[^}]*)\}/s);
+    expect(mobileBlock, 'mobile @media block must exist').not.toBeNull();
+    const rules = mobileBlock![1];
+
+    const toolbarMatch = rules.match(/\.editor-toolbar\s*\{([^}]*)\}/s);
+    expect(toolbarMatch, '.editor-toolbar rule in mobile media query').not.toBeNull();
+
+    const marginTopMatch = toolbarMatch![1].match(/margin-top:\s*(\d+)px/);
+    expect(marginTopMatch, 'margin-top must be a pixel value').not.toBeNull();
+
+    const marginTop = parseInt(marginTopMatch![1], 10);
+    // Room switcher bottom edge ≈ top(64) + padding(4+4) + min-height(36) + border(2) = ~110px
+    // Use 108 as the floor — anything below overlaps.
+    expect(marginTop).toBeGreaterThanOrEqual(108);
+  });
+
+  // ── Functional regression: toolbar buttons render and fire ──────────
+
+  const mockLayout: LayoutDoc = {
+    id: 'default',
+    name: 'Default',
+    width: 24,
+    height: 16,
+    furniture: [],
+    seats: {},
+    updatedAt: 1,
+  };
+
+  const props = {
+    catalog: ['DESK', 'PLANT'],
+    activeLayout: mockLayout,
+    isDirty: false,
+    layouts: [mockLayout],
+    editorMode: true,
+    selectedFurnitureType: null,
+    selectedFurnitureId: null,
+    deleteMode: false,
+    onSelectFurnitureType: vi.fn(),
+    onSelectFurnitureId: vi.fn(),
+    onPlaceFurniture: vi.fn(),
+    onMoveFurniture: vi.fn(),
+    onRotateFurniture: vi.fn(),
+    onDeleteFurniture: vi.fn(),
+    onToggleDeleteMode: vi.fn(),
+    onSave: vi.fn(),
+    onLoad: vi.fn(),
+    onCreate: vi.fn(),
+    onDeleteLayout: vi.fn(),
+    onToggleEditor: vi.fn(),
+  };
+
+  beforeEach(() => {
+    Object.values(props).forEach(fn => {
+      if (typeof fn === 'function' && 'mockClear' in fn) (fn as ReturnType<typeof vi.fn>).mockClear();
+    });
+  });
+
+  it('renders all five toolbar controls in editor mode', () => {
+    render(<LayoutEditor {...props} />);
+
+    expect(screen.getByTitle('Furniture palette')).toBeTruthy();
+    expect(screen.getByTitle('Delete mode — click placed items to remove them')).toBeTruthy();
+    expect(screen.getByTitle('Layout manager')).toBeTruthy();
+    expect(screen.getByTitle(/Save layout/)).toBeTruthy();
+    expect(screen.getByTitle('Exit editor')).toBeTruthy();
+  });
+
+  it('fires onSave when Save is clicked', () => {
+    render(<LayoutEditor {...props} />);
+    fireEvent.click(screen.getByTitle(/Save layout/));
+    expect(props.onSave).toHaveBeenCalledOnce();
+  });
+
+  it('fires onToggleEditor when Close is clicked', () => {
+    render(<LayoutEditor {...props} />);
+    fireEvent.click(screen.getByTitle('Exit editor'));
+    expect(props.onToggleEditor).toHaveBeenCalledOnce();
+  });
+
+  it('fires onToggleDeleteMode when Delete is clicked', () => {
+    render(<LayoutEditor {...props} />);
+    fireEvent.click(screen.getByTitle(/Delete mode/));
+    expect(props.onToggleDeleteMode).toHaveBeenCalledOnce();
+  });
+
+  it('opens the furniture palette when Furniture is clicked', () => {
+    render(<LayoutEditor {...props} />);
+    fireEvent.click(screen.getByTitle('Furniture palette'));
+    // Palette panel opens — category headers become visible
+    expect(screen.getByText('Desks & Seating')).toBeTruthy();
+    expect(screen.getByText('Plants')).toBeTruthy();
+  });
+
+  it('fires onLoad manager toggle when Layouts is clicked', () => {
+    render(<LayoutEditor {...props} />);
+    fireEvent.click(screen.getByTitle('Layout manager'));
+    // Layouts toggle is internal state; the panel opens
+    // Verify the layout list renders
+    expect(screen.getByText('Default')).toBeTruthy();
+  });
+});

--- a/src/components/RoomSwitcher.css
+++ b/src/components/RoomSwitcher.css
@@ -74,7 +74,8 @@
 
 @media (max-width: 768px) {
   .room-switcher {
-    top: 64px;
+    top: var(--mobile-room-switcher-top);
+    height: var(--mobile-room-switcher-height);
     /* below the mobile header which is ~48px tall */
     padding: 4px 8px;
     gap: 3px;


### PR DESCRIPTION
## Summary

Fixes responsive hit-testing conflicts where higher-z-index HUD elements intercepted layout editor toolbar controls.

Closes #87.

## Changes

- Defines the mobile room-switcher position, height, editor clearance, and desktop sidebar reservation as shared HUD geometry variables in `src/App.css`.
- Makes `RoomSwitcher.css` and `LayoutEditor.css` consume that shared contract.
- Leaves a 10px gap between the mobile room switcher and editor toolbar.
- Reserves the desktop agent-sidebar band so it cannot cover Save or Exit near the responsive breakpoint.
- Replaces the brittle nested-brace CSS regex with CSSOM rule inspection.
- Uses ESM-safe `import.meta.url` path resolution for CSS fixtures.
- Relies on the repository-wide Vitest `clearMocks` setting instead of a redundant manual reset loop.
- Keeps component-level interaction coverage for Furniture, Delete, Layouts, Save, and Exit.

## Verification

- Focused mobile editor tests: **8/8 passed**
- Full suite: **161/161 passed**
- Coverage suite: **161/161 passed**
  - Statements: **43.46%**
  - Branches: **40.90%**
  - Functions: **46.17%**
  - Lines: **45.28%**
- TypeScript typecheck: **passed**
- Production build: **passed**
- Browser QA:
  - **390×844**: room switcher 64–110px, editor toolbar starts at 120px, 10px gap
  - **768×844**: 10px room-toolbar gap
  - **769×844** and **1024×768**: toolbar does not intersect the desktop agent sidebar
  - **320×700**: 10px room-toolbar gap
  - All five editor controls and all room tabs own their center hit points
  - Browser console: no errors
- `git diff --check`: **passed**

## Scope notes

- #108 is a distinct collision between room tabs and sound/settings controls outside editor mode; this PR does not claim to fix it.
- #110 is the repository-wide audit index and remains tracked independently.
- The production dependency audit remains non-clean due to the advisories tracked in #96; this PR changes no dependencies.
- The known wall-clock timing flake tracked in #104 reproduced once during coverage verification; the clean sequential coverage rerun passed 161/161, and this PR does not change authentication code or tests.


<!-- kody-pr-summary:start -->
## Description

Fixes the layout editor toolbar overlapping the room switcher hit-target on desktop by reserving space for the agent sidebar band, and ensures that reservation is released on mobile viewports.

### Changes

- **CSS variables (`src/App.css`)**: Added a new `--desktop-agent-sidebar-reserved-width` design token (316px) that represents the horizontal band occupied by the desktop agent sidebar.
- **Layout editor container (`src/components/LayoutEditor.css`)**: Applied `padding-right: var(--desktop-agent-sidebar-reserved-width)` to `.layout-editor` on desktop so the toolbar and floating panels no longer collide with the right-hand agent sidebar. On viewports ≤ 768px this padding is reset to `0`.
- **Toolbar layout**: Moved `flex-wrap: wrap` and `justify-content: center` from the mobile-only block up to the base `.editor-toolbar` rule, so wrapped/centered behavior also benefits the desktop toolbar while still keeping the room-switcher-aware `margin-top` offset mobile-specific.
- **Tests (`src/components/LayoutEditor.mobile.test.tsx`)**: Added coverage that asserts the new `--desktop-agent-sidebar-reserved-width` variable is defined and that the editor reserves the sidebar band on desktop while releasing it (padding-right: 0px) on mobile.
<!-- kody-pr-summary:end -->