### PR TITLE
ci: add quality and security gates (#106)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: '05:00'
+      timezone: Europe/Berlin
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: '05:30'
+      timezone: Europe/Berlin
+    open-pull-requests-limit: 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,10 +24,10 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22
           cache: npm
@@ -58,6 +58,6 @@ jobs:
 
     steps:
       - name: Review dependency changes
-        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
         with:
           fail-on-severity: high

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,63 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  quality:
+    name: Quality and security
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Type-check
+        run: npm run typecheck
+
+      - name: Test
+        run: npm test
+
+      - name: Enforce coverage floor
+        run: npm run test:coverage
+
+      - name: Build
+        run: npm run build
+
+      - name: Audit production dependencies
+        run: npm audit --omit=dev --audit-level=high
+
+  dependency-review:
+    name: Dependency review
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Review dependency changes
+        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4
+        with:
+          fail-on-severity: high

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,44 @@
+name: CodeQL
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: '23 4 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: codeql-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze JavaScript and TypeScript
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      packages: read
+      security-events: write
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@4187e74d05793876e9989daffde9c3e66b4acd07 # v3
+        with:
+          languages: javascript-typescript
+          build-mode: none
+
+      - name: Analyze
+        uses: github/codeql-action/analyze@4187e74d05793876e9989daffde9c3e66b4acd07 # v3
+        with:
+          category: /language:javascript-typescript

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -29,15 +29,15 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@4187e74d05793876e9989daffde9c3e66b4acd07 # v3
+        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           languages: javascript-typescript
           build-mode: none
 
       - name: Analyze
-        uses: github/codeql-action/analyze@4187e74d05793876e9989daffde9c3e66b4acd07 # v3
+        uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           category: /language:javascript-typescript

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -25,7 +25,6 @@ jobs:
     timeout-minutes: 20
     permissions:
       contents: read
-      packages: read
       security-events: write
 
     steps:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,11 +53,12 @@ The dev server runs on `http://localhost:3000` and proxies API requests to the b
    ```
 5. **Open a PR** with a description of what changed and why
 
-Pull requests and updates to `main` run the same gate in GitHub Actions. Coverage
-must remain at or above 40% for statements, branches, functions, and lines.
-Pull requests also receive a dependency review that blocks newly introduced
-high- or critical-severity vulnerabilities. CodeQL scans JavaScript and
-TypeScript changes and runs weekly on the default branch.
+Pull requests and updates to `main` run the same gate in GitHub Actions.
+Repository-wide coverage includes production TypeScript under `src/`, `server/`,
+and `shared/`; the baseline floors are 39% statements, 36% branches, 37%
+functions, and 41% lines. Pull requests also receive a dependency review that
+blocks newly introduced high- or critical-severity vulnerabilities. CodeQL
+scans JavaScript and TypeScript changes and runs weekly on the default branch.
 
 ## Code Style
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,9 +41,23 @@ The dev server runs on `http://localhost:3000` and proxies API requests to the b
 
 1. **Create a branch** for your feature or fix
 2. **Make your changes** with clear, commented code
-3. **Test locally** — `npm run dev` and verify in the browser
-4. **Build check** — `npm run build` must pass cleanly
+3. **Test locally** — `npm run dev` and verify behavior in the browser when the change affects the UI
+4. **Run the automated gate**:
+   ```bash
+   npm ci
+   npm run typecheck
+   npm test
+   npm run test:coverage
+   npm run build
+   npm audit --omit=dev --audit-level=high
+   ```
 5. **Open a PR** with a description of what changed and why
+
+Pull requests and updates to `main` run the same gate in GitHub Actions. Coverage
+must remain at or above 40% for statements, branches, functions, and lines.
+Pull requests also receive a dependency review that blocks newly introduced
+high- or critical-severity vulnerabilities. CodeQL scans JavaScript and
+TypeScript changes and runs weekly on the default branch.
 
 ## Code Style
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ A pixel art office dashboard for [OpenClaw](https://github.com/openclaw/openclaw
 ![React 19](https://img.shields.io/badge/React-19-61dafb.svg)
 ![TypeScript](https://img.shields.io/badge/TypeScript-5-3178c6.svg)
 ![Vite](https://img.shields.io/badge/Vite-6-646cff.svg)
+[![CI](https://github.com/SweetSophia/openclaw-pixel-agents/actions/workflows/ci.yml/badge.svg)](https://github.com/SweetSophia/openclaw-pixel-agents/actions/workflows/ci.yml)
+[![CodeQL](https://github.com/SweetSophia/openclaw-pixel-agents/actions/workflows/codeql.yml/badge.svg)](https://github.com/SweetSophia/openclaw-pixel-agents/actions/workflows/codeql.yml)
 
 <img width="797" height="656" alt="screenshot-office" src="https://github.com/user-attachments/assets/6b485484-26ff-4739-bfdd-d7a0f90fbec6" />
 <img width="797" height="660" alt="screenshot-furniture" src="https://github.com/user-attachments/assets/506f3ec8-4c7c-4fa0-9db5-e5274eb4390d" />

--- a/server/auth.test.ts
+++ b/server/auth.test.ts
@@ -1,3 +1,4 @@
+import { createHash, timingSafeEqual } from "node:crypto";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -11,6 +12,7 @@ describe("API auth boundaries", () => {
   let io: SocketIOServer;
   let dataDir: string;
   let authenticateIngest: (req: Express.Request, res: Express.Response) => boolean;
+  let createIngestAuthenticator: typeof import("./index").createIngestAuthenticator;
   const appOrigin = "https://pixel.test";
 
   beforeAll(async () => {
@@ -26,6 +28,7 @@ describe("API auth boundaries", () => {
     app = serverModule.app;
     io = serverModule.io;
     authenticateIngest = serverModule.authenticateIngest;
+    createIngestAuthenticator = serverModule.createIngestAuthenticator;
   });
 
   afterAll(() => {
@@ -112,63 +115,42 @@ describe("API auth boundaries", () => {
     });
   });
 
-  it("authenticateIngest does not leak token length via timing", () => {
-    // Regression test for CWE-208: the old implementation had an early-return
-    // branch on length mismatch that let an attacker detect the configured
-    // token length. The SHA-256 digest approach uses a single code path for
-    // all inputs — only the hash of the attacker-controlled input varies in
-    // time, never the secret comparison.
-    //
-    // Scope: in-process only. Does not cover Express header parsing or
-    // network jitter; asserts the comparison itself is constant-time.
-    //
-    // Note on input-length normalisation: SHA-256 throughput scales with
-    // input length (Node hashes in 64-byte blocks), so timing an attacker-
-    // controllable-length token (1B vs 200B) would conflate "hash time
-    // scales with input" with "side-channel exists". To assert the
-    // *comparison* is length-insensitive, every timing measurement must
-    // pass through the same number of hash bytes — we use four same-length
-    // tokens. Any residual spread comes from JIT/GC noise only.
-    const authenticate = authenticateIngest;
-
+  it("hashes every Bearer token and compares fixed-length digests", () => {
+    // Deterministic regression coverage for CWE-208: every syntactically
+    // valid Bearer token must reach the same hash-and-compare path regardless
+    // of its length or content. Wall-clock ratios are too sensitive to runner
+    // contention to serve as a reliable correctness oracle.
     const makeReq = (token: string): Express.Request =>
       ({ headers: { authorization: `Bearer ${token}` } }) as unknown as Express.Request;
 
-    // All timing tokens are the same length (11 bytes) so the per-call
-    // hash cost is identical; the only variable is content correctness.
-    const correctToken = "test-secret"; // matches INGEST_API_TOKEN
-    const wrongSameLen1 = "AAAAAAAAAAA";
-    const wrongSameLen2 = "not-the-xxx";
-    const wrongSameLen3 = "ZZZZZZZZZZZ";
+    const digestToken = vi.fn((token: string) =>
+      createHash("sha256").update(token).digest(),
+    );
+    const compareDigests = vi.fn((configured: Buffer, provided: Buffer) =>
+      timingSafeEqual(configured, provided),
+    );
+    const authenticate = createIngestAuthenticator("test-secret", {
+      digestToken,
+      compareDigests,
+    });
+    digestToken.mockClear();
+    compareDigests.mockClear();
 
-    const ITERATIONS = 20_000;
+    const tokens = ["", "X", "not-a-secr", "test-secret", "café-secret", "X".repeat(1000)];
+    const results = tokens.map((token) =>
+      authenticate(makeReq(token), {} as Express.Response),
+    );
 
-    // Warm up JIT and caches
-    for (let i = 0; i < 2000; i++) {
-      authenticate(makeReq(correctToken), {} as Express.Response);
-      authenticate(makeReq(wrongSameLen1), {} as Express.Response);
+    expect(results).toEqual([false, false, false, true, false, false]);
+    expect(digestToken).toHaveBeenCalledTimes(tokens.length);
+    expect(compareDigests).toHaveBeenCalledTimes(tokens.length);
+
+    for (const [configuredDigest, providedDigest] of compareDigests.mock.calls) {
+      expect(configuredDigest).toBeInstanceOf(Buffer);
+      expect(providedDigest).toBeInstanceOf(Buffer);
+      expect(configuredDigest).toHaveLength(32);
+      expect(providedDigest).toHaveLength(32);
     }
-
-    const measure = (token: string): number => {
-      const req = makeReq(token);
-      const start = process.hrtime.bigint();
-      for (let i = 0; i < ITERATIONS; i++) {
-        authenticate(req, {} as Express.Response);
-      }
-      return Number(process.hrtime.bigint() - start);
-    };
-
-    const correctTime = measure(correctToken);
-    const wrongTime1 = measure(wrongSameLen1);
-    const wrongTime2 = measure(wrongSameLen2);
-    const wrongTime3 = measure(wrongSameLen3);
-
-    const max = Math.max(correctTime, wrongTime1, wrongTime2, wrongTime3);
-    const min = Math.min(correctTime, wrongTime1, wrongTime2, wrongTime3);
-    // Same-length inputs → same hash cost. Residual spread is JIT/GC noise
-    // only. 2× threshold catches any reintroduced length-based early return
-    // (old code showed >10× divergence) while tolerating CI runner variance.
-    expect(max / min).toBeLessThan(2);
   });
 
   it("does not require the collector token for same-origin UI mutation endpoints", async () => {

--- a/server/auth.test.ts
+++ b/server/auth.test.ts
@@ -13,6 +13,8 @@ describe("API auth boundaries", () => {
   let dataDir: string;
   let authenticateIngest: (req: Express.Request, res: Express.Response) => boolean;
   let createIngestAuthenticator: typeof import("./index").createIngestAuthenticator;
+  let defaultIngestTokenCrypto: typeof import("./index").defaultIngestTokenCrypto;
+  let ingestTokenDigestContext: typeof import("./index").INGEST_TOKEN_DIGEST_CONTEXT;
   const appOrigin = "https://pixel.test";
 
   beforeAll(async () => {
@@ -29,6 +31,8 @@ describe("API auth boundaries", () => {
     io = serverModule.io;
     authenticateIngest = serverModule.authenticateIngest;
     createIngestAuthenticator = serverModule.createIngestAuthenticator;
+    defaultIngestTokenCrypto = serverModule.defaultIngestTokenCrypto;
+    ingestTokenDigestContext = serverModule.INGEST_TOKEN_DIGEST_CONTEXT;
   });
 
   afterAll(() => {
@@ -92,8 +96,8 @@ describe("API auth boundaries", () => {
     expect(authenticate(makeReq("X".repeat(1000)), {} as Express.Response)).toBe(false);
 
     // Unicode token (UTF-8 must be handled consistently between env var
-    // and Bearer header — both go through sha256().update(string) which
-    // defaults to UTF-8 in Node).
+    // and Bearer header — both are normalized through HMAC-SHA-256, whose
+    // string inputs default to UTF-8 in Node).
     vi.stubEnv("INGEST_API_TOKEN", "café-secret");
     vi.resetModules();
     return import("./index").then((mod) => {
@@ -101,12 +105,12 @@ describe("API auth boundaries", () => {
       expect(unicodeAuth(makeReq("café-secret"), {} as Express.Response)).toBe(true);
       expect(unicodeAuth(makeReq("cafe-secret"), {} as Express.Response)).toBe(false);
 
-      // Restore the test secret for the timing test below
+      // Restore the test secret for the deterministic crypto-path test below.
       vi.stubEnv("INGEST_API_TOKEN", "test-secret");
       vi.resetModules();
       return import("./index").then((mod2) => {
         // Re-bind the describe-scoped binding to the re-imported function
-        // so the timing test sees the restored token.
+        // so the crypto-path test sees the restored token.
         authenticateIngest = mod2.authenticateIngest;
         expect(authenticateIngest(makeReq("test-secret"), {} as Express.Response)).toBe(true);
         expect(authenticateIngest(makeReq("not-a-secr"), {} as Express.Response)).toBe(false);
@@ -153,6 +157,19 @@ describe("API auth boundaries", () => {
       expect(configuredDigest).toHaveLength(32);
       expect(providedDigest).toHaveLength(32);
     }
+  });
+
+  it("pins the production ingest crypto policy to HMAC-SHA-256 and timingSafeEqual", () => {
+    const token = "production-policy-regression";
+    const expectedDigest = createHmac("sha256", token)
+      .update(ingestTokenDigestContext)
+      .digest();
+    const actualDigest = defaultIngestTokenCrypto.digestToken(token);
+
+    expect(Object.isFrozen(defaultIngestTokenCrypto)).toBe(true);
+    expect(actualDigest).toEqual(expectedDigest);
+    expect(actualDigest).toHaveLength(32);
+    expect(defaultIngestTokenCrypto.compareDigests).toBe(timingSafeEqual);
   });
 
   it("does not require the collector token for same-origin UI mutation endpoints", async () => {

--- a/server/auth.test.ts
+++ b/server/auth.test.ts
@@ -1,4 +1,4 @@
-import { createHash, timingSafeEqual } from "node:crypto";
+import { createHmac, timingSafeEqual } from "node:crypto";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -124,7 +124,9 @@ describe("API auth boundaries", () => {
       ({ headers: { authorization: `Bearer ${token}` } }) as unknown as Express.Request;
 
     const digestToken = vi.fn((token: string) =>
-      createHash("sha256").update(token).digest(),
+      createHmac("sha256", token)
+        .update("openclaw-pixel-agents:ingest-token:v1")
+        .digest(),
     );
     const compareDigests = vi.fn((configured: Buffer, provided: Buffer) =>
       timingSafeEqual(configured, provided),

--- a/server/index.ts
+++ b/server/index.ts
@@ -631,25 +631,39 @@ async function pollAndBroadcast(): Promise<void> {
 // ---- Ingest API (receives data from OpenClaw host collector) ----
 
 const INGEST_TOKEN = process.env.INGEST_API_TOKEN || "";
-// Pre-compute a fixed-length SHA-256 digest so the comparison never leaks the
-// configured token length via timing (CWE-208). Both sides are always 32 bytes
-// regardless of token length, eliminating the length-mismatch branch that
-// previously allowed timing side-channel analysis.
-//
-// Both INGEST_TOKEN (from env) and the provided Bearer header are JS strings;
-// createHash().update(string) defaults to UTF-8 in Node, so the two sides
-// agree on encoding for arbitrary Unicode tokens.
-const INGEST_TOKEN_DIGEST = INGEST_TOKEN
-  ? createHash("sha256").update(INGEST_TOKEN).digest()
-  : Buffer.alloc(32);
+type IngestTokenCrypto = Readonly<{
+  digestToken: (token: string) => Buffer;
+  compareDigests: (configured: Buffer, provided: Buffer) => boolean;
+}>;
 
-export function authenticateIngest(req: express.Request, _res: express.Response): boolean {
-  if (!INGEST_TOKEN) return false;
-  const auth = req.headers.authorization;
-  if (!auth || !auth.startsWith("Bearer ")) return false;
-  const provided = createHash("sha256").update(auth.slice(7)).digest();
-  return timingSafeEqual(INGEST_TOKEN_DIGEST, provided);
+const defaultIngestTokenCrypto: IngestTokenCrypto = {
+  // Both token sources are strings, and createHash uses UTF-8 for strings by
+  // default, so configured and provided Unicode tokens use the same encoding.
+  digestToken: (token) => createHash("sha256").update(token).digest(),
+  compareDigests: timingSafeEqual,
+};
+
+export function createIngestAuthenticator(
+  ingestToken: string,
+  crypto: IngestTokenCrypto = defaultIngestTokenCrypto,
+): (req: express.Request, res: express.Response) => boolean {
+  // Pre-compute a fixed-length SHA-256 digest so the comparison never leaks
+  // the configured token length via timing (CWE-208). Both sides are always
+  // 32 bytes regardless of token length.
+  const configuredDigest = ingestToken
+    ? crypto.digestToken(ingestToken)
+    : Buffer.alloc(32);
+
+  return (req: express.Request, _res: express.Response): boolean => {
+    if (!ingestToken) return false;
+    const auth = req.headers.authorization;
+    if (!auth || !auth.startsWith("Bearer ")) return false;
+    const providedDigest = crypto.digestToken(auth.slice(7));
+    return crypto.compareDigests(configuredDigest, providedDigest);
+  };
 }
+
+export const authenticateIngest = createIngestAuthenticator(INGEST_TOKEN);
 
 /**
  * POST /api/ingest/agents

--- a/server/index.ts
+++ b/server/index.ts
@@ -631,21 +631,24 @@ async function pollAndBroadcast(): Promise<void> {
 // ---- Ingest API (receives data from OpenClaw host collector) ----
 
 const INGEST_TOKEN = process.env.INGEST_API_TOKEN || "";
-type IngestTokenCrypto = Readonly<{
+export type IngestTokenCrypto = Readonly<{
   digestToken: (token: string) => Buffer;
   compareDigests: (configured: Buffer, provided: Buffer) => boolean;
 }>;
 
-const defaultIngestTokenCrypto: IngestTokenCrypto = {
+export const INGEST_TOKEN_DIGEST_CONTEXT =
+  "openclaw-pixel-agents:ingest-token:v1";
+
+export const defaultIngestTokenCrypto = Object.freeze<IngestTokenCrypto>({
   // HMAC treats each bearer token as cryptographic key material and produces
   // a fixed 32-byte value without misclassifying the token as a stored user
   // password. Node encodes both string token sources as UTF-8.
   digestToken: (token) =>
     createHmac("sha256", token)
-      .update("openclaw-pixel-agents:ingest-token:v1")
+      .update(INGEST_TOKEN_DIGEST_CONTEXT)
       .digest(),
   compareDigests: timingSafeEqual,
-};
+});
 
 export function createIngestAuthenticator(
   ingestToken: string,

--- a/server/index.ts
+++ b/server/index.ts
@@ -12,7 +12,7 @@ import { createServer } from "http";
 import { Server as SocketIOServer } from "socket.io";
 import { readFileSync, writeFileSync, existsSync, mkdirSync, readdirSync, unlinkSync, createReadStream } from "node:fs";
 import { stat as statAsync } from "node:fs/promises";
-import { createHash, randomUUID, timingSafeEqual } from "node:crypto";
+import { createHmac, randomUUID, timingSafeEqual } from "node:crypto";
 import { join, resolve } from "node:path";
 import { createInterface } from "node:readline";
 import { applyAgentSnapshot } from "./agentSnapshots";
@@ -637,9 +637,13 @@ type IngestTokenCrypto = Readonly<{
 }>;
 
 const defaultIngestTokenCrypto: IngestTokenCrypto = {
-  // Both token sources are strings, and createHash uses UTF-8 for strings by
-  // default, so configured and provided Unicode tokens use the same encoding.
-  digestToken: (token) => createHash("sha256").update(token).digest(),
+  // HMAC treats each bearer token as cryptographic key material and produces
+  // a fixed 32-byte value without misclassifying the token as a stored user
+  // password. Node encodes both string token sources as UTF-8.
+  digestToken: (token) =>
+    createHmac("sha256", token)
+      .update("openclaw-pixel-agents:ingest-token:v1")
+      .digest(),
   compareDigests: timingSafeEqual,
 };
 
@@ -647,9 +651,9 @@ export function createIngestAuthenticator(
   ingestToken: string,
   crypto: IngestTokenCrypto = defaultIngestTokenCrypto,
 ): (req: express.Request, res: express.Response) => boolean {
-  // Pre-compute a fixed-length SHA-256 digest so the comparison never leaks
-  // the configured token length via timing (CWE-208). Both sides are always
-  // 32 bytes regardless of token length.
+  // Pre-compute a fixed-length HMAC-SHA-256 digest so the comparison never
+  // leaks the configured token length via timing (CWE-208). Both sides are
+  // always 32 bytes regardless of token length.
   const configuredDigest = ingestToken
     ? crypto.digestToken(ingestToken)
     : Buffer.alloc(32);

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,5 +6,13 @@ export default defineConfig({
     setupFiles: ['./src/test/setup.ts'],
     clearMocks: true,
     exclude: [...configDefaults.exclude, '**/dist/**', '.worktrees/**'],
+    coverage: {
+      thresholds: {
+        branches: 40,
+        functions: 40,
+        lines: 40,
+        statements: 40,
+      },
+    },
   },
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,11 +7,13 @@ export default defineConfig({
     clearMocks: true,
     exclude: [...configDefaults.exclude, '**/dist/**', '.worktrees/**'],
     coverage: {
+      include: ['src/**/*.{ts,tsx}', 'server/**/*.ts', 'shared/**/*.ts'],
+      exclude: ['**/*.test.{ts,tsx}', 'src/test/**', 'src/vite-env.d.ts'],
       thresholds: {
-        branches: 40,
-        functions: 40,
-        lines: 40,
-        statements: 40,
+        branches: 36,
+        functions: 37,
+        lines: 41,
+        statements: 39,
       },
     },
   },

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
     coverage: {
       include: ['src/**/*.{ts,tsx}', 'server/**/*.ts', 'shared/**/*.ts'],
       exclude: ['**/*.test.{ts,tsx}', 'src/test/**', 'src/vite-env.d.ts'],
+      // Floors round down the measured repository-wide baseline; re-evaluate all four together.
       thresholds: {
         branches: 36,
         functions: 37,


### PR DESCRIPTION
Closes #104.
Closes #106.

## Summary

- add a least-privilege CI workflow for install, typecheck, tests, repository-wide coverage, build, and production dependency audit
- add pull-request dependency review and scheduled/push/PR CodeQL analysis
- pin every third-party workflow action to a full commit SHA
- add weekly npm and GitHub Actions Dependabot updates
- replace #104's contention-sensitive timing ratio with deterministic proof that every Bearer token reaches HMAC-SHA-256 and a 32-byte `timingSafeEqual` comparison
- document the local and hosted quality gate

## Repository security settings

- enabled Dependabot vulnerability alerts and security updates
- enabled secret scanning and push protection
- confirmed the repository-wide Actions default is read-only
- protected `main` with app-bound CI, dependency-review, CodeQL-analysis, and CodeQL-result checks
- require up-to-date pull requests, resolved conversations, and linear history
- enforce protection for administrators; force-push and branch deletion are disabled

The repository has one collaborator, so no formal approval rule is configured; requiring one would permanently deadlock owner-authored pull requests. Automated checks and conversation resolution remain mandatory.

## Verification

- `actionlint` v1.7.7: passed
- `npm ci`: passed
- focused auth tests: 11/11 passed
- `npm run typecheck`: passed
- `npm test`: 161/161 passed
- `npm run test:coverage`: 161/161 passed; 39.17% statements, 36.19% branches, 37.50% functions, 41.12% lines across all production TypeScript
- `npm run build`: passed
- `npm audit --omit=dev --audit-level=high`: 0 vulnerabilities
- `git diff --check`: passed
- hosted CI, dependency review, CodeQL analysis, and CodeQL security result: passed

## CI-discovered prerequisites

The first hosted run reproduced #104 at a ratio of `2.0005855727471316`, only 0.029% over its `< 2` wall-clock threshold. The authentication implementation still normalized both inputs and compared fixed 32-byte digests; the failing oracle measured shared-runner contention. The replacement uses an injected crypto seam to prove the path deterministically.

The first CodeQL analysis then classified raw SHA-256 token normalization as insufficient password hashing. The ingest secret is a high-entropy bearer token rather than a stored user password, but the implementation now uses domain-separated HMAC-SHA-256, which is also semantically clearer for cryptographic key material. GitHub marks the alert fixed; it was not suppressed or dismissed.


<!-- kody-pr-summary:start -->
## Summary

This pull request hardens the CI pipeline and locks in the ingest token authentication policy as a security regression test.

### CI workflow upgrades
- **`.github/workflows/ci.yml`**: Pinned `actions/checkout`, `actions/setup-node`, and `actions/dependency-review-action` to newer major versions (v7.0.1, v7.0.0, and v5.0.0 respectively) so the CI runs on maintained action releases.
- **`.github/workflows/codeql.yml`**: Upgraded `actions/checkout` to v7.0.1 and `github/codeql-action` (both `init` and `analyze`) to v4.37.3, keeping the static-analysis pipeline aligned with supported versions.

### Ingest token crypto policy pin (issue #106)
- **`server/index.ts`**: 
  - Exported the `IngestTokenCrypto` type so tests can reference the production contract.
  - Extracted the HMAC context string into a named, exported constant `INGEST_TOKEN_DIGEST_CONTEXT` so the value used in production is observable from tests.
  - Froze the `defaultIngestTokenCrypto` object so its references (e.g. `compareDigests`) cannot be swapped out at runtime.
- **`server/auth.test.ts`**: 
  - Imported the newly exported `defaultIngestTokenCrypto` and `INGEST_TOKEN_DIGEST_CONTEXT`.
  - Added a regression test that pins the production ingest crypto policy: verifies the object is frozen, `digestToken` produces a 32-byte HMAC-SHA-256 digest using the production context, and `compareDigests` is `timingSafeEqual`. This prevents silent regressions where the token handling could be weakened (e.g., switched to a plain hash, longer/short digest, or a non-constant-time comparator).
  - Updated wording in the existing Unicode-token test to reflect the switch from `sha256().update(string)` to HMAC-SHA-256.
<!-- kody-pr-summary:end -->