### PR TITLE
fix: keep running sub-agents alive until server status ends them (#102)

### DIFF
--- a/src/components/AgentSidebar.css
+++ b/src/components/AgentSidebar.css
@@ -58,6 +58,11 @@
   transition: all 0.2s ease;
   position: relative;
   overflow: hidden;
+  /* The .agent-list is a flex column with overflow-y: auto; without
+   * flex-shrink: 0 the cards collapse to the list's compressed height
+   * and the portrait (48px) + content (94px) get clipped to ~26px,
+   * making names and icons overlap. */
+  flex-shrink: 0;
 }
 
 /* Glow effect underneath active cards */

--- a/src/components/PixelOffice.subagents.test.tsx
+++ b/src/components/PixelOffice.subagents.test.tsx
@@ -1,0 +1,187 @@
+/**
+ * Contract test for the React↔engine reconciliation of sub-agents (issue #102).
+ *
+ * The GameEngine module is the mocked boundary here BY DESIGN: the engine's own
+ * lifecycle primitives (spawn / kill / revive / fade) are pinned by
+ * src/game/GameEngine.integration.test.ts running the real engine. This file pins
+ * only the adapter contract — which engine method each server-status
+ * reconciliation must call:
+ *
+ *   running + missing           ⇒ spawnSubAgent (exactly once)
+ *   running + present + dying   ⇒ reviveSubAgent (NEVER remove+respawn)
+ *   completed / failed          ⇒ killSubAgent
+ *   absent from server list     ⇒ killSubAgent (sweep)
+ *   parent leaves the room      ⇒ killSubAgent (sweep) + removeCharacter(parent)
+ *
+ * This is the exact wiring whose remove-and-respawn branch caused issue #102.
+ */
+
+import React from 'react';
+import { render, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AgentState, SubAgentInfo } from '../../shared/types';
+import { PixelOffice } from './PixelOffice';
+import { GameEngine } from '../game/GameEngine';
+
+vi.mock('../game/GameEngine', () => {
+  class MockGameEngine {
+    static latest: MockGameEngine;
+    characters = new Set<string>();
+    dying = new Set<string>();
+
+    constructor(_canvas: HTMLCanvasElement, _config: unknown) {
+      MockGameEngine.latest = this;
+    }
+
+    init = vi.fn().mockResolvedValue(undefined);
+    start = vi.fn();
+    stop = vi.fn();
+    setEditorCallbacks = vi.fn();
+    setGameCallbacks = vi.fn();
+    setEditorMode = vi.fn();
+    setDeleteMode = vi.fn();
+    setSelectedFurnitureType = vi.fn();
+    setLayout = vi.fn();
+    setCharacterSprite = vi.fn();
+    getCharacterIds = vi.fn(() => Array.from(this.characters));
+    assignSeat = vi.fn(() => ({ x: 3, y: 3 }));
+    addCharacter = vi.fn((data: { id: string }) => {
+      this.characters.add(data.id);
+    });
+    updateCharacter = vi.fn();
+    removeCharacter = vi.fn((id: string) => {
+      this.characters.delete(id);
+      this.dying.delete(id);
+    });
+    spawnSubAgent = vi.fn((_parentId: string, subId: string, _name: string) => {
+      this.characters.add(subId);
+    });
+    killSubAgent = vi.fn((subId: string) => {
+      if (this.characters.has(subId)) this.dying.add(subId);
+    });
+    reviveSubAgent = vi.fn((subId: string) => {
+      this.dying.delete(subId);
+    });
+    isCharacterDying = vi.fn((id: string) => this.dying.has(id));
+  }
+  return { GameEngine: MockGameEngine };
+});
+
+vi.mock('../game/SpriteLoader', () => ({ recomposeAgent: vi.fn(() => null) }));
+
+interface EngineSpy {
+  characters: Set<string>;
+  dying: Set<string>;
+  spawnSubAgent: ReturnType<typeof vi.fn>;
+  killSubAgent: ReturnType<typeof vi.fn>;
+  reviveSubAgent: ReturnType<typeof vi.fn>;
+  removeCharacter: ReturnType<typeof vi.fn>;
+}
+
+const engineOf = () => (GameEngine as unknown as { latest: EngineSpy }).latest;
+
+const baseProps = {
+  editorMode: false,
+  deleteMode: false,
+  activeLayout: null,
+  selectedFurnitureType: null,
+  onPlaceFurniture: vi.fn(),
+  onSelectFurniture: vi.fn(),
+  onMoveFurniture: vi.fn(),
+  onRotateFurniture: vi.fn(),
+};
+
+const parentWith = (subAgents: SubAgentInfo[]): AgentState => ({
+  id: 'cybera',
+  name: 'Cybera',
+  activity: 'typing',
+  model: 'm',
+  sessionKey: 'k',
+  active: true,
+  lastActivity: 1,
+  pixelEnabled: true,
+  tags: [],
+  subAgents,
+});
+
+const sub = (id: string, status: SubAgentInfo['status']): SubAgentInfo => ({
+  id,
+  name: id,
+  spawnedAt: 1,
+  status,
+});
+
+describe('PixelOffice sub-agent reconciliation contract (issue #102)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('spawns a running sub-agent exactly once across repeated reconciliations', async () => {
+    const { rerender } = render(
+      <PixelOffice {...baseProps} agents={[parentWith([sub('sub-1', 'running')])]} />,
+    );
+    await waitFor(() => expect(engineOf().spawnSubAgent).toHaveBeenCalledTimes(1));
+
+    // Several server updates, status still `running` — the pre-fix code
+    // remove+respawned here once the engine-side lifetime expired.
+    for (let i = 0; i < 5; i++) {
+      rerender(<PixelOffice {...baseProps} agents={[parentWith([sub('sub-1', 'running')])]} />);
+    }
+
+    expect(engineOf().spawnSubAgent).toHaveBeenCalledTimes(1);
+    expect(engineOf().reviveSubAgent).not.toHaveBeenCalled();
+    expect(engineOf().killSubAgent).not.toHaveBeenCalled();
+    expect(engineOf().removeCharacter).not.toHaveBeenCalledWith('sub-1');
+  });
+
+  it('revives a dying sub-agent in place when status returns to running — never remove+respawn', async () => {
+    const { rerender } = render(
+      <PixelOffice {...baseProps} agents={[parentWith([sub('sub-1', 'running')])]} />,
+    );
+    await waitFor(() => expect(engineOf().spawnSubAgent).toHaveBeenCalledTimes(1));
+
+    // Server reports completion: reconciliation kills the sub-agent (fade starts).
+    rerender(<PixelOffice {...baseProps} agents={[parentWith([sub('sub-1', 'completed')])]} />);
+    expect(engineOf().killSubAgent).toHaveBeenCalledWith('sub-1');
+    expect(engineOf().dying.has('sub-1')).toBe(true);
+
+    // Status flips back to running mid-fade: revive in place. THE #102 pin.
+    rerender(<PixelOffice {...baseProps} agents={[parentWith([sub('sub-1', 'running')])]} />);
+    expect(engineOf().reviveSubAgent).toHaveBeenCalledWith('sub-1');
+    expect(engineOf().spawnSubAgent).toHaveBeenCalledTimes(1);
+    expect(engineOf().removeCharacter).not.toHaveBeenCalledWith('sub-1');
+  });
+
+  it('kills a sub-agent that disappears from the server list (sweep)', async () => {
+    const { rerender } = render(
+      <PixelOffice {...baseProps} agents={[parentWith([sub('sub-1', 'running')])]} />,
+    );
+    await waitFor(() => expect(engineOf().spawnSubAgent).toHaveBeenCalledTimes(1));
+
+    rerender(<PixelOffice {...baseProps} agents={[parentWith([])]} />);
+    expect(engineOf().killSubAgent).toHaveBeenCalledWith('sub-1');
+  });
+
+  it('spawns a genuinely new execution (new sub id) while killing the old one', async () => {
+    const { rerender } = render(
+      <PixelOffice {...baseProps} agents={[parentWith([sub('sub-1', 'running')])]} />,
+    );
+    await waitFor(() => expect(engineOf().spawnSubAgent).toHaveBeenCalledTimes(1));
+
+    rerender(<PixelOffice {...baseProps} agents={[parentWith([sub('sub-2', 'running')])]} />);
+    expect(engineOf().killSubAgent).toHaveBeenCalledWith('sub-1');
+    expect(engineOf().spawnSubAgent).toHaveBeenCalledTimes(2);
+    expect(engineOf().spawnSubAgent).toHaveBeenLastCalledWith('cybera', 'sub-2', 'sub-2');
+  });
+
+  it('kills sub-agents and removes the character when the parent leaves the room', async () => {
+    const { rerender } = render(
+      <PixelOffice {...baseProps} agents={[parentWith([sub('sub-1', 'running')])]} />,
+    );
+    await waitFor(() => expect(engineOf().spawnSubAgent).toHaveBeenCalledTimes(1));
+
+    rerender(<PixelOffice {...baseProps} agents={[]} />);
+    expect(engineOf().killSubAgent).toHaveBeenCalledWith('sub-1');
+    expect(engineOf().removeCharacter).toHaveBeenCalledWith('cybera');
+  });
+});

--- a/src/components/PixelOffice.subagents.test.tsx
+++ b/src/components/PixelOffice.subagents.test.tsx
@@ -174,6 +174,24 @@ describe('PixelOffice sub-agent reconciliation contract (issue #102)', () => {
     expect(engineOf().spawnSubAgent).toHaveBeenLastCalledWith('cybera', 'sub-2', 'sub-2');
   });
 
+  it('kills sub-agents when the parent is present but pixel-disabled', async () => {
+    const { rerender } = render(
+      <PixelOffice {...baseProps} agents={[parentWith([sub('sub-1', 'running')])]} />,
+    );
+    await waitFor(() => expect(engineOf().spawnSubAgent).toHaveBeenCalledTimes(1));
+
+    // Parent stays in the list but visualization is toggled off: the parent
+    // character is removed and its sub-agent must not linger (sweep path).
+    rerender(
+      <PixelOffice
+        {...baseProps}
+        agents={[{ ...parentWith([sub('sub-1', 'running')]), pixelEnabled: false }]}
+      />,
+    );
+    expect(engineOf().removeCharacter).toHaveBeenCalledWith('cybera');
+    expect(engineOf().killSubAgent).toHaveBeenCalledWith('sub-1');
+  });
+
   it('kills sub-agents and removes the character when the parent leaves the room', async () => {
     const { rerender } = render(
       <PixelOffice {...baseProps} agents={[parentWith([sub('sub-1', 'running')])]} />,

--- a/src/components/PixelOffice.tsx
+++ b/src/components/PixelOffice.tsx
@@ -154,7 +154,9 @@ export const PixelOffice: React.FC<Props> = ({
         });
       }
 
-      // Sync sub-agents
+      // Sync sub-agents — server status is the sole lifecycle authority:
+      // `running` keeps a sub-agent alive indefinitely, `completed`/`failed`
+      // or absence fades it out (issue #102).
       if (agent.subAgents) {
         // Spawn new sub-agents
         for (const sub of agent.subAgents) {
@@ -164,9 +166,11 @@ export const PixelOffice: React.FC<Props> = ({
               engine.spawnSubAgent(agent.id, sub.id, sub.name || sub.id);
               currentIds.add(sub.id); // Prevent re-spawning
             } else if (engine.isCharacterDying(sub.id)) {
-              // Only respawn if the sub-agent is in dying/fading state
-              engine.removeCharacter(sub.id);
-              engine.spawnSubAgent(agent.id, sub.id, sub.name || sub.id);
+              // Server status flipped back to `running` mid-fade: cancel the
+              // fade in place. Server status owns the sub-agent lifecycle —
+              // never remove+respawn a running sub-agent (that replayed the
+              // spawn sound and flickered, issue #102).
+              engine.reviveSubAgent(sub.id);
             }
           } else {
             engine.killSubAgent(sub.id);

--- a/src/game/GameEngine.integration.test.ts
+++ b/src/game/GameEngine.integration.test.ts
@@ -26,10 +26,7 @@ import { GameEngine } from './GameEngine';
 import type { GameCallbacks } from './GameEngine';
 import type { EditorCallbacks } from './EditorController';
 import type { PlacedFurniture } from '../../shared/types';
-import {
-  SUBAGENT_FADE_DURATION,
-  SUBAGENT_LIFETIME,
-} from './SubAgentFSM';
+import { SUBAGENT_FADE_DURATION } from './SubAgentFSM';
 import { getDayPhase } from './Schedule';
 import { sfx } from '../audio/SoundFX';
 
@@ -94,6 +91,8 @@ type TestGameEngine = {
   setLayout(furniture: PlacedFurniture[]): void;
   getPlacedFurniture(): PlacedFurniture[];
   spawnSubAgent(parentId: string, subId: string, subName: string): void;
+  killSubAgent(subId: string): void;
+  reviveSubAgent(subId: string): void;
   isCharacterDying(id: string): boolean;
   stop(): void;
 };
@@ -313,47 +312,122 @@ describe('GameEngine integration: sub-agent lifecycle', () => {
     vi.clearAllMocks();
   });
 
-  it('applies the tickSubAgent plan: transition sound, monotonic fade, removal', () => {
+  /** Advance `seconds` of simulated time in 100ms update steps. */
+  const advance = (seconds: number) => {
+    const stepMs = 100;
+    const steps = Math.ceil((seconds * 1000) / stepMs);
+    for (let i = 0; i < steps; i++) {
+      engine.nowMs += stepMs;
+      engine.update(stepMs / 1000);
+    }
+  };
+
+  it('keeps a running sub-agent alive and stable through 60 simulated seconds (issue #102)', () => {
+    const spawnSpy = vi.mocked(sfx.spawn);
     const despawnSpy = vi.mocked(sfx.despawn);
 
-    // Pin `nowMs` so the sub-agent spawn time is known deterministically.
-    // The post-call assertion turns `update(dt)` not reading `performance.now()`
-    // back into the test into a hard regression barrier (ora-3 advisory #1).
     engine.nowMs = 1_000;
     engine.spawnSubAgent('parent', 'sub-1', 'SubOne');
-    expect(engine.characters.has('sub-1')).toBe(true);
+    expect(spawnSpy).toHaveBeenCalledTimes(1);
+    const identity = engine.characters.get('sub-1');
+
+    // 60 simulated seconds — 4x the removed 15s presentation lifetime.
+    advance(60);
+
+    // Stable identity, no fade, no despawn: server status still `running`.
+    expect(engine.characters.get('sub-1')).toBe(identity);
     expect(engine.isCharacterDying('sub-1')).toBe(false);
-    expect(engine.nowMs).toBe(1_000);
+    expect(engine.characters.get('sub-1')!.fadeAlpha).toBe(1);
+    expect(spawnSpy).toHaveBeenCalledTimes(1);
+    expect(despawnSpy).not.toHaveBeenCalled();
+  });
 
-    // Frame that crosses SUBAGENT_LIFETIME: should fire exactly one despawn-sound
-    // and apply the first fade decrement.
-    engine.nowMs = 1_000 + SUBAGENT_LIFETIME + 50;
-    engine.update(0.05);
-    expect(engine.nowMs).toBe(1_000 + SUBAGENT_LIFETIME + 50);
+  it('killSubAgent: exactly one despawn sound, monotonic fade, removal', () => {
+    const despawnSpy = vi.mocked(sfx.despawn);
 
+    engine.nowMs = 1_000;
+    engine.spawnSubAgent('parent', 'sub-1', 'SubOne');
+    expect(engine.isCharacterDying('sub-1')).toBe(false);
+
+    // Completion reconciliation kills the sub-agent: one sound, fade starts.
+    engine.killSubAgent('sub-1');
+    expect(despawnSpy).toHaveBeenCalledTimes(1);
     expect(engine.isCharacterDying('sub-1')).toBe(true);
-    expect(despawnSpy).toHaveBeenCalledTimes(1);
-    const fadeAfterFirstDyingTick = engine.characters.get('sub-1')!.fadeAlpha;
-    expect(fadeAfterFirstDyingTick).toBeLessThan(1);
 
-    // Subsequent dying ticks decay fade monotonically and MUST NOT re-emit the sound.
-    const fadeStepMs = 100;
-    engine.nowMs += fadeStepMs;
-    engine.update(fadeStepMs / 1000);
+    // Repeated kills are idempotent — the sound must not replay.
+    engine.killSubAgent('sub-1');
     expect(despawnSpy).toHaveBeenCalledTimes(1);
-    expect(engine.characters.get('sub-1')!.fadeAlpha).toBeLessThan(fadeAfterFirstDyingTick);
+
+    engine.update(0.05);
+    const fadeAfterFirstTick = engine.characters.get('sub-1')!.fadeAlpha;
+    expect(fadeAfterFirstTick).toBeLessThan(1);
+    expect(despawnSpy).toHaveBeenCalledTimes(1);
+
+    // Fade decays monotonically and MUST NOT re-emit the sound.
+    engine.nowMs += 100;
+    engine.update(0.1);
+    expect(engine.characters.get('sub-1')!.fadeAlpha).toBeLessThan(fadeAfterFirstTick);
+    expect(despawnSpy).toHaveBeenCalledTimes(1);
 
     // Exhaust the fade window: bound the loop on the FSM constant, not a magic
     // iteration count, so this stays correct if SUBAGENT_FADE_DURATION changes.
-    const fadeSteps = Math.ceil(SUBAGENT_FADE_DURATION / fadeStepMs) + 1;
+    const fadeSteps = Math.ceil(SUBAGENT_FADE_DURATION / 100) + 1;
     for (let i = 0; i < fadeSteps; i++) {
       if (!engine.characters.has('sub-1')) break;
-      engine.nowMs += fadeStepMs;
-      engine.update(fadeStepMs / 1000);
+      engine.nowMs += 100;
+      engine.update(0.1);
     }
 
     expect(engine.characters.has('sub-1')).toBe(false);
     expect(despawnSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('reviveSubAgent cancels a mid-fade kill without replaying any sound (issue #102)', () => {
+    const spawnSpy = vi.mocked(sfx.spawn);
+    const despawnSpy = vi.mocked(sfx.despawn);
+
+    engine.nowMs = 1_000;
+    engine.spawnSubAgent('parent', 'sub-1', 'SubOne');
+    engine.killSubAgent('sub-1');
+    engine.update(0.5);
+    expect(engine.isCharacterDying('sub-1')).toBe(true);
+    expect(engine.characters.get('sub-1')!.fadeAlpha).toBeLessThan(1);
+    expect(despawnSpy).toHaveBeenCalledTimes(1);
+
+    // Server status flips back to `running` mid-fade: revive in place.
+    engine.reviveSubAgent('sub-1');
+    expect(engine.isCharacterDying('sub-1')).toBe(false);
+    expect(engine.characters.get('sub-1')!.fadeAlpha).toBe(1);
+
+    // Still alive and stable long past the former presentation lifetime,
+    // with no replayed spawn or despawn sound.
+    advance(60);
+    expect(engine.characters.has('sub-1')).toBe(true);
+    expect(engine.isCharacterDying('sub-1')).toBe(false);
+    expect(spawnSpy).toHaveBeenCalledTimes(1);
+    expect(despawnSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('plays the spawn sound again only for a genuinely new appearance after removal', () => {
+    const spawnSpy = vi.mocked(sfx.spawn);
+
+    engine.nowMs = 1_000;
+    engine.spawnSubAgent('parent', 'sub-1', 'SubOne');
+    engine.killSubAgent('sub-1');
+
+    const fadeSteps = Math.ceil(SUBAGENT_FADE_DURATION / 100) + 1;
+    for (let i = 0; i < fadeSteps; i++) {
+      if (!engine.characters.has('sub-1')) break;
+      engine.nowMs += 100;
+      engine.update(0.1);
+    }
+    expect(engine.characters.has('sub-1')).toBe(false);
+    expect(spawnSpy).toHaveBeenCalledTimes(1);
+
+    // The sub-agent fully faded out, so a later `running` reconciliation is
+    // a genuinely new visual appearance — the spawn sound is justified.
+    engine.spawnSubAgent('parent', 'sub-1', 'SubOne');
+    expect(spawnSpy).toHaveBeenCalledTimes(2);
   });
 });
 

--- a/src/game/GameEngine.integration.test.ts
+++ b/src/game/GameEngine.integration.test.ts
@@ -322,6 +322,18 @@ describe('GameEngine integration: sub-agent lifecycle', () => {
     }
   };
 
+  /** Drain a dying sub-agent's fade-out to removal.
+   *  Bounded on the FSM constant (not a magic iteration count), so the loop
+   *  stays correct — and terminates — if SUBAGENT_FADE_DURATION changes. */
+  const fadeOutCompletely = (subId: string) => {
+    const fadeSteps = Math.ceil(SUBAGENT_FADE_DURATION / 100) + 1;
+    for (let i = 0; i < fadeSteps; i++) {
+      if (!engine.characters.has(subId)) break;
+      engine.nowMs += 100;
+      engine.update(0.1);
+    }
+  };
+
   it('keeps a running sub-agent alive and stable through 60 simulated seconds (issue #102)', () => {
     const spawnSpy = vi.mocked(sfx.spawn);
     const despawnSpy = vi.mocked(sfx.despawn);
@@ -369,14 +381,8 @@ describe('GameEngine integration: sub-agent lifecycle', () => {
     expect(engine.characters.get('sub-1')!.fadeAlpha).toBeLessThan(fadeAfterFirstTick);
     expect(despawnSpy).toHaveBeenCalledTimes(1);
 
-    // Exhaust the fade window: bound the loop on the FSM constant, not a magic
-    // iteration count, so this stays correct if SUBAGENT_FADE_DURATION changes.
-    const fadeSteps = Math.ceil(SUBAGENT_FADE_DURATION / 100) + 1;
-    for (let i = 0; i < fadeSteps; i++) {
-      if (!engine.characters.has('sub-1')) break;
-      engine.nowMs += 100;
-      engine.update(0.1);
-    }
+    // Exhaust the fade window.
+    fadeOutCompletely('sub-1');
 
     expect(engine.characters.has('sub-1')).toBe(false);
     expect(despawnSpy).toHaveBeenCalledTimes(1);
@@ -415,12 +421,7 @@ describe('GameEngine integration: sub-agent lifecycle', () => {
     engine.spawnSubAgent('parent', 'sub-1', 'SubOne');
     engine.killSubAgent('sub-1');
 
-    const fadeSteps = Math.ceil(SUBAGENT_FADE_DURATION / 100) + 1;
-    for (let i = 0; i < fadeSteps; i++) {
-      if (!engine.characters.has('sub-1')) break;
-      engine.nowMs += 100;
-      engine.update(0.1);
-    }
+    fadeOutCompletely('sub-1');
     expect(engine.characters.has('sub-1')).toBe(false);
     expect(spawnSpy).toHaveBeenCalledTimes(1);
 

--- a/src/game/GameEngine.ts
+++ b/src/game/GameEngine.ts
@@ -1696,7 +1696,8 @@ export class GameEngine {
 
   /** Cancel a pending fade-out: the server status flipped back to `running`
    *  mid-fade. The character never left, so no spawn sound and no position
-   *  reset — identity stays stable (issue #102). */
+   *  reset — identity stays stable (issue #102). The spawn glow is likewise
+   *  not replayed (`spawnTime` is untouched): no visual re-emphasis either. */
   reviveSubAgent(subId: string) {
     const sub = this.characters.get(subId);
     if (!sub?.isSubAgent || !sub.dying) return;

--- a/src/game/GameEngine.ts
+++ b/src/game/GameEngine.ts
@@ -383,14 +383,11 @@ export class GameEngine {
 
   private update(dt: number) {
     for (const char of this.characters.values()) {
-      // Sub-agent lifecycle (planner returns actions for caller to execute)
+      // Sub-agent lifecycle: server status owns dying/removal (issue #102);
+      // the planner only advances the fade-out for dying sub-agents.
       if (char.isSubAgent) {
-        const tick = tickSubAgent(char, this.nowMs, dt);
+        const tick = tickSubAgent(char, dt);
         char.fadeAlpha = tick.fadeAlpha;
-        char.dying = tick.dying;
-        for (const action of tick.actions) {
-          if (action.kind === 'despawn-sound') sfx.despawn();
-        }
         if (tick.shouldRemove) {
           this.characters.delete(char.id);
           continue;
@@ -1687,10 +1684,24 @@ export class GameEngine {
     sfx.spawn();
   }
 
-  /** Mark a sub-agent as dying (will fade out) */
+  /** Mark a sub-agent as dying and start its fade-out.
+   *  Plays the despawn sound on the live→dying transition only, so repeated
+   *  kill reconciliations are idempotent and never replay the sound. */
   killSubAgent(subId: string) {
     const sub = this.characters.get(subId);
-    if (sub?.isSubAgent) sub.dying = true;
+    if (!sub?.isSubAgent || sub.dying) return;
+    sub.dying = true;
+    sfx.despawn();
+  }
+
+  /** Cancel a pending fade-out: the server status flipped back to `running`
+   *  mid-fade. The character never left, so no spawn sound and no position
+   *  reset — identity stays stable (issue #102). */
+  reviveSubAgent(subId: string) {
+    const sub = this.characters.get(subId);
+    if (!sub?.isSubAgent || !sub.dying) return;
+    sub.dying = false;
+    sub.fadeAlpha = 1;
   }
 
   /** Check if a character (typically a sub-agent) is in dying state */

--- a/src/game/SubAgentFSM.test.ts
+++ b/src/game/SubAgentFSM.test.ts
@@ -1,109 +1,66 @@
 import { describe, it, expect } from 'vitest';
-import { tickSubAgent, SUBAGENT_LIFETIME, SUBAGENT_FADE_DURATION } from './SubAgentFSM';
+import { tickSubAgent, SUBAGENT_FADE_DURATION } from './SubAgentFSM';
 
 describe('tickSubAgent', () => {
-  it('returns fadeAlpha=1, dying=false, no actions for young sub-agent', () => {
-    const tick = tickSubAgent({ spawnTime: 0, dying: false, fadeAlpha: 1 }, 10_000, 0.016);
+  it('returns fadeAlpha unchanged, dying=false, shouldRemove=false for a live sub-agent', () => {
+    const tick = tickSubAgent({ dying: false, fadeAlpha: 1 }, 0.016);
     expect(tick.fadeAlpha).toBe(1);
     expect(tick.dying).toBe(false);
-    expect(tick.actions).toEqual([]);
     expect(tick.shouldRemove).toBe(false);
   });
 
-  it('transitions to dying and emits despawn-sound when age crosses LIFETIME', () => {
-    const tick = tickSubAgent(
-      { spawnTime: 0, dying: false, fadeAlpha: 1 },
-      SUBAGENT_LIFETIME + 1,
-      0.016,
-    );
-    expect(tick.dying).toBe(true);
-    expect(tick.actions).toEqual([{ kind: 'despawn-sound' }]);
-    // fadeAlpha decreases by dtSec/FADE_DURATION from the moment dying starts
-    expect(tick.fadeAlpha).toBeCloseTo(1 - 0.016 / (SUBAGENT_FADE_DURATION / 1000), 5);
-    expect(tick.shouldRemove).toBe(false);
+  it('never ages a live sub-agent into dying (issue #102 regression pin)', () => {
+    // The pre-fix FSM transitioned to dying once nowMs - spawnTime crossed
+    // SUBAGENT_LIFETIME, which made the engine a second lifecycle owner and
+    // caused the remove-and-respawn loop for long-running sub-agents. The
+    // tick signature no longer accepts time-of-day or spawn time at all, so
+    // age-based death is unrepresentable; this pin guards against its return.
+    let state = { dying: false, fadeAlpha: 1 };
+    for (let i = 0; i < 10_000; i++) {
+      const tick = tickSubAgent(state, 0.1);
+      expect(tick.dying).toBe(false);
+      expect(tick.shouldRemove).toBe(false);
+      state = { dying: tick.dying, fadeAlpha: tick.fadeAlpha };
+    }
+    expect(state.fadeAlpha).toBe(1);
   });
 
-  it('does NOT re-emit despawn-sound on subsequent dying ticks', () => {
-    const tick = tickSubAgent(
-      { spawnTime: 0, dying: true, fadeAlpha: 0.5 },
-      16_000,
-      0.016,
-    );
-    expect(tick.dying).toBe(true);
-    expect(tick.actions).toEqual([]);
-    expect(tick.fadeAlpha).toBeCloseTo(0.5 - 0.016 / (SUBAGENT_FADE_DURATION / 1000), 3);
+  it('preserves existing fadeAlpha for a live sub-agent (no implicit reset)', () => {
+    const tick = tickSubAgent({ dying: false, fadeAlpha: 0.7 }, 0.016);
+    expect(tick.dying).toBe(false);
+    expect(tick.fadeAlpha).toBe(0.7);
   });
 
-  it('fades at correct rate: full fade in SUBAGENT_FADE_DURATION seconds', () => {
-    const tick = tickSubAgent(
-      { spawnTime: 0, dying: true, fadeAlpha: 1 },
-      SUBAGENT_LIFETIME + 1,
-      SUBAGENT_FADE_DURATION / 1000,
-    );
+  it('fades a dying sub-agent at the correct rate: full fade in SUBAGENT_FADE_DURATION', () => {
+    const tick = tickSubAgent({ dying: true, fadeAlpha: 1 }, SUBAGENT_FADE_DURATION / 1000);
+    expect(tick.dying).toBe(true);
     expect(tick.fadeAlpha).toBeCloseTo(0, 5);
     expect(tick.shouldRemove).toBe(true);
   });
 
+  it('fades monotonically across dying ticks', () => {
+    const first = tickSubAgent({ dying: true, fadeAlpha: 0.5 }, 0.016);
+    expect(first.fadeAlpha).toBeCloseTo(0.5 - 0.016 / (SUBAGENT_FADE_DURATION / 1000), 5);
+    expect(first.shouldRemove).toBe(false);
+    const second = tickSubAgent({ dying: true, fadeAlpha: first.fadeAlpha }, 0.016);
+    expect(second.fadeAlpha).toBeLessThan(first.fadeAlpha);
+  });
+
   it('clamps fadeAlpha at 0 when dt exceeds remaining fade time', () => {
-    const tick = tickSubAgent(
-      { spawnTime: 0, dying: true, fadeAlpha: 0.001 },
-      20_000,
-      1.0,
-    );
+    const tick = tickSubAgent({ dying: true, fadeAlpha: 0.001 }, 1.0);
     expect(tick.fadeAlpha).toBe(0);
     expect(tick.shouldRemove).toBe(true);
   });
 
   it('marks shouldRemove when fadeAlpha reaches 0', () => {
-    const tick = tickSubAgent(
-      { spawnTime: 0, dying: true, fadeAlpha: 0 },
-      20_000,
-      0.016,
-    );
+    const tick = tickSubAgent({ dying: true, fadeAlpha: 0 }, 0.016);
     expect(tick.shouldRemove).toBe(true);
     expect(tick.fadeAlpha).toBe(0);
   });
-
-  it('preserves existing dying state (killSubAgent) without re-emitting sound', () => {
-    const tick = tickSubAgent(
-      { spawnTime: 0, dying: true, fadeAlpha: 1 },
-      5_000,
-      0.016,
-    );
-    expect(tick.dying).toBe(true);
-    expect(tick.actions).toEqual([]);
-    expect(tick.fadeAlpha).toBeCloseTo(1 - 0.016 / (SUBAGENT_FADE_DURATION / 1000), 3);
-  });
-
-  it('emits no despawn-sound at exactly LIFETIME boundary (strict > check)', () => {
-    const tick = tickSubAgent(
-      { spawnTime: 0, dying: false, fadeAlpha: 1 },
-      SUBAGENT_LIFETIME,
-      0.016,
-    );
-    expect(tick.dying).toBe(false);
-    expect(tick.actions).toEqual([]);
-  });
-
-  it('preserves existing fadeAlpha for non-dying sub-agent (no implicit reset)', () => {
-    // The original GameEngine code only set fadeAlpha in the dying branch;
-    // non-dying sub-agents retained their prior value. This regression test
-    // pins that behavior so future changes don't silently override it.
-    const tick = tickSubAgent(
-      { spawnTime: 0, dying: false, fadeAlpha: 0.7 },
-      1_000, // well under LIFETIME
-      0.016,
-    );
-    expect(tick.dying).toBe(false);
-    expect(tick.fadeAlpha).toBe(0.7);
-  });
 });
 
-describe('SUBAGENT_LIFETIME and SUBAGENT_FADE_DURATION constants', () => {
-  it('SUBAGENT_LIFETIME is 15000ms', () => {
-    expect(SUBAGENT_LIFETIME).toBe(15_000);
-  });
-  it('SUBAGENT_FADE_DURATION is 2000ms', () => {
+describe('SUBAGENT_FADE_DURATION constant', () => {
+  it('is 2000ms', () => {
     expect(SUBAGENT_FADE_DURATION).toBe(2_000);
   });
 });

--- a/src/game/SubAgentFSM.ts
+++ b/src/game/SubAgentFSM.ts
@@ -1,47 +1,35 @@
-/** SubAgentFSM — pure planner for sub-agent lifecycle ticks.
- * Encapsulates the per-frame state transitions for sub-agent characters
- * (age check, despawn trigger, fade-out, removal). Side effects (sound,
- * character deletion) are reported as actions for the caller to execute.
+/** SubAgentFSM — pure planner for sub-agent fade-out ticks.
+ *
+ * Lifecycle authority: the server-reported sub-agent status is the sole
+ * owner of a sub-agent's lifetime (issue #102). PixelOffice reconciles that
+ * status into `killSubAgent()` / `reviveSubAgent()` calls; this planner only
+ * runs the fade-out once a character is dying and reports when it should be
+ * removed. There is intentionally NO age-based expiry: a sub-agent whose
+ * status stays `running` lives indefinitely.
  */
 
-export const SUBAGENT_LIFETIME = 15_000;
 export const SUBAGENT_FADE_DURATION = 2_000;
 
 export interface SubAgentInput {
-  spawnTime: number;
   dying: boolean;
   fadeAlpha: number;
 }
 
-export type SubAgentAction = { kind: 'despawn-sound' };
-
-const EMPTY_ACTIONS: SubAgentAction[] = [];
-
 export interface SubAgentTick {
   fadeAlpha: number;
   dying: boolean;
-  actions: SubAgentAction[];
   shouldRemove: boolean;
 }
 
 export function tickSubAgent(
   char: SubAgentInput,
-  nowMs: number,
   dtSec: number,
 ): SubAgentTick {
-  const age = nowMs - char.spawnTime;
-  const dying = char.dying || age > SUBAGENT_LIFETIME;
-  const justEnteredDying = dying && !char.dying;
-
-  if (!dying) {
-    // Preserve existing fadeAlpha — the original `if (char.isSubAgent)` block
-    // in GameEngine had no else that reset it. Only dying agents fade.
-    return { fadeAlpha: char.fadeAlpha, dying: false, actions: EMPTY_ACTIONS, shouldRemove: false };
+  if (!char.dying) {
+    // Preserve existing fadeAlpha — only dying agents fade.
+    return { fadeAlpha: char.fadeAlpha, dying: false, shouldRemove: false };
   }
 
   const fadeAlpha = Math.max(0, char.fadeAlpha - dtSec / (SUBAGENT_FADE_DURATION / 1000));
-  const shouldRemove = fadeAlpha <= 0;
-  const actions: SubAgentAction[] = justEnteredDying ? [{ kind: 'despawn-sound' }] : EMPTY_ACTIONS;
-
-  return { fadeAlpha, dying, actions, shouldRemove };
+  return { fadeAlpha, dying: true, shouldRemove: fadeAlpha <= 0 };
 }


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
## Summary

Establishes the server-reported sub-agent status as the single source of truth (SSOT) for sub-agent lifecycle, eliminating a remove-and-respawn loop that caused audible/visual flicker for long-running sub-agents.

## Problem

Two independent lifecycle writers conflicted:
- The engine's fixed 15s presentation lifetime (`SUBAGENT_LIFETIME`) forced `running` sub-agents into `dying`/fade-out.
- `PixelOffice` reconciled server status back to `running`, which removed the dying character and respawned a new one — replaying the spawn sound and resetting position every ~17s.

## Solution

- **Server status owns lifecycle** — `PixelOffice` reconciles `running`/`completed`/`failed` into kill/revive commands on the existing character; it never removes a `running` sub-agent.
- **FSM no longer knows time-of-day** — `tickSubAgent(char, dtSec)` is reduced to a pure fade-out stepper; `SUBAGENT_LIFETIME`, `SubAgentAction`, and the `nowMs`/`spawnTime` inputs are removed, making age-based expiry unrepresentable.
- **Exactly-once despawn sound** — `killSubAgent` guards on the `dying` flag and emits `sfx.despawn()` only on the live→dying transition; repeated reconciliations are idempotent.
- **Mid-fade revival** — new `reviveSubAgent` clears `dying` and restores `fadeAlpha = 1` in place, preserving identity, position, and avoiding any replayed audio.
- **`spawnTime` retained** — it still drives the spawn-glow render; the FSM just no longer reads it.

## Changes by area

| File | Change |
|---|---|
| `src/game/SubAgentFSM.ts` | Deleted `SUBAGENT_LIFETIME`, `SubAgentAction`, and `nowMs`/`spawnTime` inputs; tick only advances fade-out for dying characters. |
| `src/game/GameEngine.ts` | `update()` only applies `fadeAlpha`/removal; `killSubAgent` is guarded and plays despawn once on transition; new `reviveSubAgent` cancels the fade in place. |
| `src/components/PixelOffice.tsx` | Dying-but-`running` reconciliation now revives in place instead of remove+respawn; comments document the SSOT invariant. |
| `src/game/GameEngine.integration.test.ts` | New scenarios: 60s alive stability, idempotent kill, soundless mid-fade revival, and re-spawn after full fade-out. |
| `src/game/SubAgentFSM.test.ts` | Updated for the new tick signature; new 10 000-tick regression pin preventing age-based death; removed obsolete lifetime-boundary tests. |

## Verification

- 187/187 tests pass across 21 files.
- `npm run build`, `npm run typecheck`, `npm run test:coverage` all clean (no regressions).
- Demo mode confirmed unaffected — `spawnDemoAgents` spawns no sub-agents.
- WebSocket/polling path intentionally out of scope (server-side status production unchanged).

---

# Keep running sub-agents alive until the server status ends them

## Summary
Fixes the sub-agent respawn loop where running sub-agents were being torn down and respawned every time the engine's internal lifetime expired, even though the server still reported them as `running`. Sub-agents are now kept alive by the engine until the server explicitly transitions them to a terminal status (or otherwise drops them from the list), and a mid-fade revival preserves their identity instead of replacing them.

## Changes

### `src/components/PixelOffice.subagents.test.tsx` (new)
Adds a contract test suite pinning the React↔engine reconciliation rules for sub-agents:

- **Running + present** → `spawnSubAgent` exactly once; subsequent reconciliations must not touch the sub-agent (this is the regression pin for issue #102).
- **Running + previously dying** → `reviveSubAgent` is called; `removeCharacter` and a fresh `spawnSubAgent` must **not** be invoked.
- **Completed / failed** → `killSubAgent`.
- **Disappeared from server list** → `killSubAgent` (sweep).
- **Parent leaves the room** → `killSubAgent` for each child + `removeCharacter(parent)`.
- **New execution (new sub id)** → `killSubAgent(old)` + `spawnSubAgent(new)`.

The GameEngine is mocked as the boundary so this file only pins which engine method each reconciliation must call; the engine's own lifecycle primitives remain covered by `GameEngine.integration.test.ts`.

### `src/game/GameEngine.ts`
Documents and tightens `reviveSubAgent`'s behavior: when a sub-agent's status flips back to `running` mid-fade, it is restored in place without replaying the spawn glow (`spawnTime` is left untouched), in addition to the existing guarantees of no respawn and no position reset.

## Behavioral impact
A running sub-agent will no longer flicker in and out of the office between server updates. When its status briefly drops to a terminal value and returns to `running`, it revives in place rather than being removed and recreated, eliminating the respawn loop that caused issue #102.

---

Added `flex-shrink: 0` to the agent card styling in `AgentSidebar.css` to prevent cards from collapsing within the scrollable agent list. Without this, cards were being clipped because the flex container was compressing them, causing agent names and icons to overlap. This ensures each card maintains its full height (portrait + content) for proper display.

---

**PR Summary: Fix sub-agent respawn loop (#102)**

This PR addresses an issue (#102) where sub-agents were getting stuck in a respawn loop. The changes ensure that running sub-agents remain alive until the server explicitly ends them, rather than being prematurely killed and respawned.

**Key Changes:**

1. **`src/components/PixelOffice.subagents.test.tsx`** — Added a new test case that verifies sub-agents are properly cleaned up when their parent agent remains in the room but has visualization (`pixelEnabled`) toggled off. This ensures both the parent character and its lingering sub-agents are removed via the sweep path.

2. **`src/game/GameEngine.integration.test.ts`** — Extracted a shared `fadeOutCompletely()` test helper that drains a dying sub-agent's fade-out to removal. The helper is bounded on the `SUBAGENT_FADE_DURATION` FSM constant, so the loop stays correct (and terminates) if the duration constant changes. This refactor consolidates duplicated fade-out logic across multiple test cases.

**Functional Impact:**

The core fix prevents sub-agents from being incorrectly terminated during the parent's lifecycle. The added test guards against a regression where a pixel-disabled parent could leave its sub-agents lingering in the scene, and the refactored test helper improves maintainability of the sub-agent lifecycle test suite.
<!-- kody-pr-summary:end -->