### PR TITLE
fix: validate ingest sessions before transcript access

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,11 @@ Just run it on the same machine as OpenClaw. No extra configuration needed.
    sudo systemctl enable --now openclaw-pixel-collector.timer
    ```
 
+The ingest endpoint validates the collector's session schema, registered agent IDs,
+field sizes, and opaque session IDs before applying an update. Invalid payloads
+return HTTP 400; upgrade the collector and server together if the OpenClaw session
+schema changes.
+
 See [collector/README.md](collector/README.md) for full setup instructions.
 
 ### Key Components

--- a/README.md
+++ b/README.md
@@ -134,10 +134,10 @@ Just run it on the same machine as OpenClaw. No extra configuration needed.
    sudo systemctl enable --now openclaw-pixel-collector.timer
    ```
 
-The ingest endpoint validates the collector's session schema, registered agent IDs,
-field sizes, and opaque session IDs before applying an update. Invalid payloads
-return HTTP 400; upgrade the collector and server together if the OpenClaw session
-schema changes.
+The ingest endpoint accepts additive fields from OpenClaw's evolving session output,
+then sanitizes each entry into the small session shape used by this server. Registered
+agent IDs, retained field types and sizes, and opaque session IDs are validated before
+an update is applied; invalid retained fields return HTTP 400.
 
 See [collector/README.md](collector/README.md) for full setup instructions.
 

--- a/server/auth.test.ts
+++ b/server/auth.test.ts
@@ -129,10 +129,27 @@ describe("API auth boundaries", () => {
       .expect({ error: "Missing or invalid 'sessions' array" });
   });
 
-  it("rejects unknown agents, fields, and oversized values", async () => {
+  it("maps malformed JSON to 400 before ingest authentication", async () => {
+    await request(app)
+      .post("/api/ingest/agents")
+      .set("Content-Type", "application/json")
+      .send('{"sessions":[')
+      .expect(400)
+      .expect({ error: "Malformed JSON body" });
+  });
+
+  it("maps oversized JSON to 413 before ingest authentication", async () => {
+    await request(app)
+      .post("/api/ingest/agents")
+      .set("Content-Type", "application/json")
+      .send(JSON.stringify({ payload: "x".repeat(101 * 1024) }))
+      .expect(413)
+      .expect({ error: "Request body too large" });
+  });
+
+  it("rejects unknown agents and oversized known values", async () => {
     const invalidSessions = [
       { key: "agent:unknown:test", agentId: "unknown" },
-      { key: "agent:main:test", agentId: "main", unexpected: true },
       { key: "agent:main:test", agentId: "main", model: "x".repeat(257) },
     ];
 
@@ -160,6 +177,7 @@ describe("API auth boundaries", () => {
           modelProvider: "openai",
           sessionId: "123e4567-e89b-12d3-a456-426614174000",
           updatedAt: Date.now(),
+          spawnedBy: "agent:main:fixture-parent",
         }],
       })
       .expect(200)

--- a/server/auth.test.ts
+++ b/server/auth.test.ts
@@ -15,13 +15,27 @@ describe("API auth boundaries", () => {
   let createIngestAuthenticator: typeof import("./index").createIngestAuthenticator;
   let defaultIngestTokenCrypto: typeof import("./index").defaultIngestTokenCrypto;
   let ingestTokenDigestContext: typeof import("./index").INGEST_TOKEN_DIGEST_CONTEXT;
+  let tailTranscript: typeof import("./index").tailTranscript;
+  let outsideTranscriptPath: string;
   const appOrigin = "https://pixel.test";
 
   beforeAll(async () => {
     dataDir = mkdtempSync(join(tmpdir(), "pixel-agents-auth-test-"));
+    const agentsDir = join(dataDir, "agents");
+    mkdirSync(agentsDir, { recursive: true });
+    outsideTranscriptPath = join(dataDir, "outside.jsonl");
+    writeFileSync(
+      outsideTranscriptPath,
+      `${JSON.stringify({
+        role: "assistant",
+        content: "outside transcript secret",
+        timestamp: Date.now(),
+      })}\n`,
+    );
     vi.stubEnv("DATA_DIR", dataDir);
     vi.stubEnv("DATA_SOURCE", "ingest");
     vi.stubEnv("INGEST_API_TOKEN", "test-secret");
+    vi.stubEnv("OPENCLAW_AGENTS_DIR", agentsDir);
     vi.stubEnv("NODE_ENV", "production");
     vi.stubEnv("CORS_ORIGIN", appOrigin);
 
@@ -33,6 +47,7 @@ describe("API auth boundaries", () => {
     createIngestAuthenticator = serverModule.createIngestAuthenticator;
     defaultIngestTokenCrypto = serverModule.defaultIngestTokenCrypto;
     ingestTokenDigestContext = serverModule.INGEST_TOKEN_DIGEST_CONTEXT;
+    tailTranscript = serverModule.tailTranscript;
   });
 
   afterAll(() => {
@@ -71,6 +86,104 @@ describe("API auth boundaries", () => {
         expect(response.body).toMatchObject({ ok: true, received: 0 });
         expect(response.body.agents).toBeGreaterThanOrEqual(0);
       });
+  });
+
+  it.each([
+    "../outside",
+    "/tmp/outside",
+  ])("rejects unsafe collector sessionId %s", async (sessionId) => {
+    await request(app)
+      .post("/api/ingest/agents")
+      .set("Authorization", "Bearer test-secret")
+      .send({
+        sessions: [{
+          key: "agent:main:test",
+          agentId: "main",
+          sessionId,
+        }],
+      })
+      .expect(400)
+      .expect({ error: "Invalid sessions payload" });
+  });
+
+  it("rejects malformed sub-agent keys with 400 instead of throwing", async () => {
+    await request(app)
+      .post("/api/ingest/agents")
+      .set("Authorization", "Bearer test-secret")
+      .send({
+        sessions: [{
+          key: 123,
+          agentId: "main",
+          kind: "subagent",
+        }],
+      })
+      .expect(400)
+      .expect({ error: "Invalid sessions payload" });
+  });
+
+  it("rejects a missing collector body with 400 instead of throwing", async () => {
+    await request(app)
+      .post("/api/ingest/agents")
+      .set("Authorization", "Bearer test-secret")
+      .expect(400)
+      .expect({ error: "Missing or invalid 'sessions' array" });
+  });
+
+  it("rejects unknown agents, fields, and oversized values", async () => {
+    const invalidSessions = [
+      { key: "agent:unknown:test", agentId: "unknown" },
+      { key: "agent:main:test", agentId: "main", unexpected: true },
+      { key: "agent:main:test", agentId: "main", model: "x".repeat(257) },
+    ];
+
+    for (const session of invalidSessions) {
+      await request(app)
+        .post("/api/ingest/agents")
+        .set("Authorization", "Bearer test-secret")
+        .send({ sessions: [session] })
+        .expect(400)
+        .expect({ error: "Invalid sessions payload" });
+    }
+  });
+
+  it("maps and broadcasts a valid collector session", async () => {
+    const emitSpy = vi.spyOn(io, "emit");
+
+    await request(app)
+      .post("/api/ingest/agents")
+      .set("Authorization", "Bearer test-secret")
+      .send({
+        sessions: [{
+          key: "agent:main:test",
+          agentId: "main",
+          model: "gpt-5",
+          modelProvider: "openai",
+          sessionId: "123e4567-e89b-12d3-a456-426614174000",
+          updatedAt: Date.now(),
+        }],
+      })
+      .expect(200)
+      .expect((response) => {
+        expect(response.body).toMatchObject({ ok: true, received: 1 });
+        expect(response.body.agents).toBeGreaterThan(0);
+      });
+
+    expect(emitSpy).toHaveBeenCalledWith(
+      "agents:update",
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "main",
+          sessionKey: "agent:main:test",
+        }),
+      ]),
+    );
+    emitSpy.mockRestore();
+  });
+
+  it("refuses to read a transcript outside the registered agent's sessions directory", async () => {
+    await expect(
+      tailTranscript("main", "Shodan", outsideTranscriptPath),
+    ).resolves.toEqual([]);
   });
 
   it("authenticateIngest is functionally correct across token shapes", () => {

--- a/server/errors.test.ts
+++ b/server/errors.test.ts
@@ -13,6 +13,12 @@ function spyOnLoggerError(): MockInstance<Logger["error"]> {
     .mockImplementation((() => logger) as unknown as Logger["error"]);
 }
 
+function spyOnLoggerWarn(): MockInstance<Logger["warn"]> {
+  return vi
+    .spyOn(logger, "warn")
+    .mockImplementation((() => logger) as unknown as Logger["warn"]);
+}
+
 describe("Express error boundary", () => {
   afterEach(() => {
     vi.restoreAllMocks();
@@ -46,6 +52,57 @@ describe("Express error boundary", () => {
       .get("/health")
       .expect(200)
       .expect({ ok: true });
+  });
+
+  it("maps malformed JSON to 400 without logging the raw body", async () => {
+    const errorSpy = spyOnLoggerError();
+    const warnSpy = spyOnLoggerWarn();
+    const rawMarker = "malformed-sensitive-marker";
+    const app = express();
+    app.use(express.json({ limit: "100kb" }));
+    app.post("/ingest", (_req, res) => res.json({ ok: true }));
+    app.use(apiErrorHandler);
+
+    await request(app)
+      .post("/ingest")
+      .set("Content-Type", "application/json")
+      .send(`{"sessions":[${rawMarker}`)
+      .expect(400)
+      .expect({ error: "Malformed JSON body" });
+
+    expect(errorSpy).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ errorType: "entity.parse.failed" }),
+      "[api request rejected]",
+    );
+    expect(JSON.stringify(warnSpy.mock.calls)).not.toContain(rawMarker);
+  });
+
+  it("maps oversized JSON to 413 without logging the raw body", async () => {
+    const errorSpy = spyOnLoggerError();
+    const warnSpy = spyOnLoggerWarn();
+    const rawMarker = "oversized-sensitive-marker";
+    const app = express();
+    app.use(express.json({ limit: "1kb" }));
+    app.post("/ingest", (_req, res) => res.json({ ok: true }));
+    app.use(apiErrorHandler);
+
+    await request(app)
+      .post("/ingest")
+      .set("Content-Type", "application/json")
+      .send(JSON.stringify({ payload: `${rawMarker}${"x".repeat(2048)}` }))
+      .expect(413)
+      .expect({ error: "Request body too large" });
+
+    expect(errorSpy).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        errorType: "entity.too.large",
+        limit: 1024,
+      }),
+      "[api request rejected]",
+    );
+    expect(JSON.stringify(warnSpy.mock.calls)).not.toContain(rawMarker);
   });
 
   it("normalizes async string rejections so the logged err is an Error preserving the original on cause", async () => {

--- a/server/errors.ts
+++ b/server/errors.ts
@@ -3,6 +3,49 @@ import { logger } from "./logger";
 
 type AsyncRequestHandler = (req: Request, res: Response, next: NextFunction) => unknown | Promise<unknown>;
 
+type BodyParserFailure = {
+  type: "entity.parse.failed" | "entity.too.large";
+  status: 400 | 413;
+  response: string;
+  limit?: number;
+  length?: number;
+};
+
+function boundedNonNegativeNumber(value: unknown): number | undefined {
+  return typeof value === "number"
+    && Number.isFinite(value)
+    && value >= 0
+    ? value
+    : undefined;
+}
+
+function classifyBodyParserFailure(value: unknown): BodyParserFailure | null {
+  if (!(value instanceof Error)) return null;
+  const candidate = value as Error & {
+    type?: unknown;
+    limit?: unknown;
+    length?: unknown;
+  };
+
+  if (candidate.type === "entity.parse.failed") {
+    return {
+      type: candidate.type,
+      status: 400,
+      response: "Malformed JSON body",
+    };
+  }
+  if (candidate.type === "entity.too.large") {
+    return {
+      type: candidate.type,
+      status: 413,
+      response: "Request body too large",
+      limit: boundedNonNegativeNumber(candidate.limit),
+      length: boundedNonNegativeNumber(candidate.length),
+    };
+  }
+  return null;
+}
+
 export function asyncHandler(handler: AsyncRequestHandler): RequestHandler {
   return (req, res, next) => {
     Promise.resolve(handler(req, res, next)).catch(next);
@@ -17,6 +60,20 @@ export const apiErrorHandler: ErrorRequestHandler = (err, req, res, next) => {
 
   // Use the per-request child logger if available, otherwise fall back to the base logger.
   const log = req.log ?? logger;
+  const bodyParserFailure = classifyBodyParserFailure(err);
+  if (bodyParserFailure) {
+    // body-parser parse failures can carry the raw request body on `err.body`.
+    // Log only bounded metadata and never pass the original error to pino.
+    log.warn({
+      errorType: bodyParserFailure.type,
+      reqId: req.id,
+      limit: bodyParserFailure.limit,
+      length: bodyParserFailure.length,
+    }, "[api request rejected]");
+    res.status(bodyParserFailure.status).json({ error: bodyParserFailure.response });
+    return;
+  }
+
   // Normalize non-Error rejections (string/object) so pino's { err } serializer
   // produces a real Error — stringification alone drops stacks and loses the
   // original reason.

--- a/server/fixtures/openclaw-sessions-v2026.7.2.json
+++ b/server/fixtures/openclaw-sessions-v2026.7.2.json
@@ -1,0 +1,40 @@
+{
+  "source": "Shape captured from `openclaw sessions --all-agents --json`; identifying values replaced for regression safety.",
+  "openclawVersion": "2026.7.2-beta.3",
+  "sessions": [
+    {
+      "key": "agent:main:subagent:fixture",
+      "agentId": "main",
+      "model": "gpt-5",
+      "modelProvider": "openai",
+      "totalTokens": 1234,
+      "contextTokens": 200000,
+      "updatedAt": null,
+      "ageMs": null,
+      "kind": "subagent",
+      "status": "active",
+      "abortedLastRun": false,
+      "inputTokens": 100,
+      "outputTokens": 200,
+      "sessionId": "123e4567-e89b-12d3-a456-426614174000",
+      "sessionFile": "/collector/.openclaw/agents/main/sessions/fixture.jsonl",
+      "spawnedBy": "agent:main:fixture-parent",
+      "spawnedWorkspaceDir": "/collector/workspace",
+      "spawnedCwd": "/collector/workspace/project",
+      "parentSessionKey": "agent:main:fixture-parent",
+      "forkedFromParent": true,
+      "spawnDepth": 1,
+      "subagentRole": "worker",
+      "subagentControlScope": "parent",
+      "verboseLevel": "full",
+      "traceLevel": "off",
+      "elevatedLevel": "off",
+      "responseUsage": {
+        "inputTokens": 100,
+        "outputTokens": 200
+      },
+      "groupActivation": "mention",
+      "runtimePolicySessionKey": "agent:main:fixture-policy"
+    }
+  ]
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -735,17 +735,23 @@ app.post("/api/ingest/agents", (req, res) => {
     return;
   }
 
-  const parsedSessions = parseIngestSessions(
+  const parsedSessionsResult = parseIngestSessions(
     sessions,
     new Set(AGENT_REGISTRY.keys()),
   );
-  if (!parsedSessions) {
+  if (!parsedSessionsResult.ok) {
+    logger.warn({
+      subsystem: "ingest",
+      validationCode: parsedSessionsResult.error.code,
+      sessionIndex: parsedSessionsResult.error.sessionIndex,
+      field: parsedSessionsResult.error.field,
+    }, "ingest payload rejected");
     res.status(400).json({ error: "Invalid sessions payload" });
     return;
   }
 
   // Map and broadcast
-  const agentMap = mapToAgentStates(parsedSessions);
+  const agentMap = mapToAgentStates(parsedSessionsResult.sessions);
   const { snapshot } = applyAgentSnapshot(agentStates, agentMap);
 
   lastIngestAt = Date.now();

--- a/server/index.ts
+++ b/server/index.ts
@@ -19,6 +19,12 @@ import { applyAgentSnapshot } from "./agentSnapshots";
 import { correlationMiddleware, httpRequestLogMiddleware } from "./correlation";
 import { createCorsConfig, isOriginAllowed } from "./cors";
 import { apiErrorHandler, registerProcessErrorHandlers } from "./errors";
+import {
+  isTranscriptPathContained,
+  parseIngestSessions,
+  resolveTranscriptPath,
+  type CliSession,
+} from "./ingestSessions";
 import { isValidLayoutId } from "./layouts";
 import { logger } from "./logger";
 import { parseLayoutMutationBody, parseOfficeLayoutDoc, parsePersistedPrefs, parseRecipe, parseSpriteBody, parseTagsBody, parseToggleBody, type OfficeLayoutDoc, type PersistedPrefs } from "./validation";
@@ -198,23 +204,6 @@ const agentTranscriptPaths = new Map<string, string>();
 
 // ---- CLI data source ----
 
-interface CliSession {
-  key: string;
-  agentId: string;
-  model?: string;
-  modelProvider?: string;
-  totalTokens?: number | null;
-  contextTokens?: number | null;
-  updatedAt?: number;
-  kind?: string;
-  status?: string;
-  abortedLastRun?: boolean;
-  inputTokens?: number;
-  outputTokens?: number;
-  sessionId?: string;
-  thinkingLevel?: string;
-}
-
 interface CliSessionsResult {
   sessions: CliSession[];
   count: number;
@@ -314,6 +303,7 @@ function mapToAgentStates(cliSessions: CliSession[]): Map<string, AgentState> {
     const sessions = byAgent.get(agentId);
     const sorted = sessions ? [...sessions].sort((a, b) => (b.updatedAt ?? 0) - (a.updatedAt ?? 0)) : [];
     const latestSession = sorted[0];
+    agentTranscriptPaths.delete(agentId);
 
     if (latestSession) {
       const activity = inferActivity(latestSession);
@@ -323,8 +313,12 @@ function mapToAgentStates(cliSessions: CliSession[]): Map<string, AgentState> {
 
       // Capture transcript path for message ticker polling
       if (latestSession.sessionId) {
-        const transcriptPath = join(AGENTS_DIR, agentId, "sessions", `${latestSession.sessionId}.jsonl`);
-        agentTranscriptPaths.set(agentId, transcriptPath);
+        const transcriptPath = resolveTranscriptPath(
+          AGENTS_DIR,
+          agentId,
+          latestSession.sessionId,
+        );
+        if (transcriptPath) agentTranscriptPaths.set(agentId, transcriptPath);
       }
 
       results.set(agentId, {
@@ -424,12 +418,17 @@ function extractText(content: unknown): string {
  * Uses a byte-offset to seek directly to the end of what was already read,
  * so each poll cycle reads only the newly-appended lines.
  */
-async function tailTranscript(
+export async function tailTranscript(
   agentId: string,
   agentName: string,
   transcriptPath: string | undefined,
 ): Promise<TickerMessage[]> {
-  if (!transcriptPath) return [];
+  if (
+    !transcriptPath
+    || !isTranscriptPathContained(AGENTS_DIR, agentId, transcriptPath)
+  ) {
+    return [];
+  }
 
   const key = `${agentId}:${transcriptPath}`;
   const offset = lastReadOffset.get(key) ?? 0;
@@ -726,7 +725,7 @@ app.post("/api/ingest/agents", (req, res) => {
   recentRequests.push(now);
   ingestRateBuckets.set(rateKey, recentRequests);
 
-  const { sessions } = req.body;
+  const sessions = req.body?.sessions;
   if (!Array.isArray(sessions)) {
     res.status(400).json({ error: "Missing or invalid 'sessions' array" });
     return;
@@ -736,8 +735,17 @@ app.post("/api/ingest/agents", (req, res) => {
     return;
   }
 
+  const parsedSessions = parseIngestSessions(
+    sessions,
+    new Set(AGENT_REGISTRY.keys()),
+  );
+  if (!parsedSessions) {
+    res.status(400).json({ error: "Invalid sessions payload" });
+    return;
+  }
+
   // Map and broadcast
-  const agentMap = mapToAgentStates(sessions as CliSession[]);
+  const agentMap = mapToAgentStates(parsedSessions);
   const { snapshot } = applyAgentSnapshot(agentStates, agentMap);
 
   lastIngestAt = Date.now();

--- a/server/ingestSessions.test.ts
+++ b/server/ingestSessions.test.ts
@@ -5,6 +5,7 @@ import {
   parseIngestSessions,
   resolveTranscriptPath,
 } from "./ingestSessions";
+import upstreamFixture from "./fixtures/openclaw-sessions-v2026.7.2.json";
 
 const knownAgentIds = new Set(["main", "cybera"]);
 
@@ -39,13 +40,51 @@ const validSession = {
 
 describe("parseIngestSessions", () => {
   it("accepts the current collector session schema", () => {
-    const { sessionFile: collectorLocalPath, ...mappedSession } = validSession;
-
-    expect(collectorLocalPath).toContain("/home/test/.openclaw/");
     expect(parseIngestSessions([validSession], knownAgentIds)).toEqual({
       ok: true,
-      sessions: [mappedSession],
+      sessions: [{
+        key: validSession.key,
+        agentId: validSession.agentId,
+        model: validSession.model,
+        modelProvider: validSession.modelProvider,
+        totalTokens: validSession.totalTokens,
+        contextTokens: validSession.contextTokens,
+        updatedAt: validSession.updatedAt,
+        kind: validSession.kind,
+        status: validSession.status,
+        abortedLastRun: validSession.abortedLastRun,
+        inputTokens: validSession.inputTokens,
+        outputTokens: validSession.outputTokens,
+        sessionId: validSession.sessionId,
+      }],
     });
+  });
+
+  it("accepts and sanitizes a captured upstream session shape", () => {
+    const result = parseIngestSessions(upstreamFixture.sessions, knownAgentIds);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    expect(result.sessions).toEqual([
+      {
+        key: "agent:main:subagent:fixture",
+        agentId: "main",
+        model: "gpt-5",
+        modelProvider: "openai",
+        totalTokens: 1234,
+        contextTokens: 200000,
+        updatedAt: null,
+        kind: "subagent",
+        status: "active",
+        abortedLastRun: false,
+        inputTokens: 100,
+        outputTokens: 200,
+        sessionId: "123e4567-e89b-12d3-a456-426614174000",
+      },
+    ]);
+    expect(result.sessions[0]).not.toHaveProperty("spawnedBy");
+    expect(result.sessions[0]).not.toHaveProperty("sessionFile");
   });
 
   it.each([
@@ -80,7 +119,7 @@ describe("parseIngestSessions", () => {
     });
   });
 
-  it("rejects unknown agents, unknown fields, and overlong fields", () => {
+  it("rejects unknown agents and overlong known fields while dropping unknown fields", () => {
     expect(parseIngestSessions([
       { ...validSession, agentId: "unknown" },
     ], knownAgentIds)).toMatchObject({
@@ -90,14 +129,29 @@ describe("parseIngestSessions", () => {
     expect(parseIngestSessions([
       { ...validSession, unexpected: true },
     ], knownAgentIds)).toMatchObject({
-      ok: false,
-      error: { code: "unknown-field" },
+      ok: true,
+      sessions: [expect.not.objectContaining({ unexpected: true })],
     });
     expect(parseIngestSessions([
       { ...validSession, model: "x".repeat(257) },
     ], knownAgentIds)).toMatchObject({
       ok: false,
       error: { code: "invalid-string", field: "model" },
+    });
+  });
+
+  it.each([
+    "__proto__",
+    "constructor",
+    "prototype",
+  ])("rejects reserved object key %s instead of copying it", (reservedKey) => {
+    const session = JSON.parse(
+      `{"key":"agent:main:test","agentId":"main","${reservedKey}":{"polluted":true}}`,
+    );
+
+    expect(parseIngestSessions([session], knownAgentIds)).toMatchObject({
+      ok: false,
+      error: { code: "reserved-field" },
     });
   });
 });

--- a/server/ingestSessions.test.ts
+++ b/server/ingestSessions.test.ts
@@ -1,0 +1,112 @@
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  isTranscriptPathContained,
+  parseIngestSessions,
+  resolveTranscriptPath,
+} from "./ingestSessions";
+
+const knownAgentIds = new Set(["main", "cybera"]);
+
+const validSession = {
+  key: "agent:main:telegram:direct:123",
+  agentId: "main",
+  model: "gpt-5",
+  modelProvider: "openai",
+  totalTokens: 1234,
+  contextTokens: 200000,
+  updatedAt: 1_753_300_000_000,
+  kind: "direct",
+  status: "active",
+  abortedLastRun: false,
+  inputTokens: 100,
+  outputTokens: 200,
+  sessionId: "123e4567-e89b-12d3-a456-426614174000",
+  thinkingLevel: "high",
+  ageMs: 1000,
+  acpRuntime: false,
+  agentRuntime: { id: "codex", source: "openclaw" },
+  lastInteractionAt: 1_753_300_000_000,
+  modelOverride: "gpt-5",
+  providerOverride: "openai",
+  reasoningLevel: "high",
+  sessionFile: "/home/test/.openclaw/agents/main/sessions/session.jsonl",
+  sessionStartedAt: 1_753_299_000_000,
+  systemSent: true,
+  totalTokensFresh: true,
+};
+
+describe("parseIngestSessions", () => {
+  it("accepts the current collector session schema", () => {
+    expect(parseIngestSessions([validSession], knownAgentIds)).toEqual([validSession]);
+  });
+
+  it.each([
+    "../outside",
+    "..\\outside",
+    "/tmp/outside",
+    "C:\\outside",
+    "nested/session",
+  ])("rejects unsafe sessionId %s", (sessionId) => {
+    expect(parseIngestSessions([{ ...validSession, sessionId }], knownAgentIds)).toBeNull();
+  });
+
+  it("rejects non-string sub-agent keys before mapping", () => {
+    expect(parseIngestSessions([
+      { ...validSession, kind: "subagent", key: 123 },
+    ], knownAgentIds)).toBeNull();
+  });
+
+  it("rejects unknown agents, unknown fields, and overlong fields", () => {
+    expect(parseIngestSessions([
+      { ...validSession, agentId: "unknown" },
+    ], knownAgentIds)).toBeNull();
+    expect(parseIngestSessions([
+      { ...validSession, unexpected: true },
+    ], knownAgentIds)).toBeNull();
+    expect(parseIngestSessions([
+      { ...validSession, model: "x".repeat(257) },
+    ], knownAgentIds)).toBeNull();
+  });
+});
+
+describe("transcript path containment", () => {
+  const agentsDir = "/srv/openclaw/agents";
+
+  it("resolves an opaque session ID inside the registered agent's sessions directory", () => {
+    const transcriptPath = resolveTranscriptPath(
+      agentsDir,
+      "main",
+      "123e4567-e89b-12d3-a456-426614174000",
+    );
+
+    expect(transcriptPath).toBe(
+      resolve(
+        agentsDir,
+        "main",
+        "sessions",
+        "123e4567-e89b-12d3-a456-426614174000.jsonl",
+      ),
+    );
+    expect(isTranscriptPathContained(agentsDir, "main", transcriptPath!)).toBe(true);
+  });
+
+  it("rejects paths outside the expected agent sessions directory at the sink", () => {
+    expect(
+      isTranscriptPathContained(
+        agentsDir,
+        "main",
+        resolve(agentsDir, "cybera", "sessions", "session.jsonl"),
+      ),
+    ).toBe(false);
+    expect(
+      isTranscriptPathContained(agentsDir, "main", "/tmp/outside.jsonl"),
+    ).toBe(false);
+    expect(
+      isTranscriptPathContained(agentsDir, "../../tmp", "/tmp/session.jsonl"),
+    ).toBe(false);
+    expect(
+      resolveTranscriptPath(agentsDir, "../../tmp", "session"),
+    ).toBeNull();
+  });
+});

--- a/server/ingestSessions.test.ts
+++ b/server/ingestSessions.test.ts
@@ -39,9 +39,12 @@ const validSession = {
 
 describe("parseIngestSessions", () => {
   it("accepts the current collector session schema", () => {
+    const { sessionFile: collectorLocalPath, ...mappedSession } = validSession;
+
+    expect(collectorLocalPath).toContain("/home/test/.openclaw/");
     expect(parseIngestSessions([validSession], knownAgentIds)).toEqual({
       ok: true,
-      sessions: [validSession],
+      sessions: [mappedSession],
     });
   });
 

--- a/server/ingestSessions.test.ts
+++ b/server/ingestSessions.test.ts
@@ -17,6 +17,7 @@ const validSession = {
   contextTokens: 200000,
   updatedAt: 1_753_300_000_000,
   kind: "direct",
+  label: "Primary session",
   status: "active",
   abortedLastRun: false,
   inputTokens: 100,
@@ -38,7 +39,10 @@ const validSession = {
 
 describe("parseIngestSessions", () => {
   it("accepts the current collector session schema", () => {
-    expect(parseIngestSessions([validSession], knownAgentIds)).toEqual([validSession]);
+    expect(parseIngestSessions([validSession], knownAgentIds)).toEqual({
+      ok: true,
+      sessions: [validSession],
+    });
   });
 
   it.each([
@@ -48,25 +52,50 @@ describe("parseIngestSessions", () => {
     "C:\\outside",
     "nested/session",
   ])("rejects unsafe sessionId %s", (sessionId) => {
-    expect(parseIngestSessions([{ ...validSession, sessionId }], knownAgentIds)).toBeNull();
+    expect(
+      parseIngestSessions([{ ...validSession, sessionId }], knownAgentIds),
+    ).toEqual({
+      ok: false,
+      error: {
+        code: "invalid-session-id",
+        sessionIndex: 0,
+        field: "sessionId",
+      },
+    });
   });
 
   it("rejects non-string sub-agent keys before mapping", () => {
     expect(parseIngestSessions([
       { ...validSession, kind: "subagent", key: 123 },
-    ], knownAgentIds)).toBeNull();
+    ], knownAgentIds)).toEqual({
+      ok: false,
+      error: {
+        code: "invalid-key",
+        sessionIndex: 0,
+        field: "key",
+      },
+    });
   });
 
   it("rejects unknown agents, unknown fields, and overlong fields", () => {
     expect(parseIngestSessions([
       { ...validSession, agentId: "unknown" },
-    ], knownAgentIds)).toBeNull();
+    ], knownAgentIds)).toMatchObject({
+      ok: false,
+      error: { code: "unknown-agent" },
+    });
     expect(parseIngestSessions([
       { ...validSession, unexpected: true },
-    ], knownAgentIds)).toBeNull();
+    ], knownAgentIds)).toMatchObject({
+      ok: false,
+      error: { code: "unknown-field" },
+    });
     expect(parseIngestSessions([
       { ...validSession, model: "x".repeat(257) },
-    ], knownAgentIds)).toBeNull();
+    ], knownAgentIds)).toMatchObject({
+      ok: false,
+      error: { code: "invalid-string", field: "model" },
+    });
   });
 });
 

--- a/server/ingestSessions.ts
+++ b/server/ingestSessions.ts
@@ -1,0 +1,202 @@
+import { isAbsolute, relative, resolve, sep } from "node:path";
+
+export interface CliSession {
+  key: string;
+  agentId: string;
+  model?: string;
+  modelProvider?: string;
+  totalTokens?: number | null;
+  contextTokens?: number | null;
+  updatedAt?: number;
+  kind?: string;
+  status?: string;
+  abortedLastRun?: boolean;
+  inputTokens?: number;
+  outputTokens?: number;
+  sessionId?: string;
+  thinkingLevel?: string;
+  ageMs?: number;
+  acpRuntime?: boolean;
+  agentRuntime?: {
+    id?: string;
+    source?: string;
+  };
+  lastInteractionAt?: number;
+  modelOverride?: string;
+  providerOverride?: string;
+  reasoningLevel?: string;
+  sessionFile?: string;
+  sessionStartedAt?: number;
+  systemSent?: boolean;
+  totalTokensFresh?: boolean;
+}
+
+const SESSION_KEYS = new Set<keyof CliSession>([
+  "key",
+  "agentId",
+  "model",
+  "modelProvider",
+  "totalTokens",
+  "contextTokens",
+  "updatedAt",
+  "kind",
+  "status",
+  "abortedLastRun",
+  "inputTokens",
+  "outputTokens",
+  "sessionId",
+  "thinkingLevel",
+  "ageMs",
+  "acpRuntime",
+  "agentRuntime",
+  "lastInteractionAt",
+  "modelOverride",
+  "providerOverride",
+  "reasoningLevel",
+  "sessionFile",
+  "sessionStartedAt",
+  "systemSent",
+  "totalTokensFresh",
+]);
+const AGENT_RUNTIME_KEYS = new Set(["id", "source"]);
+const STRING_LIMITS: Partial<Record<keyof CliSession, number>> = {
+  key: 512,
+  model: 256,
+  modelProvider: 128,
+  kind: 64,
+  status: 64,
+  thinkingLevel: 64,
+  modelOverride: 256,
+  providerOverride: 128,
+  reasoningLevel: 64,
+  sessionFile: 4096,
+};
+const NUMBER_FIELDS = [
+  "updatedAt",
+  "inputTokens",
+  "outputTokens",
+  "ageMs",
+  "lastInteractionAt",
+  "sessionStartedAt",
+] as const satisfies readonly (keyof CliSession)[];
+const NULLABLE_NUMBER_FIELDS = [
+  "totalTokens",
+  "contextTokens",
+] as const satisfies readonly (keyof CliSession)[];
+const BOOLEAN_FIELDS = [
+  "abortedLastRun",
+  "acpRuntime",
+  "systemSent",
+  "totalTokensFresh",
+] as const satisfies readonly (keyof CliSession)[];
+const OPAQUE_AGENT_ID_RE = /^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$/;
+const OPAQUE_SESSION_ID_RE = /^[A-Za-z0-9][A-Za-z0-9_-]{0,127}$/;
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+function isBoundedString(value: unknown, maxLength: number): value is string {
+  return typeof value === "string" && value.length > 0 && value.length <= maxLength;
+}
+
+function isNonNegativeSafeInteger(value: unknown): value is number {
+  return typeof value === "number"
+    && Number.isSafeInteger(value)
+    && value >= 0;
+}
+
+function isAgentRuntime(value: unknown): value is NonNullable<CliSession["agentRuntime"]> {
+  if (!isPlainObject(value)) return false;
+  if (!Object.keys(value).every((key) => AGENT_RUNTIME_KEYS.has(key))) return false;
+  return (value.id === undefined || isBoundedString(value.id, 128))
+    && (value.source === undefined || isBoundedString(value.source, 128));
+}
+
+function parseIngestSession(
+  value: unknown,
+  knownAgentIds: ReadonlySet<string>,
+): CliSession | null {
+  if (!isPlainObject(value)) return null;
+  if (!Object.keys(value).every((key) => SESSION_KEYS.has(key as keyof CliSession))) {
+    return null;
+  }
+  if (!isBoundedString(value.key, STRING_LIMITS.key!)) return null;
+  if (typeof value.agentId !== "string" || !knownAgentIds.has(value.agentId)) return null;
+
+  for (const [field, maxLength] of Object.entries(STRING_LIMITS) as [keyof CliSession, number][]) {
+    const fieldValue = value[field];
+    if (fieldValue !== undefined && !isBoundedString(fieldValue, maxLength)) return null;
+  }
+  for (const field of NUMBER_FIELDS) {
+    const fieldValue = value[field];
+    if (fieldValue !== undefined && !isNonNegativeSafeInteger(fieldValue)) return null;
+  }
+  for (const field of NULLABLE_NUMBER_FIELDS) {
+    const fieldValue = value[field];
+    if (fieldValue !== undefined && fieldValue !== null && !isNonNegativeSafeInteger(fieldValue)) {
+      return null;
+    }
+  }
+  for (const field of BOOLEAN_FIELDS) {
+    const fieldValue = value[field];
+    if (fieldValue !== undefined && typeof fieldValue !== "boolean") return null;
+  }
+  if (
+    value.sessionId !== undefined
+    && (typeof value.sessionId !== "string" || !OPAQUE_SESSION_ID_RE.test(value.sessionId))
+  ) {
+    return null;
+  }
+  if (value.agentRuntime !== undefined && !isAgentRuntime(value.agentRuntime)) return null;
+
+  return { ...value } as unknown as CliSession;
+}
+
+export function parseIngestSessions(
+  value: unknown,
+  knownAgentIds: ReadonlySet<string>,
+): CliSession[] | null {
+  if (!Array.isArray(value) || value.length > 50) return null;
+
+  const sessions: CliSession[] = [];
+  for (const candidate of value) {
+    const session = parseIngestSession(candidate, knownAgentIds);
+    if (!session) return null;
+    sessions.push(session);
+  }
+  return sessions;
+}
+
+function isContained(expectedDir: string, candidatePath: string): boolean {
+  const candidateRelativePath = relative(expectedDir, candidatePath);
+  return candidateRelativePath !== ""
+    && !isAbsolute(candidateRelativePath)
+    && candidateRelativePath !== ".."
+    && !candidateRelativePath.startsWith(`..${sep}`);
+}
+
+export function resolveTranscriptPath(
+  agentsDir: string,
+  agentId: string,
+  sessionId: string,
+): string | null {
+  if (!OPAQUE_AGENT_ID_RE.test(agentId) || !OPAQUE_SESSION_ID_RE.test(sessionId)) {
+    return null;
+  }
+  const expectedDir = resolve(agentsDir, agentId, "sessions");
+  const candidatePath = resolve(expectedDir, `${sessionId}.jsonl`);
+  return isContained(expectedDir, candidatePath) ? candidatePath : null;
+}
+
+export function isTranscriptPathContained(
+  agentsDir: string,
+  agentId: string,
+  transcriptPath: string,
+): boolean {
+  if (!OPAQUE_AGENT_ID_RE.test(agentId)) return false;
+  const expectedDir = resolve(agentsDir, agentId, "sessions");
+  return isContained(expectedDir, resolve(transcriptPath));
+}

--- a/server/ingestSessions.ts
+++ b/server/ingestSessions.ts
@@ -86,8 +86,8 @@ const SESSION_KEYS = new Set<keyof CliSession>([
   "totalTokensFresh",
 ]);
 const AGENT_RUNTIME_KEYS = new Set(["id", "source"]);
+const KEY_MAX_LENGTH = 512;
 const STRING_LIMITS: Partial<Record<keyof CliSession, number>> = {
-  key: 512,
   model: 256,
   modelProvider: 128,
   kind: 64,
@@ -160,7 +160,7 @@ function parseIngestSession(
   if (!Object.keys(value).every((key) => SESSION_KEYS.has(key as keyof CliSession))) {
     return invalid("unknown-field");
   }
-  if (!isBoundedString(value.key, STRING_LIMITS.key!)) return invalid("invalid-key", "key");
+  if (!isBoundedString(value.key, KEY_MAX_LENGTH)) return invalid("invalid-key", "key");
   if (typeof value.agentId !== "string" || !knownAgentIds.has(value.agentId)) {
     return invalid("unknown-agent", "agentId");
   }
@@ -199,9 +199,15 @@ function parseIngestSession(
     return invalid("invalid-agent-runtime", "agentRuntime");
   }
 
+  const session = { ...value };
+  // `sessionFile` is an absolute path on the collector host. Accept it as part
+  // of the current CLI schema, but never carry that foreign path into server
+  // state; transcript access is derived solely from the validated session ID.
+  delete session.sessionFile;
+
   return {
     ok: true,
-    session: { ...value } as unknown as CliSession,
+    session: session as unknown as CliSession,
   };
 }
 

--- a/server/ingestSessions.ts
+++ b/server/ingestSessions.ts
@@ -9,6 +9,7 @@ export interface CliSession {
   contextTokens?: number | null;
   updatedAt?: number;
   kind?: string;
+  label?: string;
   status?: string;
   abortedLastRun?: boolean;
   inputTokens?: number;
@@ -31,6 +32,31 @@ export interface CliSession {
   totalTokensFresh?: boolean;
 }
 
+export type IngestSessionValidationError = {
+  code:
+    | "sessions-not-array"
+    | "too-many-sessions"
+    | "invalid-session-object"
+    | "unknown-field"
+    | "invalid-key"
+    | "unknown-agent"
+    | "invalid-string"
+    | "invalid-number"
+    | "invalid-boolean"
+    | "invalid-session-id"
+    | "invalid-agent-runtime";
+  sessionIndex?: number;
+  field?: keyof CliSession;
+};
+
+export type ParseIngestSessionsResult =
+  | { ok: true; sessions: CliSession[] }
+  | { ok: false; error: IngestSessionValidationError };
+
+type ParseIngestSessionResult =
+  | { ok: true; session: CliSession }
+  | { ok: false; error: IngestSessionValidationError };
+
 const SESSION_KEYS = new Set<keyof CliSession>([
   "key",
   "agentId",
@@ -40,6 +66,7 @@ const SESSION_KEYS = new Set<keyof CliSession>([
   "contextTokens",
   "updatedAt",
   "kind",
+  "label",
   "status",
   "abortedLastRun",
   "inputTokens",
@@ -64,6 +91,7 @@ const STRING_LIMITS: Partial<Record<keyof CliSession, number>> = {
   model: 256,
   modelProvider: 128,
   kind: 64,
+  label: 256,
   status: 64,
   thinkingLevel: 64,
   modelOverride: 256,
@@ -118,56 +146,83 @@ function isAgentRuntime(value: unknown): value is NonNullable<CliSession["agentR
 function parseIngestSession(
   value: unknown,
   knownAgentIds: ReadonlySet<string>,
-): CliSession | null {
-  if (!isPlainObject(value)) return null;
+  sessionIndex: number,
+): ParseIngestSessionResult {
+  const invalid = (
+    code: IngestSessionValidationError["code"],
+    field?: keyof CliSession,
+  ): ParseIngestSessionResult => ({
+    ok: false,
+    error: { code, sessionIndex, ...(field ? { field } : {}) },
+  });
+
+  if (!isPlainObject(value)) return invalid("invalid-session-object");
   if (!Object.keys(value).every((key) => SESSION_KEYS.has(key as keyof CliSession))) {
-    return null;
+    return invalid("unknown-field");
   }
-  if (!isBoundedString(value.key, STRING_LIMITS.key!)) return null;
-  if (typeof value.agentId !== "string" || !knownAgentIds.has(value.agentId)) return null;
+  if (!isBoundedString(value.key, STRING_LIMITS.key!)) return invalid("invalid-key", "key");
+  if (typeof value.agentId !== "string" || !knownAgentIds.has(value.agentId)) {
+    return invalid("unknown-agent", "agentId");
+  }
 
   for (const [field, maxLength] of Object.entries(STRING_LIMITS) as [keyof CliSession, number][]) {
     const fieldValue = value[field];
-    if (fieldValue !== undefined && !isBoundedString(fieldValue, maxLength)) return null;
+    if (fieldValue !== undefined && !isBoundedString(fieldValue, maxLength)) {
+      return invalid("invalid-string", field);
+    }
   }
   for (const field of NUMBER_FIELDS) {
     const fieldValue = value[field];
-    if (fieldValue !== undefined && !isNonNegativeSafeInteger(fieldValue)) return null;
+    if (fieldValue !== undefined && !isNonNegativeSafeInteger(fieldValue)) {
+      return invalid("invalid-number", field);
+    }
   }
   for (const field of NULLABLE_NUMBER_FIELDS) {
     const fieldValue = value[field];
     if (fieldValue !== undefined && fieldValue !== null && !isNonNegativeSafeInteger(fieldValue)) {
-      return null;
+      return invalid("invalid-number", field);
     }
   }
   for (const field of BOOLEAN_FIELDS) {
     const fieldValue = value[field];
-    if (fieldValue !== undefined && typeof fieldValue !== "boolean") return null;
+    if (fieldValue !== undefined && typeof fieldValue !== "boolean") {
+      return invalid("invalid-boolean", field);
+    }
   }
   if (
     value.sessionId !== undefined
     && (typeof value.sessionId !== "string" || !OPAQUE_SESSION_ID_RE.test(value.sessionId))
   ) {
-    return null;
+    return invalid("invalid-session-id", "sessionId");
   }
-  if (value.agentRuntime !== undefined && !isAgentRuntime(value.agentRuntime)) return null;
+  if (value.agentRuntime !== undefined && !isAgentRuntime(value.agentRuntime)) {
+    return invalid("invalid-agent-runtime", "agentRuntime");
+  }
 
-  return { ...value } as unknown as CliSession;
+  return {
+    ok: true,
+    session: { ...value } as unknown as CliSession,
+  };
 }
 
 export function parseIngestSessions(
   value: unknown,
   knownAgentIds: ReadonlySet<string>,
-): CliSession[] | null {
-  if (!Array.isArray(value) || value.length > 50) return null;
+): ParseIngestSessionsResult {
+  if (!Array.isArray(value)) {
+    return { ok: false, error: { code: "sessions-not-array" } };
+  }
+  if (value.length > 50) {
+    return { ok: false, error: { code: "too-many-sessions" } };
+  }
 
   const sessions: CliSession[] = [];
-  for (const candidate of value) {
-    const session = parseIngestSession(candidate, knownAgentIds);
-    if (!session) return null;
-    sessions.push(session);
+  for (const [sessionIndex, candidate] of value.entries()) {
+    const result = parseIngestSession(candidate, knownAgentIds, sessionIndex);
+    if (!result.ok) return result;
+    sessions.push(result.session);
   }
-  return sessions;
+  return { ok: true, sessions };
 }
 
 function isContained(expectedDir: string, candidatePath: string): boolean {

--- a/server/ingestSessions.ts
+++ b/server/ingestSessions.ts
@@ -7,29 +7,13 @@ export interface CliSession {
   modelProvider?: string;
   totalTokens?: number | null;
   contextTokens?: number | null;
-  updatedAt?: number;
+  updatedAt?: number | null;
   kind?: string;
-  label?: string;
   status?: string;
   abortedLastRun?: boolean;
   inputTokens?: number;
   outputTokens?: number;
   sessionId?: string;
-  thinkingLevel?: string;
-  ageMs?: number;
-  acpRuntime?: boolean;
-  agentRuntime?: {
-    id?: string;
-    source?: string;
-  };
-  lastInteractionAt?: number;
-  modelOverride?: string;
-  providerOverride?: string;
-  reasoningLevel?: string;
-  sessionFile?: string;
-  sessionStartedAt?: number;
-  systemSent?: boolean;
-  totalTokensFresh?: boolean;
 }
 
 export type IngestSessionValidationError = {
@@ -37,14 +21,13 @@ export type IngestSessionValidationError = {
     | "sessions-not-array"
     | "too-many-sessions"
     | "invalid-session-object"
-    | "unknown-field"
+    | "reserved-field"
     | "invalid-key"
     | "unknown-agent"
     | "invalid-string"
     | "invalid-number"
     | "invalid-boolean"
-    | "invalid-session-id"
-    | "invalid-agent-runtime";
+    | "invalid-session-id";
   sessionIndex?: number;
   field?: keyof CliSession;
 };
@@ -57,65 +40,25 @@ type ParseIngestSessionResult =
   | { ok: true; session: CliSession }
   | { ok: false; error: IngestSessionValidationError };
 
-const SESSION_KEYS = new Set<keyof CliSession>([
-  "key",
-  "agentId",
-  "model",
-  "modelProvider",
-  "totalTokens",
-  "contextTokens",
-  "updatedAt",
-  "kind",
-  "label",
-  "status",
-  "abortedLastRun",
-  "inputTokens",
-  "outputTokens",
-  "sessionId",
-  "thinkingLevel",
-  "ageMs",
-  "acpRuntime",
-  "agentRuntime",
-  "lastInteractionAt",
-  "modelOverride",
-  "providerOverride",
-  "reasoningLevel",
-  "sessionFile",
-  "sessionStartedAt",
-  "systemSent",
-  "totalTokensFresh",
-]);
-const AGENT_RUNTIME_KEYS = new Set(["id", "source"]);
+const RESERVED_SESSION_KEYS = new Set(["__proto__", "constructor", "prototype"]);
 const KEY_MAX_LENGTH = 512;
 const STRING_LIMITS: Partial<Record<keyof CliSession, number>> = {
   model: 256,
   modelProvider: 128,
   kind: 64,
-  label: 256,
   status: 64,
-  thinkingLevel: 64,
-  modelOverride: 256,
-  providerOverride: 128,
-  reasoningLevel: 64,
-  sessionFile: 4096,
 };
 const NUMBER_FIELDS = [
-  "updatedAt",
   "inputTokens",
   "outputTokens",
-  "ageMs",
-  "lastInteractionAt",
-  "sessionStartedAt",
 ] as const satisfies readonly (keyof CliSession)[];
 const NULLABLE_NUMBER_FIELDS = [
   "totalTokens",
   "contextTokens",
+  "updatedAt",
 ] as const satisfies readonly (keyof CliSession)[];
 const BOOLEAN_FIELDS = [
   "abortedLastRun",
-  "acpRuntime",
-  "systemSent",
-  "totalTokensFresh",
 ] as const satisfies readonly (keyof CliSession)[];
 const OPAQUE_AGENT_ID_RE = /^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$/;
 const OPAQUE_SESSION_ID_RE = /^[A-Za-z0-9][A-Za-z0-9_-]{0,127}$/;
@@ -136,13 +79,6 @@ function isNonNegativeSafeInteger(value: unknown): value is number {
     && value >= 0;
 }
 
-function isAgentRuntime(value: unknown): value is NonNullable<CliSession["agentRuntime"]> {
-  if (!isPlainObject(value)) return false;
-  if (!Object.keys(value).every((key) => AGENT_RUNTIME_KEYS.has(key))) return false;
-  return (value.id === undefined || isBoundedString(value.id, 128))
-    && (value.source === undefined || isBoundedString(value.source, 128));
-}
-
 function parseIngestSession(
   value: unknown,
   knownAgentIds: ReadonlySet<string>,
@@ -157,37 +93,47 @@ function parseIngestSession(
   });
 
   if (!isPlainObject(value)) return invalid("invalid-session-object");
-  if (!Object.keys(value).every((key) => SESSION_KEYS.has(key as keyof CliSession))) {
-    return invalid("unknown-field");
+  if (Object.keys(value).some((key) => RESERVED_SESSION_KEYS.has(key))) {
+    return invalid("reserved-field");
   }
   if (!isBoundedString(value.key, KEY_MAX_LENGTH)) return invalid("invalid-key", "key");
   if (typeof value.agentId !== "string" || !knownAgentIds.has(value.agentId)) {
     return invalid("unknown-agent", "agentId");
   }
 
+  const session: CliSession = {
+    key: value.key,
+    agentId: value.agentId,
+  };
+  const sessionRecord = session as unknown as Record<string, unknown>;
+
   for (const [field, maxLength] of Object.entries(STRING_LIMITS) as [keyof CliSession, number][]) {
     const fieldValue = value[field];
     if (fieldValue !== undefined && !isBoundedString(fieldValue, maxLength)) {
       return invalid("invalid-string", field);
     }
+    if (fieldValue !== undefined) sessionRecord[field] = fieldValue;
   }
   for (const field of NUMBER_FIELDS) {
     const fieldValue = value[field];
     if (fieldValue !== undefined && !isNonNegativeSafeInteger(fieldValue)) {
       return invalid("invalid-number", field);
     }
+    if (fieldValue !== undefined) sessionRecord[field] = fieldValue;
   }
   for (const field of NULLABLE_NUMBER_FIELDS) {
     const fieldValue = value[field];
     if (fieldValue !== undefined && fieldValue !== null && !isNonNegativeSafeInteger(fieldValue)) {
       return invalid("invalid-number", field);
     }
+    if (fieldValue !== undefined) sessionRecord[field] = fieldValue;
   }
   for (const field of BOOLEAN_FIELDS) {
     const fieldValue = value[field];
     if (fieldValue !== undefined && typeof fieldValue !== "boolean") {
       return invalid("invalid-boolean", field);
     }
+    if (fieldValue !== undefined) sessionRecord[field] = fieldValue;
   }
   if (
     value.sessionId !== undefined
@@ -195,19 +141,11 @@ function parseIngestSession(
   ) {
     return invalid("invalid-session-id", "sessionId");
   }
-  if (value.agentRuntime !== undefined && !isAgentRuntime(value.agentRuntime)) {
-    return invalid("invalid-agent-runtime", "agentRuntime");
-  }
-
-  const session = { ...value };
-  // `sessionFile` is an absolute path on the collector host. Accept it as part
-  // of the current CLI schema, but never carry that foreign path into server
-  // state; transcript access is derived solely from the validated session ID.
-  delete session.sessionFile;
+  if (value.sessionId !== undefined) session.sessionId = value.sessionId;
 
   return {
     ok: true,
-    session: session as unknown as CliSession,
+    session,
   };
 }
 


### PR DESCRIPTION
## Summary

- accept additive fields from OpenClaw's evolving session output, then sanitize each entry into the bounded session DTO this server owns
- validate registered agent IDs, retained field types/sizes, malformed keys, and opaque session IDs while rejecting reserved object keys
- resolve transcript paths inside each registered agent's sessions directory and re-check containment immediately before filesystem access
- discard collector-local absolute paths and clear stale transcript paths when a successful snapshot no longer supplies a session
- map malformed JSON to 400 and oversized JSON to 413 without logging raw request bodies
- log bounded validation diagnostics without logging raw ingest payloads
- document the upstream-compatible ingest contract

## Security impact

This adds an anti-corruption layer at the authenticated ingest boundary without coupling availability to upstream's full display schema. An ingest payload can no longer plant traversal or absolute paths, malformed sub-agent keys no longer reach mapping code as a 500, collector-local transcript paths are removed before mapping, and unauthenticated body-parser failures no longer become raw-body 500 logs.

## Verification

- `npm ci` — 327 packages, 0 vulnerabilities
- live 30-minute OpenClaw payload accepted
- 50-session mixed historical OpenClaw sample accepted and sanitized
- captured OpenClaw 2026.7.2-beta.3 fixture covers lineage/display fields and nullable timestamps
- focused ingest/path/error regressions — 45/45
- full test suite — 187/187
- coverage suite — 187/187
  - statements 41.57%
  - branches 40.05%
  - functions 39.72%
  - lines 43.48%
- `npm run typecheck`
- `npm run build`
- `npm audit --omit=dev --audit-level=high` — 0 vulnerabilities
- `git diff --check`
- changed-file secret-pattern scan

Closes #101


<!-- kody-pr-summary:start -->
## Summary

This PR fixes ingest validation so the server safely handles OpenClaw's evolving session output while still enforcing real invariants (registered agent IDs, opaque session IDs, retained field types/sizes, and path containment). Unknown top-level fields are now dropped instead of rejected, and validation rejects prototype-pollution attempts (`__proto__`, `constructor`, `prototype`) on incoming session objects.

## What's changed

### Ingest session parser (`server/ingestSessions.ts`)
- **Sanitizes instead of rejecting unknown fields**: The parser now picks only the fields the server actually retains (key, agentId, model, modelProvider, totalTokens, contextTokens, updatedAt, kind, status, abortedLastRun, inputTokens, outputTokens, sessionId). Anything else passed by the collector is silently dropped, so OpenClaw can add fields upstream without breaking the collector/server pair.
- **Shrinks the retained surface area**: Removed formerly-tracked fields from `CliSession` (e.g., `label`, `thinkingLevel`, `ageMs`, `acpRuntime`, `agentRuntime`, `lastInteractionAt`, `modelOverride`, `providerOverride`, `reasoningLevel`, `sessionFile`, `sessionStartedAt`, `systemSent`, `totalTokensFresh`) and their validators, since the server didn't use them. `updatedAt` now correctly allows `null`.
- **Prototype-pollution guard**: Replaces the old `unknown-field` check with a `reserved-field` check that rejects incoming session objects carrying `__proto__`, `constructor`, or `prototype` keys.
- **`agentRuntime` validation removed** along with its error code, since the field is no longer retained.

### Body-parser error handling (`server/errors.ts`)
- Malformed JSON now maps to `HTTP 400 { error: "Malformed JSON body" }`.
- Oversized JSON bodies now map to `HTTP 413 { error: "Request body too large" }`.
- In both cases, the raw request body is **not** logged — only bounded metadata (`errorType`, `reqId`, `limit`, `length`) is recorded via a warn-level entry. The original error object is never passed to pino, so any sensitive payload attached to `err.body` cannot leak into logs.

### Tests
- **`server/auth.test.ts`**: Adds tests asserting malformed JSON → 400 and oversized JSON → 413 *before* ingest authentication runs. Removes the "unknown field" rejection case and the `unexpected: true` fixture (unknown fields are now dropped) and adds a `spawnedBy` field to the valid case to prove extra upstream fields are accepted.
- **`server/errors.test.ts`**: Adds tests verifying that body-parser failures produce the right HTTP status, don't call `logger.error`, do call `logger.warn` with bounded metadata only, and that any raw-body marker placed in the request never appears in the logged output.
- **`server/ingestSessions.test.ts`**: Updates the happy-path assertion to match the now-explicit retained-field shape, adds a fixture-driven test using a captured upstream session shape (with `spawnedBy` and `sessionFile`) to verify sanitization drops unknown fields, and adds parameterized tests confirming `__proto__`, `constructor`, and `prototype` are rejected as `reserved-field`.

### Documentation (`README.md`)
- Rewrites the ingest validation blurb to describe the new behavior: the endpoint accepts additive upstream fields and sanitizes them into the retained session shape, while still validating registered agent IDs, retained field types/sizes, and opaque session IDs. Notes that invalid retained fields return HTTP 400.
<!-- kody-pr-summary:end -->