### PR TITLE
feat(ui): replace absolute-island chrome with a responsive layout system

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -22,10 +22,17 @@
   --shadow-neon-pink: 0 0 10px rgba(255, 0, 85, 0.2), inset 0 0 5px rgba(255, 0, 85, 0.1);
   --glass-blur: blur(12px);
 
-  /* Shared mobile HUD geometry keeps independently positioned controls apart. */
-  --mobile-room-switcher-top: 64px;
-  --mobile-room-switcher-height: 46px;
-  --mobile-editor-toolbar-gap: 10px;
+  /* Layout system: one fixed top bar, full-bleed stage, responsive drawers.
+   * Chrome elements compose in flex flow — no absolute islands with magic
+   * offsets (that system collided at every viewport below 1920px). */
+  --topbar-h: 64px;
+  --z-canvas: 10;
+  --z-ticker: 150;
+  --z-editor: 190;
+  --z-backdrop: 240;
+  --z-drawer: 250;
+  --z-topbar: 300;
+  --z-modal: 1000;
   --desktop-agent-sidebar-reserved-width: 316px;
 }
 
@@ -48,40 +55,46 @@ body {
   background-position: center;
 }
 
-/* Floating HUD Header */
+/* Fixed top bar — the single chrome strip. Brand left, room switcher
+ * centered in the remaining flex space, controls right. In-flow composition
+ * makes collisions structurally impossible at any width. */
 .app-header {
-  position: absolute;
-  top: 16px;
-  left: 16px;
-  z-index: 100;
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: var(--z-topbar);
   display: flex;
-  justify-content: space-between;
   align-items: center;
-  padding: 12px 24px;
+  gap: 16px;
+  min-height: var(--topbar-h);
+  padding: 8px 16px;
+  box-sizing: border-box;
   background: var(--bg-panel);
   backdrop-filter: var(--glass-blur);
   -webkit-backdrop-filter: var(--glass-blur);
-  border: var(--border-glass);
-  box-shadow: var(--shadow-neon-cyan);
-  border-radius: 8px; /* Slight rounding for modern feel */
-  /* Remove width to let it fit tightly */
-  gap: 32px;
+  border-bottom: var(--border-glass);
+  box-shadow: 0 2px 16px rgba(0, 0, 0, 0.4), var(--shadow-neon-cyan);
 }
 
 .app-header h1 {
+  flex-shrink: 0;
   font-family: var(--font-pixel);
-  font-size: 18px;
+  font-size: 16px;
   color: var(--acc-cyan);
   text-transform: uppercase;
   letter-spacing: 1px;
   text-shadow: 0 0 5px rgba(0, 240, 255, 0.5);
   margin: 0;
+  white-space: nowrap;
 }
 
 .header-controls {
   display: flex;
   align-items: center;
-  gap: 16px;
+  gap: 12px;
+  flex-shrink: 0;
+  margin-left: auto;
 }
 
 .connection-status {
@@ -92,6 +105,45 @@ body {
 
 .connection-status.connected { color: var(--acc-green); text-shadow: 0 0 5px var(--acc-green); }
 .connection-status.disconnected { color: var(--acc-pink); text-shadow: 0 0 5px var(--acc-pink); }
+
+/* Keyboard navigation: visible focus on every interactive element. */
+button:focus-visible,
+input:focus-visible,
+[tabindex]:focus-visible {
+  outline: 2px solid var(--acc-cyan);
+  outline-offset: 2px;
+  border-radius: 4px;
+}
+
+/* Sidebar drawer toggle — drawer mode only (see AgentSidebar.css). */
+.sidebar-toggle {
+  display: none;
+  align-items: center;
+  gap: 6px;
+  background: rgba(0, 240, 255, 0.1);
+  color: var(--acc-cyan);
+  border: 1px solid var(--acc-cyan);
+  font-family: var(--font-pixel);
+  font-size: 12px;
+  padding: 8px 12px;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+.sidebar-toggle:hover {
+  background: rgba(0, 240, 255, 0.2);
+  box-shadow: 0 0 8px rgba(0, 240, 255, 0.4);
+}
+
+/* Backdrop behind the drawer — click / tap dismisses. */
+.sidebar-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: var(--z-backdrop);
+  background: rgba(4, 6, 12, 0.55);
+  backdrop-filter: blur(2px);
+  -webkit-backdrop-filter: blur(2px);
+}
 
 /* The Editor Toggle */
 .editor-toggle {
@@ -124,7 +176,7 @@ body {
   position: absolute;
   top: 0;
   left: 0;
-  z-index: 10;
+  z-index: var(--z-canvas);
 }
 .office-wrapper {
   width: 100%;
@@ -132,14 +184,22 @@ body {
   position: relative;
 }
 
-/* Mobile Adjustments for Header HUD */
+/* Tablet: drawer toggle appears (sidebar becomes a drawer). */
+@media (max-width: 1024px) {
+  .sidebar-toggle { display: inline-flex; }
+}
+
+/* Mobile: top bar wraps to two rows — brand+controls, then room tabs. */
 @media (max-width: 768px) {
+  :root { --topbar-h: 104px; }
   .app-header {
-    top: 8px; left: 8px; right: 8px;
-    padding: 8px 12px;
     flex-wrap: wrap;
-    gap: 8px;
+    gap: 6px 12px;
+    padding: 8px 12px;
+    min-height: unset;
   }
-  .app-header h1 { font-size: 14px; }
-  .editor-toggle { min-height: 40px; min-width: 40px; font-size: 10px; }
+  .app-header h1 { font-size: 13px; }
+  .editor-toggle { min-height: 40px; font-size: 10px; padding: 8px 10px; }
+  .sidebar-toggle { min-height: 40px; }
+  .connection-status { font-size: 10px; }
 }

--- a/src/App.css
+++ b/src/App.css
@@ -135,7 +135,9 @@ input:focus-visible,
   box-shadow: 0 0 8px rgba(0, 240, 255, 0.4);
 }
 
-/* Backdrop behind the drawer — click / tap dismisses. */
+/* Backdrop behind the drawer — click / tap dismisses. Only ever shown in
+ * drawer mode; hard-hidden above the breakpoint so a stale open state can
+ * never obscure the desktop layout. */
 .sidebar-backdrop {
   position: fixed;
   inset: 0;
@@ -143,6 +145,10 @@ input:focus-visible,
   background: rgba(4, 6, 12, 0.55);
   backdrop-filter: blur(2px);
   -webkit-backdrop-filter: blur(2px);
+}
+
+@media (min-width: 1025px) {
+  .sidebar-backdrop { display: none; }
 }
 
 /* The Editor Toggle */
@@ -187,6 +193,15 @@ input:focus-visible,
 /* Tablet: drawer toggle appears (sidebar becomes a drawer). */
 @media (max-width: 1024px) {
   .sidebar-toggle { display: inline-flex; }
+}
+
+/* Small phones: icon-only brand and status dot keep the top bar to two
+ * rows. Accessible names live on aria-labels, so hiding text is safe. */
+@media (max-width: 480px) {
+  .brand-text,
+  .status-text {
+    display: none;
+  }
 }
 
 /* Mobile: top bar wraps to two rows — brand+controls, then room tabs. */

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from 'react';
+import React, { useState, useCallback, useEffect } from 'react';
 import { PixelOffice } from './components/PixelOffice';
 import { AgentSidebar } from './components/AgentSidebar';
 import { AgentDetailPanel } from './components/AgentDetailPanel';
@@ -16,7 +16,7 @@ import './App.css';
 export const App: React.FC = () => {
   const { agents, connected, toggleAgent, toggleAll, updateTags, updateRecipe, activeRoomId, setActiveRoomId, roomAgents } = useAgentStore();
   const {
-    layouts, activeLayout, isDirty, catalog,
+    layouts, activeLayout, isDirty, saveStatus, catalog,
     loadLayoutById, saveActiveLayout, createLayout, deleteLayout, updateFurniture,
   } = useLayoutStore();
 
@@ -25,6 +25,20 @@ export const App: React.FC = () => {
   const [selectedFurnitureId, setSelectedFurnitureId] = useState<string | null>(null);
   const [selectedAgentId, setSelectedAgentId] = useState<string | null>(null);
   const [deleteMode, setDeleteMode] = useState(false);
+  // Agents drawer (≤1024px the sidebar is off-canvas; see AgentSidebar.css)
+  const [sidebarOpen, setSidebarOpen] = useState(false);
+
+  const enabledAgentCount = agents.filter(a => a.pixelEnabled).length;
+
+  // Escape closes the agents drawer.
+  useEffect(() => {
+    if (!sidebarOpen) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setSidebarOpen(false);
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [sidebarOpen]);
 
   // Place new furniture
   const handlePlaceFurniture = useCallback((type: string, gridX: number, gridY: number) => {
@@ -105,7 +119,20 @@ export const App: React.FC = () => {
     <div className="app">
       <header className="app-header">
         <h1>🖥️ OpenClaw Pixel Agents</h1>
+        <RoomSwitcher
+          activeRoomId={activeRoomId}
+          onRoomChange={setActiveRoomId}
+          agents={agents}
+        />
         <div className="header-controls">
+          <button
+            className={`sidebar-toggle ${sidebarOpen ? 'active' : ''}`}
+            onClick={() => setSidebarOpen(open => !open)}
+            aria-label="Toggle agents panel"
+            aria-expanded={sidebarOpen}
+          >
+            👥 {enabledAgentCount}
+          </button>
           <button
             className={`editor-toggle ${editorMode ? 'active' : ''}`}
             onClick={() => setEditorMode(!editorMode)}
@@ -118,11 +145,6 @@ export const App: React.FC = () => {
           <SoundControls />
         </div>
       </header>
-      <RoomSwitcher
-        activeRoomId={activeRoomId}
-        onRoomChange={setActiveRoomId}
-        agents={agents}
-      />
       <main className="app-main">
         <div className="office-wrapper">
           {editorMode && (
@@ -130,6 +152,7 @@ export const App: React.FC = () => {
               catalog={catalog}
               activeLayout={activeLayout}
               isDirty={isDirty}
+              saveStatus={saveStatus}
               layouts={layouts}
               editorMode={editorMode}
               selectedFurnitureType={selectedFurnitureType}
@@ -165,6 +188,13 @@ export const App: React.FC = () => {
             onCharacterClick={handleCharacterClick}
           />
         </div>
+        {sidebarOpen && (
+          <div
+            className="sidebar-backdrop"
+            onClick={() => setSidebarOpen(false)}
+            aria-hidden="true"
+          />
+        )}
         <AgentSidebar
           agents={agents}
           onToggle={toggleAgent}
@@ -172,6 +202,8 @@ export const App: React.FC = () => {
           onSelectAgent={setSelectedAgentId}
           onUpdateTags={updateTags}
           onUpdateRecipe={updateRecipe}
+          open={sidebarOpen}
+          onClose={() => setSidebarOpen(false)}
         />
       </main>
       <AgentDetailPanel

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useEffect } from 'react';
+import React, { useState, useCallback, useEffect, useRef } from 'react';
 import { PixelOffice } from './components/PixelOffice';
 import { AgentSidebar } from './components/AgentSidebar';
 import { AgentDetailPanel } from './components/AgentDetailPanel';
@@ -39,6 +39,38 @@ export const App: React.FC = () => {
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
   }, [sidebarOpen]);
+
+  // Close the drawer when leaving drawer mode (viewport crosses above
+  // 1024px) — otherwise the backdrop would linger over the desktop layout.
+  useEffect(() => {
+    if (typeof window.matchMedia !== 'function') return;
+    const mql = window.matchMedia('(min-width: 1025px)');
+    const onChange = (e: MediaQueryListEvent) => {
+      if (e.matches) setSidebarOpen(false);
+    };
+    mql.addEventListener('change', onChange);
+    return () => mql.removeEventListener('change', onChange);
+  }, []);
+
+  // The top bar wraps to two (very narrow: three) rows depending on width,
+  // so --topbar-h is derived from the RENDERED header height rather than a
+  // fixed guess. CSS values in App.css remain the pre-JS fallback. Editor
+  // toolbar, sidebar, and drawer all offset from this var.
+  const headerRef = useRef<HTMLElement>(null);
+  useEffect(() => {
+    const header = headerRef.current;
+    if (!header || typeof ResizeObserver === 'undefined') return;
+    const syncTopbarHeight = () => {
+      document.documentElement.style.setProperty(
+        '--topbar-h',
+        `${Math.ceil(header.getBoundingClientRect().height)}px`,
+      );
+    };
+    syncTopbarHeight();
+    const observer = new ResizeObserver(syncTopbarHeight);
+    observer.observe(header);
+    return () => observer.disconnect();
+  }, []);
 
   // Place new furniture
   const handlePlaceFurniture = useCallback((type: string, gridX: number, gridY: number) => {
@@ -117,8 +149,8 @@ export const App: React.FC = () => {
 
   return (
     <div className="app">
-      <header className="app-header">
-        <h1>🖥️ OpenClaw Pixel Agents</h1>
+      <header className="app-header" ref={headerRef}>
+        <h1 aria-label="OpenClaw Pixel Agents"><span aria-hidden="true">🖥️ </span><span className="brand-text">OpenClaw Pixel Agents</span></h1>
         <RoomSwitcher
           activeRoomId={activeRoomId}
           onRoomChange={setActiveRoomId}
@@ -139,8 +171,11 @@ export const App: React.FC = () => {
           >
             {editorMode ? '✏️ Editor ON' : '✏️ Editor'}
           </button>
-          <span className={`connection-status ${connected ? 'connected' : 'disconnected'}`}>
-            {connected ? '● Connected' : '○ Disconnected'}
+          <span
+            className={`connection-status ${connected ? 'connected' : 'disconnected'}`}
+            aria-label={connected ? 'Connected' : 'Disconnected'}
+          >
+            {connected ? '●' : '○'}<span className="status-text">{connected ? ' Connected' : ' Disconnected'}</span>
           </span>
           <SoundControls />
         </div>
@@ -188,24 +223,27 @@ export const App: React.FC = () => {
             onCharacterClick={handleCharacterClick}
           />
         </div>
-        {sidebarOpen && (
-          <div
-            className="sidebar-backdrop"
-            onClick={() => setSidebarOpen(false)}
-            aria-hidden="true"
-          />
-        )}
-        <AgentSidebar
-          agents={agents}
-          onToggle={toggleAgent}
-          onToggleAll={toggleAll}
-          onSelectAgent={setSelectedAgentId}
-          onUpdateTags={updateTags}
-          onUpdateRecipe={updateRecipe}
-          open={sidebarOpen}
-          onClose={() => setSidebarOpen(false)}
-        />
       </main>
+      {sidebarOpen && (
+        <div
+          className="sidebar-backdrop"
+          onClick={() => setSidebarOpen(false)}
+          aria-hidden="true"
+        />
+      )}
+      {/* Sidebar + backdrop are direct .app children: inside .app-main's
+          z-10 stacking context they'd be capped below the ticker (150) and
+          top bar (300). position:fixed keeps geometry identical. */}
+      <AgentSidebar
+        agents={agents}
+        onToggle={toggleAgent}
+        onToggleAll={toggleAll}
+        onSelectAgent={setSelectedAgentId}
+        onUpdateTags={updateTags}
+        onUpdateRecipe={updateRecipe}
+        open={sidebarOpen}
+        onClose={() => setSidebarOpen(false)}
+      />
       <AgentDetailPanel
         agent={selectedAgentId ? agents.find(a => a.id === selectedAgentId) ?? null : null}
         onClose={() => setSelectedAgentId(null)}

--- a/src/components/AgentSidebar.css
+++ b/src/components/AgentSidebar.css
@@ -337,5 +337,8 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .agent-sidebar { transition: visibility 0s; }
+  /* Include .open: its (0,2,0) specificity would otherwise override this
+   * rule and keep the 0.25s slide for reduced-motion users. */
+  .agent-sidebar,
+  .agent-sidebar.open { transition: visibility 0s; }
 }

--- a/src/components/AgentSidebar.css
+++ b/src/components/AgentSidebar.css
@@ -1,9 +1,9 @@
 /* AgentSidebar.css - Frosted 16-Bit HUD */
 .agent-sidebar {
-  position: absolute;
-  top: 16px;
+  position: fixed;
+  top: calc(var(--topbar-h) + 8px);
   right: 16px;
-  bottom: 80px; /* Leave room for marquee */
+  bottom: 64px; /* clear of the message ticker zone */
   width: 300px;
   background: var(--bg-panel);
   backdrop-filter: var(--glass-blur);
@@ -17,6 +17,22 @@
   z-index: 100;
   transition: all 0.3s ease;
 }
+
+/* Drawer close button — drawer mode only (≤1024px). */
+.sidebar-close-btn {
+  display: none;
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  background: rgba(0, 0, 0, 0.3);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  color: var(--text-main);
+  border-radius: 4px;
+  padding: 4px 8px;
+  cursor: pointer;
+  font-size: 12px;
+}
+.sidebar-close-btn:hover { border-color: var(--acc-pink); color: var(--acc-pink); }
 
 /* Custom Scrollbar for HUD */
 .agent-sidebar::-webkit-scrollbar {
@@ -283,23 +299,37 @@
   box-shadow: 0 0 8px rgba(255, 0, 85, 0.4);
 }
 
-/* ── Mobile: absolute slide-up panel or stripped down ── */
-@media (max-width: 768px) {
+/* ── Drawer mode: off-canvas right panel, toggled from the top bar ──
+ * Below 1024px a floating 300px panel covers too much of the office stage
+ * (measured: 736px of 768px at tablet width). The drawer keeps the stage
+ * clear and opens on demand with a backdrop. */
+@media (max-width: 1024px) {
   .agent-sidebar {
-    width: auto;
-    left: 16px; /* Span across on small screens */
-    top: auto;
-    bottom: 16px;
-    height: 35vh; /* Take bottom 1/3 */
-    max-height: none;
-    border-radius: 12px;
+    top: var(--topbar-h);
+    right: 0;
+    bottom: 0;
+    width: min(320px, 88vw);
+    border-radius: 0;
+    border-right: none;
+    border-top: none;
+    transform: translateX(105%);
+    transition: transform 0.25s ease;
+    z-index: var(--z-drawer);
+    box-shadow: -8px 0 24px rgba(0, 0, 0, 0.5);
   }
+  .agent-sidebar.open {
+    transform: translateX(0);
+  }
+  .sidebar-close-btn { display: block; }
 }
 
 @media (max-width: 480px) {
   .agent-sidebar {
-    left: 8px; right: 8px; bottom: 8px;
-    height: 30vh;
-    padding: 10px;
+    width: min(320px, 92vw);
+    padding: 12px;
   }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .agent-sidebar { transition: none; }
 }

--- a/src/components/AgentSidebar.css
+++ b/src/components/AgentSidebar.css
@@ -313,12 +313,18 @@
     border-right: none;
     border-top: none;
     transform: translateX(105%);
-    transition: transform 0.25s ease;
+    /* Closed drawer must leave tab order and the a11y tree, not just the
+     * viewport. visibility:hidden does all three; the delayed visibility
+     * transition lets the slide-out finish before the panel disappears. */
+    visibility: hidden;
+    transition: transform 0.25s ease, visibility 0s linear 0.25s;
     z-index: var(--z-drawer);
     box-shadow: -8px 0 24px rgba(0, 0, 0, 0.5);
   }
   .agent-sidebar.open {
     transform: translateX(0);
+    visibility: visible;
+    transition: transform 0.25s ease, visibility 0s;
   }
   .sidebar-close-btn { display: block; }
 }
@@ -331,5 +337,5 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .agent-sidebar { transition: none; }
+  .agent-sidebar { transition: visibility 0s; }
 }

--- a/src/components/AgentSidebar.drawer.test.tsx
+++ b/src/components/AgentSidebar.drawer.test.tsx
@@ -1,0 +1,120 @@
+/**
+ * Drawer-mode contract tests for AgentSidebar (PR #121 bot-review fixes).
+ *
+ * Two classes of pins:
+ *  1. CSS: below 1024px the CLOSED drawer must leave tab order and the a11y
+ *     tree (visibility:hidden), not just the viewport (transform) — an
+ *     off-screen panel whose controls stay tabbable is the classic
+ *     off-canvas accessibility defect Codex flagged.
+ *  2. Behavior: the `open` prop drives the `open` class and the close
+ *     button requests `onClose`.
+ */
+
+import React from 'react';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { AgentSidebar } from './AgentSidebar';
+import type { AgentState } from '../../shared/types';
+
+vi.mock('./AgentPortrait', () => ({ AgentPortrait: () => null }));
+vi.mock('./TagEditor', () => ({ TagEditor: () => null }));
+vi.mock('./CharacterCustomizer', () => ({ CharacterCustomizer: () => null }));
+
+const DRAWER_MEDIA_QUERY = '(max-width: 1024px)';
+const COMPONENT_DIR = dirname(fileURLToPath(import.meta.url));
+const sidebarCss = readFileSync(resolve(COMPONENT_DIR, 'AgentSidebar.css'), 'utf-8');
+
+function getRuleDeclarations(css: string, selector: string, mediaQuery?: string) {
+  const styleElement = document.createElement('style');
+  styleElement.textContent = css;
+  document.head.append(styleElement);
+
+  try {
+    const sheet = styleElement.sheet;
+    expect(sheet, 'CSS must produce a stylesheet').not.toBeNull();
+
+    let rules = Array.from(sheet!.cssRules);
+    if (mediaQuery) {
+      const mediaRule = rules.find(
+        (rule): rule is CSSMediaRule =>
+          'conditionText' in rule && rule.conditionText === mediaQuery,
+      );
+      expect(mediaRule, `${mediaQuery} block must exist`).toBeDefined();
+      rules = Array.from(mediaRule!.cssRules);
+    }
+
+    const styleRule = rules.find(
+      (rule): rule is CSSStyleRule =>
+        'selectorText' in rule && rule.selectorText === selector,
+    );
+    expect(styleRule, `${selector} rule must exist`).toBeDefined();
+
+    const declarations = new Map<string, string>();
+    for (let index = 0; index < styleRule!.style.length; index += 1) {
+      const property = styleRule!.style.item(index);
+      declarations.set(property, styleRule!.style.getPropertyValue(property).trim());
+    }
+    return declarations;
+  } finally {
+    styleElement.remove();
+  }
+}
+
+const agent: AgentState = {
+  id: 'cybera',
+  name: 'Cybera',
+  activity: 'typing',
+  model: 'm',
+  sessionKey: 'k',
+  active: true,
+  lastActivity: 1,
+  pixelEnabled: true,
+  tags: [],
+};
+
+const baseProps = {
+  agents: [agent],
+  onToggle: vi.fn(),
+  onToggleAll: vi.fn(),
+};
+
+describe('AgentSidebar drawer mode', () => {
+  afterEach(cleanup);
+
+  it('closed drawer is hidden from tab order and AT, open drawer is visible', () => {
+    const closed = getRuleDeclarations(sidebarCss, '.agent-sidebar', DRAWER_MEDIA_QUERY);
+    expect(closed.get('visibility')).toBe('hidden');
+    expect(closed.get('transform')).toContain('translateX(105%)');
+
+    const open = getRuleDeclarations(sidebarCss, '.agent-sidebar.open', DRAWER_MEDIA_QUERY);
+    expect(open.get('visibility')).toBe('visible');
+    expect(open.get('transform')).toBe('translateX(0)');
+  });
+
+  it('applies the open class from the prop and requests close from the close button', () => {
+    const onClose = vi.fn();
+    const { container, rerender } = render(
+      <AgentSidebar {...baseProps} open={false} onClose={onClose} />,
+    );
+    const aside = container.querySelector('aside')!;
+    expect(aside.classList.contains('open')).toBe(false);
+
+    rerender(<AgentSidebar {...baseProps} open onClose={onClose} />);
+    expect(aside.classList.contains('open')).toBe(true);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Close agents panel' }));
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it('labels the aside and the icon-only card controls for assistive tech', () => {
+    render(<AgentSidebar {...baseProps} open />);
+    expect(screen.getByRole('complementary', { name: 'Agents' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Hide Cybera from office' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Add tags for Cybera' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Customize appearance for Cybera' })).toBeTruthy();
+  });
+});

--- a/src/components/AgentSidebar.drawer.test.tsx
+++ b/src/components/AgentSidebar.drawer.test.tsx
@@ -47,10 +47,10 @@ function getRuleDeclarations(css: string, selector: string, mediaQuery?: string)
       rules = Array.from(mediaRule!.cssRules);
     }
 
-    const styleRule = rules.find(
-      (rule): rule is CSSStyleRule =>
-        'selectorText' in rule && rule.selectorText === selector,
-    );
+    const styleRule = rules.find((rule): rule is CSSStyleRule => {
+      if (!('selectorText' in rule) || typeof rule.selectorText !== 'string') return false;
+      return rule.selectorText.split(',').map(s => s.trim()).includes(selector);
+    });
     expect(styleRule, `${selector} rule must exist`).toBeDefined();
 
     const declarations = new Map<string, string>();
@@ -93,6 +93,23 @@ describe('AgentSidebar drawer mode', () => {
     const open = getRuleDeclarations(sidebarCss, '.agent-sidebar.open', DRAWER_MEDIA_QUERY);
     expect(open.get('visibility')).toBe('visible');
     expect(open.get('transform')).toBe('translateX(0)');
+  });
+
+  it('reduced-motion override covers the higher-specificity .open rule', () => {
+    // .agent-sidebar.open has (0,2,0) specificity — the reduced-motion block
+    // must name it explicitly or the slide animation survives (Kody, #121).
+    const reducedClosed = getRuleDeclarations(
+      sidebarCss,
+      '.agent-sidebar',
+      '(prefers-reduced-motion: reduce)',
+    );
+    expect(reducedClosed.get('transition')).toBe('visibility 0s');
+    const reducedOpen = getRuleDeclarations(
+      sidebarCss,
+      '.agent-sidebar.open',
+      '(prefers-reduced-motion: reduce)',
+    );
+    expect(reducedOpen.get('transition')).toBe('visibility 0s');
   });
 
   it('applies the open class from the prop and requests close from the close button', () => {

--- a/src/components/AgentSidebar.tsx
+++ b/src/components/AgentSidebar.tsx
@@ -13,6 +13,10 @@ interface Props {
   onSelectAgent?: (agentId: string) => void;
   onUpdateTags?: (agentId: string, tags: AgentTag[]) => Promise<void>;
   onUpdateRecipe?: (agentId: string, recipe: CharacterRecipe) => Promise<void>;
+  /** Drawer mode (≤1024px): whether the off-canvas panel is open. */
+  open?: boolean;
+  /** Drawer mode: request to close (backdrop / close button). */
+  onClose?: () => void;
 }
 
 const activityIcons: Record<AgentActivity, string> = {
@@ -65,6 +69,8 @@ const AgentCard = React.memo<AgentCardProps>(({ agent, onToggle, onSelectAgent, 
               className={`toggle-btn ${agent.pixelEnabled ? 'on' : 'off'}`}
               onClick={(e) => { e.stopPropagation(); onToggle(agent.id, !agent.pixelEnabled); }}
               title={agent.pixelEnabled ? 'Hide from office' : 'Show in office'}
+              aria-label={agent.pixelEnabled ? `Hide ${agent.name} from office` : `Show ${agent.name} in office`}
+              aria-pressed={agent.pixelEnabled}
             >
               {agent.pixelEnabled ? '👁️' : '👁️‍🗨️'}
             </button>
@@ -114,6 +120,7 @@ const AgentCard = React.memo<AgentCardProps>(({ agent, onToggle, onSelectAgent, 
                   className="tag-edit-btn"
                   onClick={(e) => { e.stopPropagation(); onOpenTagEditor(agent); }}
                   title="Edit tags"
+                  aria-label={`Edit tags for ${agent.name}`}
                 >
                   ✏️
                 </button>
@@ -121,6 +128,7 @@ const AgentCard = React.memo<AgentCardProps>(({ agent, onToggle, onSelectAgent, 
                   className="tag-edit-btn"
                   onClick={(e) => { e.stopPropagation(); onOpenCustomizer(agent); }}
                   title="Customize appearance"
+                  aria-label={`Customize appearance for ${agent.name}`}
                 >
                   🎨
                 </button>
@@ -133,6 +141,7 @@ const AgentCard = React.memo<AgentCardProps>(({ agent, onToggle, onSelectAgent, 
                 className="tag-add-btn"
                 onClick={(e) => { e.stopPropagation(); onOpenTagEditor(agent); }}
                 title="Add tags"
+                aria-label={`Add tags for ${agent.name}`}
               >
                 + tags
               </button>
@@ -141,6 +150,7 @@ const AgentCard = React.memo<AgentCardProps>(({ agent, onToggle, onSelectAgent, 
                   className="tag-edit-btn"
                   onClick={(e) => { e.stopPropagation(); onOpenCustomizer(agent); }}
                   title="Customize appearance"
+                  aria-label={`Customize appearance for ${agent.name}`}
                 >
                   🎨
                 </button>
@@ -153,7 +163,7 @@ const AgentCard = React.memo<AgentCardProps>(({ agent, onToggle, onSelectAgent, 
   );
 });
 
-export const AgentSidebar: React.FC<Props> = React.memo(({ agents, onToggle, onToggleAll, onSelectAgent, onUpdateTags, onUpdateRecipe }) => {
+export const AgentSidebar: React.FC<Props> = React.memo(({ agents, onToggle, onToggleAll, onSelectAgent, onUpdateTags, onUpdateRecipe, open = true, onClose }) => {
   const enabledCount = agents.filter(a => a.pixelEnabled).length;
   const [tagEditorAgent, setTagEditorAgent] = useState<AgentState | null>(null);
   const [customizerAgent, setCustomizerAgent] = useState<AgentState | null>(null);
@@ -170,7 +180,8 @@ export const AgentSidebar: React.FC<Props> = React.memo(({ agents, onToggle, onT
   )), [agents, onToggle, onSelectAgent]);
 
   return (
-    <aside className="agent-sidebar">
+    <aside className={`agent-sidebar ${open ? 'open' : ''}`} aria-label="Agents">
+      <button className="sidebar-close-btn" onClick={onClose} aria-label="Close agents panel">✖</button>
       <h2>Agents ({enabledCount}/{agents.length})</h2>
       <div className="agent-list">
         {agentCards}

--- a/src/components/LayoutEditor.css
+++ b/src/components/LayoutEditor.css
@@ -4,11 +4,15 @@
   top: 0;
   left: 0;
   right: 0;
-  z-index: 90; /* Below Header, above Canvas */
+  z-index: var(--z-editor);
   pointer-events: none;
-  padding-right: var(--desktop-agent-sidebar-reserved-width);
 }
 .layout-editor > * { pointer-events: auto; }
+
+@media (min-width: 1025px) {
+  /* Keep editor panels clear of the floating sidebar on desktop. */
+  .layout-editor { padding-right: var(--desktop-agent-sidebar-reserved-width); }
+}
 
 /* Toolbar */
 .editor-toolbar {
@@ -18,7 +22,7 @@
   align-items: center;
   gap: 12px;
   padding: 8px 16px;
-  margin-top: 80px; /* Below floating header */
+  margin-top: calc(var(--topbar-h) + 12px); /* Below the fixed top bar */
   width: fit-content;
   margin-left: auto;
   margin-right: auto;
@@ -61,6 +65,26 @@
 }
 .toolbar-btn.save-btn.dirty {
   animation: pulse-dirty 2s ease-in-out infinite;
+}
+.toolbar-btn.save-btn:disabled {
+  opacity: 0.45;
+  cursor: default;
+  animation: none;
+  box-shadow: none;
+}
+.toolbar-btn.save-btn:disabled:hover {
+  background: rgba(0, 255, 170, 0.1);
+  box-shadow: none;
+}
+.toolbar-btn.save-btn.saved {
+  border-color: var(--acc-green);
+  color: var(--acc-green);
+  background: rgba(0, 255, 170, 0.25);
+}
+.toolbar-btn.save-btn.error {
+  border-color: var(--acc-pink);
+  color: var(--acc-pink);
+  background: rgba(255, 0, 85, 0.15);
 }
 @keyframes pulse-dirty {
   0%, 100% { box-shadow: 0 0 0 0 rgba(255, 200, 0, 0.4); }
@@ -254,15 +278,8 @@
 .furniture-palette::-webkit-scrollbar-thumb, .layout-list::-webkit-scrollbar-thumb { background: var(--acc-cyan); border-radius: 4px; }
 
 @media (max-width: 768px) {
-  .layout-editor { padding-right: 0; }
-
-  /* Keep the toolbar below the complete room switcher hit-target band. */
+  /* Toolbar sits below the (two-row) top bar via the shared --topbar-h var. */
   .editor-toolbar {
-    margin-top: calc(
-      var(--mobile-room-switcher-top)
-      + var(--mobile-room-switcher-height)
-      + var(--mobile-editor-toolbar-gap)
-    );
     width: 90%;
   }
   .furniture-palette, .layout-manager { position: static; width: auto; max-height: 250px; margin: 12px; }

--- a/src/components/LayoutEditor.mobile.test.tsx
+++ b/src/components/LayoutEditor.mobile.test.tsx
@@ -51,63 +51,67 @@ function getRuleDeclarations(css: string, selector: string, mediaQuery?: string)
 }
 
 /**
- * Regression test for issue #87: mobile toolbar overlap with room switcher.
+ * Regression test for the overlap family first reported in issue #87
+ * (mobile toolbar vs room switcher) and generalized in the 2026 responsive
+ * revamp: ALL chrome collisions came from absolutely positioned islands
+ * with magic offsets.
  *
- * Root cause: at ≤768px the room switcher sits at top:64px with z-index:100
- * and a height of 46px (bottom edge 110px). The editor toolbar was at
- * margin-top:60px inside a z-index:90 container — so it occupied the same
- * vertical band and lost hit-testing to the room switcher.
- *
- * Fix: derive both elements from shared mobile HUD geometry so future room
- * switcher changes cannot silently reintroduce the overlap.
+ * Current architecture: one fixed top bar composes brand, room switcher,
+ * and controls in flex flow (collisions structurally impossible), and the
+ * editor toolbar offsets from the shared `--topbar-h` variable so it always
+ * clears the bar — including the two-row mobile wrap. These pins fail if
+ * anyone reintroduces independent absolute positioning.
  */
 describe('Issue #87 — mobile toolbar / room switcher overlap', () => {
   afterEach(cleanup);
   // ── CSS regression: catch anyone reverting the offset ──────────────
 
-  it('derives the mobile toolbar offset from the room switcher geometry', () => {
+  it('derives the toolbar offset from the shared top-bar height', () => {
     const root = getRuleDeclarations(appCss, ':root');
-    expect(root.get('--mobile-room-switcher-top')).toBe('64px');
-    expect(root.get('--mobile-room-switcher-height')).toBe('46px');
-    expect(root.get('--mobile-editor-toolbar-gap')).toBe('10px');
+    expect(root.get('--topbar-h')).toBe('64px');
     expect(root.get('--desktop-agent-sidebar-reserved-width')).toBe('316px');
 
-    const roomSwitcher = getRuleDeclarations(
+    // Mobile wraps the top bar to two rows and grows the shared height var.
+    const mobileRoot = getRuleDeclarations(appCss, ':root', MOBILE_MEDIA_QUERY);
+    expect(mobileRoot.get('--topbar-h')).toBe('104px');
+
+    // The room switcher is composed in flex flow inside the top bar — never
+    // absolutely positioned. On mobile it becomes the full-width second row.
+    const baseSwitcher = getRuleDeclarations(roomSwitcherCss, '.room-switcher');
+    expect(baseSwitcher.get('position')).toBe('static');
+    const mobileSwitcher = getRuleDeclarations(
       roomSwitcherCss,
       '.room-switcher',
       MOBILE_MEDIA_QUERY,
     );
+    expect(mobileSwitcher.get('order')).toBe('3');
+    expect(mobileSwitcher.get('top')).toBeUndefined();
 
-    expect(roomSwitcher.get('top')).toBe('var(--mobile-room-switcher-top)');
-    expect(roomSwitcher.get('height')).toBe('var(--mobile-room-switcher-height)');
-
-    const editorToolbar = getRuleDeclarations(
-      layoutEditorCss,
-      '.editor-toolbar',
-      MOBILE_MEDIA_QUERY,
-    );
+    // The toolbar clears the whole bar via the shared var, in every mode.
+    const editorToolbar = getRuleDeclarations(layoutEditorCss, '.editor-toolbar');
     const toolbarOffset = editorToolbar
       .get('margin-top')
       ?.replace(/\s+/g, ' ')
       .replace(/\(\s+/g, '(')
       .replace(/\s+\)/g, ')');
-    expect(toolbarOffset).toBe(
-      'calc(var(--mobile-room-switcher-top) + var(--mobile-room-switcher-height) + var(--mobile-editor-toolbar-gap))',
-    );
+    expect(toolbarOffset).toBe('calc(var(--topbar-h) + 12px)');
   });
 
-  it('reserves the desktop agent sidebar band and releases it on mobile', () => {
-    const desktopEditor = getRuleDeclarations(layoutEditorCss, '.layout-editor');
+  it('reserves the desktop agent sidebar band above drawer width only', () => {
+    // Desktop (above the 1024px drawer breakpoint): reserve the sidebar band.
+    const desktopEditor = getRuleDeclarations(
+      layoutEditorCss,
+      '.layout-editor',
+      '(min-width: 1025px)',
+    );
     expect(desktopEditor.get('padding-right')).toBe(
       'var(--desktop-agent-sidebar-reserved-width)',
     );
 
-    const mobileEditor = getRuleDeclarations(
-      layoutEditorCss,
-      '.layout-editor',
-      MOBILE_MEDIA_QUERY,
-    );
-    expect(mobileEditor.get('padding-right')).toBe('0px');
+    // Base rule reserves nothing: below 1024px the sidebar is an off-canvas
+    // drawer, so the editor may use the full stage width.
+    const baseEditor = getRuleDeclarations(layoutEditorCss, '.layout-editor');
+    expect(baseEditor.get('padding-right')).toBeUndefined();
   });
   // ── Functional regression: toolbar buttons render and fire ──────────
 
@@ -154,9 +158,34 @@ describe('Issue #87 — mobile toolbar / room switcher overlap', () => {
     expect(screen.getByTitle('Exit editor')).toBeTruthy();
   });
 
-  it('fires onSave when Save is clicked', () => {
-    render(<LayoutEditor {...props} />);
+  it('fires onSave when Save is clicked with unsaved changes', () => {
+    render(<LayoutEditor {...props} isDirty />);
     fireEvent.click(screen.getByTitle(/Save layout/));
+    expect(props.onSave).toHaveBeenCalledOnce();
+  });
+
+  it('disables Save when there are no unsaved changes', () => {
+    render(<LayoutEditor {...props} />);
+    const saveButton = screen.getByTitle(/Save layout/);
+    expect(saveButton).toHaveProperty('disabled', true);
+    fireEvent.click(saveButton);
+    expect(props.onSave).not.toHaveBeenCalled();
+  });
+
+  it('reflects the save lifecycle state from the layout store', () => {
+    const { unmount } = render(<LayoutEditor {...props} isDirty saveStatus="saving" />);
+    expect(screen.getByTitle('Saving layout…')).toHaveProperty('disabled', true);
+    unmount();
+
+    const { unmount: unmountSaved } = render(<LayoutEditor {...props} saveStatus="saved" />);
+    expect(screen.getByTitle('Layout saved').textContent).toContain('✓ Saved');
+    unmountSaved();
+
+    // Error state: stays enabled so the user can retry immediately.
+    render(<LayoutEditor {...props} saveStatus="error" />);
+    const retryButton = screen.getByTitle(/Couldn't save/);
+    expect(retryButton).toHaveProperty('disabled', false);
+    fireEvent.click(retryButton);
     expect(props.onSave).toHaveBeenCalledOnce();
   });
 

--- a/src/components/LayoutEditor.tsx
+++ b/src/components/LayoutEditor.tsx
@@ -1,12 +1,14 @@
 import React, { useState } from 'react';
 import type { PlacedFurniture } from '../../shared/types';
-import type { LayoutDoc } from '../hooks/useLayoutStore';
+import type { LayoutDoc, SaveStatus } from '../hooks/useLayoutStore';
 import './LayoutEditor.css';
 
 interface Props {
   catalog: string[];
   activeLayout: LayoutDoc | null;
   isDirty: boolean;
+  /** Save lifecycle feedback from useLayoutStore (optional for tests). */
+  saveStatus?: SaveStatus;
   layouts: LayoutDoc[];
   editorMode: boolean;
   selectedFurnitureType: string | null;
@@ -107,6 +109,7 @@ export const LayoutEditor: React.FC<Props> = ({
   catalog,
   activeLayout,
   isDirty,
+  saveStatus = 'idle',
   layouts,
   editorMode,
   selectedFurnitureType,
@@ -130,6 +133,26 @@ export const LayoutEditor: React.FC<Props> = ({
   if (!editorMode) return null;
 
   const selectedFurniture = activeLayout?.furniture.find(f => f.id === selectedFurnitureId);
+
+  // Save button doubles as the save-status indicator (aria-live region).
+  const saveLabel =
+    saveStatus === 'saving' ? '💾 Saving…'
+    : saveStatus === 'saved' ? '✓ Saved'
+    : saveStatus === 'error' ? '⚠ Retry save'
+    : isDirty ? '💾 Save ●'
+    : '💾 Save';
+  const saveTitle =
+    saveStatus === 'saving' ? 'Saving layout…'
+    : saveStatus === 'saved' ? 'Layout saved'
+    : saveStatus === 'error' ? 'Couldn\'t save — the app retries automatically; click to retry now'
+    : isDirty ? 'Save layout (unsaved changes)'
+    : 'Save layout (no unsaved changes)';
+  const saveDisabled = saveStatus === 'saving' || (!isDirty && saveStatus !== 'error');
+  const saveClass =
+    saveStatus === 'saved' ? 'saved'
+    : saveStatus === 'error' ? 'error'
+    : isDirty ? 'dirty'
+    : '';
 
   return (
     <div className="layout-editor">
@@ -158,9 +181,16 @@ export const LayoutEditor: React.FC<Props> = ({
           📐 Layouts
         </button>
         <div className="toolbar-separator" />
-        <button className={`toolbar-btn save-btn ${isDirty ? 'dirty' : ''}`} onClick={onSave} title={isDirty ? 'Save layout (unsaved changes)' : 'Save layout'}>
-          {isDirty ? '💾 Save ●' : '💾 Save'}
-        </button>
+        <span role="status" aria-live="polite" className="save-status-region">
+          <button
+            className={`toolbar-btn save-btn ${saveClass}`}
+            onClick={onSave}
+            disabled={saveDisabled}
+            title={saveTitle}
+          >
+            {saveLabel}
+          </button>
+        </span>
         <button className="toolbar-btn" onClick={onToggleEditor} title="Exit editor">
           ✖ Close
         </button>

--- a/src/components/MessageTicker.css
+++ b/src/components/MessageTicker.css
@@ -1,12 +1,13 @@
 /* ── Message Ticker - HUD Marquee ──────────────────── */
 
 .ticker-container {
-  position: absolute;
-  bottom: 24px;
-  left: 50%;
-  transform: translateX(-50%);
-  width: 80%;
-  max-width: 800px;
+  position: fixed;
+  bottom: 12px;
+  left: 16px;
+  right: calc(var(--desktop-agent-sidebar-reserved-width) + 16px);
+  width: auto;
+  max-width: 760px;
+  margin: 0 auto;
   height: 40px;
   background: var(--bg-panel);
   backdrop-filter: var(--glass-blur);
@@ -20,7 +21,7 @@
   font-family: var(--font-pixel);
   font-size: 11px;
   color: var(--text-main);
-  z-index: 100;
+  z-index: var(--z-ticker);
 }
 
 .ticker-label {
@@ -99,10 +100,20 @@
   100% { transform: translateX(var(--ticker-width, -2000px)); }
 }
 
+@media (max-width: 1024px) {
+  .ticker-container {
+    /* Sidebar is a drawer below this width — reclaim its reserved strip. */
+    right: 16px;
+  }
+}
+
 @media (max-width: 768px) {
   .ticker-container {
-    width: calc(100% - 32px);
-    bottom: 16px;
+    left: 8px;
+    right: 8px;
+    bottom: 8px;
+    max-width: none;
+    height: 36px;
   }
 }
 

--- a/src/components/RoomSwitcher.css
+++ b/src/components/RoomSwitcher.css
@@ -1,9 +1,14 @@
+/* Room switcher lives inside the fixed top bar (App.css .app-header),
+ * composed in flex flow: it centers in the leftover space and scrolls
+ * internally when tabs overflow — it can never collide with the brand or
+ * the header controls. */
 .room-switcher {
-  position: absolute;
-  top: 16px;
-  left: 50%;
-  transform: translateX(-50%);
-  z-index: 100;
+  position: static;
+  transform: none;
+  flex: 1 1 auto;
+  min-width: 0;
+  max-width: fit-content;
+  margin: 0 auto;
 
   display: flex;
   gap: 4px;
@@ -73,10 +78,12 @@
 }
 
 @media (max-width: 768px) {
+  /* Second row of the wrapped top bar: full-width scrollable tab strip. */
   .room-switcher {
-    top: var(--mobile-room-switcher-top);
-    height: var(--mobile-room-switcher-height);
-    /* below the mobile header which is ~48px tall */
+    order: 3;
+    flex: 1 1 100%;
+    max-width: none;
+    margin: 0;
     padding: 4px 8px;
     gap: 3px;
   }

--- a/src/components/SoundControls.tsx
+++ b/src/components/SoundControls.tsx
@@ -46,6 +46,8 @@ export const SoundControls: React.FC = () => {
         className="sound-toggle"
         onClick={toggleMute}
         title={muted ? 'Unmute' : 'Mute'}
+        aria-label={muted ? 'Unmute sounds' : 'Mute sounds'}
+        aria-pressed={muted}
       >
         {muted ? '🔇' : volume > 0.6 ? '🔊' : volume > 0.2 ? '🔉' : '🔈'}
       </button>
@@ -54,6 +56,8 @@ export const SoundControls: React.FC = () => {
         className="sound-expand"
         onClick={() => setExpanded(!expanded)}
         title="Sound settings"
+        aria-label="Sound settings"
+        aria-expanded={expanded}
       >
         ⚙️
       </button>
@@ -76,6 +80,7 @@ export const SoundControls: React.FC = () => {
           <button
             className={`sound-ambience ${ambience ? 'on' : ''}`}
             onClick={toggleAmbience}
+            aria-pressed={ambience}
           >
             {ambience ? '🌐 Ambience ON' : '🌐 Ambience OFF'}
           </button>

--- a/src/hooks/useLayoutStore.ts
+++ b/src/hooks/useLayoutStore.ts
@@ -13,6 +13,8 @@ export interface LayoutDoc {
   updatedAt: number;
 }
 
+export type SaveStatus = 'idle' | 'saving' | 'saved' | 'error';
+
 type PersistedRevision = { id: string; updatedAt: number };
 
 function isLayoutDoc(value: unknown): value is LayoutDoc {
@@ -93,6 +95,10 @@ export function useLayoutStore() {
   // --- Auto-save state ---
   // isDirty: true when furniture has been changed but not yet persisted.
   const [isDirty, setIsDirty] = useState(false);
+  // saveStatus: user-visible save lifecycle feedback. Purely additive —
+  // nothing in the persistence protocol reads it.
+  const [saveStatus, setSaveStatus] = useState<SaveStatus>('idle');
+  const saveStatusTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   // skipAutoSaveRef: set to true before programmatic layout changes (load,
   // create, save-response) so the auto-save effect doesn't fire on them.
   // The auto-save effect resets it to false after skipping.
@@ -112,6 +118,22 @@ export function useLayoutStore() {
       autoSaveTimerRef.current = null;
       retry();
     }, delay);
+  }, []);
+
+  // 'saved' auto-clears back to 'idle' so the button returns to its neutral
+  // state; 'saving' and 'error' persist until the next save attempt resolves.
+  const markSaveStatus = useCallback((status: SaveStatus) => {
+    if (saveStatusTimerRef.current) {
+      clearTimeout(saveStatusTimerRef.current);
+      saveStatusTimerRef.current = null;
+    }
+    setSaveStatus(status);
+    if (status === 'saved') {
+      saveStatusTimerRef.current = setTimeout(() => {
+        saveStatusTimerRef.current = null;
+        setSaveStatus('idle');
+      }, 2500);
+    }
   }, []);
 
   const advancePersistedRevision = useCallback((id: string, updatedAt: number) => {
@@ -207,6 +229,7 @@ export function useLayoutStore() {
       // the ref sync.
       const currentLayout = activeLayoutRef.current;
       if (!currentLayout) return;
+      markSaveStatus('saving');
       const editVersionAtSaveStart = furnitureEditVersionRef.current;
       const persistedRevision = persistedRevisionRef.current;
       const baseUpdatedAt = pickBaseUpdatedAt(currentLayout, persistedRevision);
@@ -230,6 +253,7 @@ export function useLayoutStore() {
           } else if (response.status >= 500) {
             scheduleSaveRetry(() => { void saveActiveLayout(); });
           }
+          markSaveStatus('error');
           return;
         }
         const data = await response.json().catch(() => null);
@@ -243,10 +267,12 @@ export function useLayoutStore() {
           if (activeLayoutRef.current?.id === merged.id) {
             scheduleSaveRetry(() => { void saveActiveLayout(); });
           }
+          markSaveStatus('error');
           return;
         }
         // Success — reset retry counter and advance the revision monotonically.
         retryAttemptRef.current = 0;
+        markSaveStatus('saved');
         const currentRevision = persistedRevisionRef.current;
         const responseIsCurrent = currentRevision?.id !== savedLayout.id
           || savedLayout.updatedAt >= currentRevision.updatedAt;
@@ -266,6 +292,7 @@ export function useLayoutStore() {
       } catch (err: any) {
         console.error('Failed to save layout:', err);
         // Network error — retry with backoff
+        markSaveStatus('error');
         scheduleSaveRetry(() => { void saveActiveLayout(); });
       }
     });
@@ -273,6 +300,7 @@ export function useLayoutStore() {
   }, [
     advancePersistedRevision,
     fetchLayouts,
+    markSaveStatus,
     refreshPersistedRevision,
     scheduleSaveRetry,
     setActiveLayoutProgrammatic,
@@ -460,6 +488,7 @@ export function useLayoutStore() {
     layouts,
     activeLayout,
     isDirty,
+    saveStatus,
     catalog,
     loadLayoutById,
     saveActiveLayout,


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
## Analysis

This PR replaces a brittle absolute-positioned chrome with a cohesive responsive layout system driven by a single fixed top bar and tokenized z-index scale. Beyond the existing summary, the diff reveals several functional nuances worth highlighting.

### Layout architecture

The previous `App.css` exposed three `--mobile-*` geometry variables (`--mobile-room-switcher-top`, `--mobile-room-switcher-height`, `--mobile-editor-toolbar-gap`) that the editor toolbar summed together to clear the room switcher — a workaround for two absolutely positioned islands. The new system collapses all of those into a single `--topbar-h` variable that the editor toolbar offsets from directly (`calc(var(--topbar-h) + 12px)`). The mobile breakpoint now grows `--topbar-h` to 104px (vs. 64px desktop) to accommodate the two-row wrap, which the layout-editor test pins explicitly. This makes it impossible for the toolbar to collide with the bar regardless of how many controls the bar contains.

The room switcher is no longer a sibling overlay at all — it is a flex child of `.app-header` (`flex: 1 1 auto`, `min-width: 0`, `margin: 0 auto`) that centers in leftover space. On mobile it drops to `order: 3; flex: 1 1 100%`, becoming the second row of the wrapped bar. The RoomSwitcher test now asserts `position: static` on the base rule, pinning the architectural choice itself.

### Drawer / sidebar logic

The sidebar's `position: absolute` (anchored `top: 16px; right: 16px; bottom: 80px`) is replaced with `position: fixed; top: calc(var(--topbar-h) + 8px)` for desktop. Below 1024px it becomes a true off-canvas drawer: `transform: translateX(105%)` (closed) → `translateX(0)` (open), with a `prefers-reduced-motion` guard that disables the slide transition entirely. A `.sidebar-close-btn` is `display: none` by default and shown only inside the drawer media query. The backdrop click-to-dismiss and `Escape` keyboard handler are implemented in `App.tsx`.

The editor's right-side reservation of `--desktop-agent-sidebar-reserved-width` is now scoped inside `@media (min-width: 1025px)`, which guarantees that on tablet the editor uses full stage width — the drawer is off-canvas rather than occupying the band.

### Save-lifecycle protocol

`useLayoutStore` gains `SaveStatus = 'idle' | 'saving' | 'saved' | 'error'` as a purely additive surface — `isDirty`, the `baseUpdatedAt` optimistic-concurrency check, 409 retry, serialization, and 2s debounce remain untouched. `markSaveStatus`:
- Sets `saving` immediately at the start of `saveActiveLayout`,
- Sets `error` on any non-2xx, 409, or thrown network error (alongside the existing `scheduleSaveRetry`),
- Sets `saved` on success (auto-clears to `idle` after 2.5s via a ref-tracked timer),
- Cancels any pending auto-clear timer on subsequent state changes.

### Save button UX

The button now derives its label/class/title/disabled state from the combination of `saveStatus` × `isDirty`:

| state | label | class | disabled |
|---|---|---|---|
| idle + clean | 💾 Save | — | **yes** (new — no more no-op PUTs) |
| idle + dirty | 💾 Save ● | `dirty` (pulse) | no |
| saving | 💾 Saving… | — | yes |
| saved | ✓ Saved | `saved` (green) | yes |
| error | ⚠ Retry save | `error` (pink) | **no** (immediate retry possible) |

The button is wrapped in `<span role="status" aria-live="polite">` so the lifecycle change is announced without stealing focus.

### Accessibility additions

- All icon-only buttons received `aria-label`s: per-agent hide/show, edit-tags, customize-appearance, add-tags (in `AgentSidebar`), and mute/sound-settings (in `SoundControls`).
- Stateful toggles now expose `aria-pressed` (mute, ambience, per-agent toggle) or `aria-expanded` (drawer toggle, sound settings).
- The sidebar `<aside>` has `aria-label="Agents"`.
- A global `:focus-visible` rule (2px cyan outline, 2px offset) covers `button`, `input`, and `[tabindex]`, restoring keyboard navigation visibility lost in the old chrome.

### Tests

`LayoutEditor.mobile.test.tsx` is rewritten as a general "no chrome collisions" regression rather than the original narrow issue #87 pin:
- Asserts `--topbar-h: 64px` (desktop) / `104px` (mobile) on `:root`,
- Asserts `.room-switcher { position: static }` in the base rule (catches any reversion to absolute),
- Asserts the toolbar's `margin-top` is `calc(var(--topbar-h) + 12px)` exactly,
- New tests pin the disabled-when-clean behavior and the full `saving`/`saved`/`error` label transitions (retry button stays enabled on error).

### Subtle behavior changes worth flagging

1. **No more no-op saves**: the save button is `disabled` when clean, so users can no longer fire an empty PUT. Previously `onSave` was always callable.
2. **Retry semantics**: clicking the error-state button now invokes `onSave` synchronously rather than waiting for the backoff timer.
3. **Ticker geometry**: the message ticker went from `width: 80%; max-width: 800px` to a fixed positioning scheme that reserves the sidebar band on desktop only (`right: calc(var(--desktop-agent-sidebar-reserved-width) + 16px)`), reclaiming full width at ≤1024px and ≤768px.
4. **Demo data and canvas contracts are untouched** as stated, but the `LayoutEditor` props API changed: `saveStatus` is now a required prop type (optional in practice, defaulting to `'idle'` for test renders).

---

# feat(ui): replace absolute-island chrome with a responsive layout system

## Summary

Replaces the previous absolute-positioned UI chrome with a cohesive responsive layout system that adapts to viewport size and fixes several accessibility issues.

## Key Changes

### Drawer Accessibility Fix
- **Closed drawer now removes itself from tab order and the accessibility tree** using `visibility: hidden` (in addition to the existing `transform`), not just from the viewport. This fixes the off-canvas accessibility defect where off-screen controls remained tabbable.
- The visibility transition is delayed so the slide-out animation completes before the panel becomes invisible.
- `prefers-reduced-motion` correctly preserves the visibility behavior while removing transform animation.

### Layout Restructuring
- **`AgentSidebar` and the sidebar backdrop are now direct children of `.app`** instead of nested inside `.app-main`. This avoids the z-index stacking cap (10) imposed by `.app-main`, which previously kept the drawer below the ticker (z-index 150) and top bar (z-index 300). Since they use `position: fixed`, their geometry is unchanged.
- Added a **dynamic top-bar height system** via `ResizeObserver` that writes the measured header height into the `--topbar-h` CSS variable. This replaces the fixed-per-breakpoint guess with the actual rendered height, ensuring the editor toolbar, sidebar, and drawer offset correctly regardless of how many rows the top bar wraps to.

### Drawer Lifecycle
- **Auto-closes the drawer when the viewport crosses above 1024px** via a `matchMedia` listener. Without this, a stale open state would leave the backdrop obscuring the desktop layout.

### Mobile Polish
- **Small phones (≤480px) show an icon-only top bar** — brand text and connection status text are hidden via CSS, with accessible names preserved on `aria-label`s so screen readers still announce them.

### Tests
- Added `AgentSidebar.drawer.test.tsx` covering:
  - CSS contract: closed drawer is `visibility: hidden`, open is `visibility: visible`
  - Behavior: `open` prop toggles the `.open` class, close button invokes `onClose`
  - A11y: the `<aside>` is labeled "Agents" and each icon-only control has a descriptive accessible name

### Misc
- Wrapped the brand emoji and text in spans so the icon-only breakpoint can hide text without affecting the decorative emoji.
- The connection status now keeps its text inside a `.status-text` span, with `aria-label` providing the full status to assistive tech on small screens.

---

**Fix: Ensure reduced-motion users don't see the sidebar slide animation**

This PR fixes an accessibility issue where the `AgentSidebar` slide animation would still play for users with `prefers-reduced-motion: reduce`, due to CSS specificity.

**Changes:**

1. **`AgentSidebar.css`** — Updated the reduced-motion media query to explicitly include the `.agent-sidebar.open` selector alongside the base `.agent-sidebar` selector. The `.open` modifier has higher specificity (0,2,0) which was overriding the previous reduced-motion rule, causing the 0.25s slide animation to still play for reduced-motion users.

2. **`AgentSidebar.drawer.test.tsx`** — Two related updates:
   - Added a new test case verifying that the reduced-motion override applies to both `.agent-sidebar` and `.agent-sidebar.open` selectors, preventing regression of this bug.
   - Updated the `getRuleDeclarations` helper to handle comma-separated selectors (e.g., `.agent-sidebar, .agent-sidebar.open`), so tests can find individual selectors within grouped rules.
<!-- kody-pr-summary:end -->