### PR TITLE
fix(editor): confirm custom layout deletion before permanent removal

### DIFF
--- a/src/components/LayoutEditor.css
+++ b/src/components/LayoutEditor.css
@@ -291,6 +291,7 @@
   border: var(--border-glass);
   box-shadow: var(--shadow-neon-cyan);
   border-radius: 8px;
+  box-sizing: border-box; /* keep padding+border inside the width cap on narrow viewports (P3) */
   padding: 24px;
   width: min(340px, calc(100vw - 32px));
   text-align: center;
@@ -309,6 +310,12 @@
   color: var(--text-muted);
   margin: 0 0 16px;
   line-height: 1.4;
+}
+.confirm-error {
+  font-family: var(--font-body);
+  font-size: 12px;
+  color: var(--acc-pink);
+  margin: 0 0 12px;
 }
 .confirm-actions {
   display: flex;

--- a/src/components/LayoutEditor.css
+++ b/src/components/LayoutEditor.css
@@ -294,6 +294,8 @@
   box-sizing: border-box; /* keep padding+border inside the width cap on narrow viewports (P3) */
   padding: 24px;
   width: min(340px, calc(100vw - 32px));
+  max-height: calc(100vh - 32px); /* keep the dialog on-screen in short landscape viewports (Sophie review) */
+  overflow-y: auto;
   text-align: center;
 }
 .confirm-message {
@@ -330,6 +332,20 @@
   cursor: pointer;
   border: 1px solid rgba(255,255,255,0.2);
   transition: all 0.15s;
+}
+/* Visible disabled treatment: drop the pointer/hover affordances while a
+   delete is in flight so "Deleting…" reads as non-interactive (Sophie review). */
+.confirm-actions button:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+.confirm-cancel:disabled:hover {
+  background: rgba(0,0,0,0.3);
+  border-color: rgba(255,255,255,0.2);
+}
+.confirm-delete:disabled:hover {
+  background: rgba(255, 0, 85, 0.15);
+  border-color: var(--acc-pink);
 }
 .confirm-cancel {
   background: rgba(0,0,0,0.3);

--- a/src/components/LayoutEditor.css
+++ b/src/components/LayoutEditor.css
@@ -272,6 +272,66 @@
 }
 .layout-create button:hover { background: rgba(0, 240, 255, 0.3); }
 
+/* Delete confirmation dialog — Fail-Safe guard (issue #109) */
+.confirm-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 9999;
+}
+.confirm-dialog {
+  background: var(--bg-panel);
+  backdrop-filter: var(--glass-blur);
+  -webkit-backdrop-filter: var(--glass-blur);
+  border: var(--border-glass);
+  box-shadow: var(--shadow-neon-cyan);
+  border-radius: 8px;
+  padding: 24px;
+  max-width: 340px;
+  text-align: center;
+}
+.confirm-message {
+  font-family: var(--font-body);
+  font-size: 14px;
+  color: var(--text-main);
+  margin: 0 0 16px;
+  line-height: 1.5;
+}
+.confirm-message strong { color: var(--acc-pink); }
+.confirm-actions {
+  display: flex;
+  gap: 12px;
+  justify-content: center;
+}
+.confirm-actions button {
+  padding: 8px 20px;
+  border-radius: 4px;
+  font-family: var(--font-body);
+  font-size: 13px;
+  cursor: pointer;
+  border: 1px solid rgba(255,255,255,0.2);
+  transition: all 0.15s;
+}
+.confirm-cancel {
+  background: rgba(0,0,0,0.3);
+  color: var(--text-main);
+}
+.confirm-cancel:hover {
+  background: rgba(0, 240, 255, 0.1);
+  border-color: var(--acc-cyan);
+}
+.confirm-delete {
+  background: rgba(255, 0, 85, 0.15);
+  color: var(--acc-pink);
+  border-color: var(--acc-pink);
+}
+.confirm-delete:hover {
+  background: rgba(255, 0, 85, 0.3);
+}
+
 /* Scrollbars */
 .furniture-palette::-webkit-scrollbar, .layout-list::-webkit-scrollbar { width: 4px; }
 .furniture-palette::-webkit-scrollbar-track, .layout-list::-webkit-scrollbar-track { background: transparent; }

--- a/src/components/LayoutEditor.css
+++ b/src/components/LayoutEditor.css
@@ -272,7 +272,9 @@
 }
 .layout-create button:hover { background: rgba(0, 240, 255, 0.3); }
 
-/* Delete confirmation dialog — Fail-Safe guard (issue #109) */
+/* Delete confirmation dialog — Confirmation Barrier / Guard Pattern (issue #109).
+   Portaled to document.body so it escapes the .app-main stacking context and
+   can use the --z-modal token to sit above all app chrome (P2 fix). */
 .confirm-overlay {
   position: fixed;
   inset: 0;
@@ -280,7 +282,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  z-index: 9999;
+  z-index: var(--z-modal);
 }
 .confirm-dialog {
   background: var(--bg-panel);
@@ -290,17 +292,24 @@
   box-shadow: var(--shadow-neon-cyan);
   border-radius: 8px;
   padding: 24px;
-  max-width: 340px;
+  width: min(340px, calc(100vw - 32px));
   text-align: center;
 }
 .confirm-message {
   font-family: var(--font-body);
   font-size: 14px;
   color: var(--text-main);
-  margin: 0 0 16px;
+  margin: 0 0 8px;
   line-height: 1.5;
 }
-.confirm-message strong { color: var(--acc-pink); }
+.confirm-message strong { color: var(--acc-pink); overflow-wrap: anywhere; }
+.confirm-description {
+  font-family: var(--font-body);
+  font-size: 12px;
+  color: var(--text-muted);
+  margin: 0 0 16px;
+  line-height: 1.4;
+}
 .confirm-actions {
   display: flex;
   gap: 12px;

--- a/src/components/LayoutEditor.delete.test.tsx
+++ b/src/components/LayoutEditor.delete.test.tsx
@@ -1,0 +1,191 @@
+/**
+ * Issue #109 — Delete confirmation guard for custom layouts.
+ *
+ * Semantic anchors: Fail-Safe / Guard Pattern, Defense in Depth.
+ * The component owns the user-facing confirmation barrier; the store and
+ * server remain raw delete primitives. These tests pin the barrier so it
+ * cannot be silently removed.
+ *
+ * Test cases (mapped from issue #109):
+ *   1. Clicking Delete opens confirmation containing the layout name.
+ *   2. Cancel retains the row and never calls onDeleteLayout.
+ *   3. Confirm calls onDeleteLayout exactly once with the correct id.
+ *   4. Default layout exposes no delete control.
+ *   5. Store deletion tests use an explicit DELETE mock branch.
+ */
+
+import React from 'react';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { LayoutEditor } from './LayoutEditor';
+import type { LayoutDoc } from '../hooks/useLayoutStore';
+
+const defaultLayout: LayoutDoc = {
+  id: 'default',
+  name: 'Default',
+  width: 24,
+  height: 16,
+  furniture: [],
+  seats: {},
+  updatedAt: 1,
+};
+
+const customLayout: LayoutDoc = {
+  id: 'qa-layout',
+  name: 'QA Layout',
+  width: 24,
+  height: 16,
+  furniture: [
+    { id: 'f1', type: 'DESK', x: 3, y: 4, rotation: 0 },
+  ],
+  seats: { cybera: { x: 3, y: 5 } },
+  updatedAt: 1721900000000,
+};
+
+function makeProps(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    catalog: ['DESK'],
+    activeLayout: defaultLayout,
+    isDirty: false,
+    layouts: [defaultLayout, customLayout],
+    editorMode: true,
+    selectedFurnitureType: null,
+    selectedFurnitureId: null,
+    deleteMode: false,
+    onSelectFurnitureType: vi.fn(),
+    onSelectFurnitureId: vi.fn(),
+    onPlaceFurniture: vi.fn(),
+    onMoveFurniture: vi.fn(),
+    onRotateFurniture: vi.fn(),
+    onDeleteFurniture: vi.fn(),
+    onToggleDeleteMode: vi.fn(),
+    onSave: vi.fn(),
+    onLoad: vi.fn(),
+    onCreate: vi.fn(),
+    onDeleteLayout: vi.fn(),
+    onToggleEditor: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe('Issue #109 — delete confirmation guard', () => {
+  afterEach(cleanup);
+
+  // ── Test 1: Clicking Delete opens confirmation ─────────────────────
+
+  it('opens a confirmation dialog containing the layout name when Delete is clicked', () => {
+    render(<LayoutEditor {...makeProps()} />);
+
+    // Open the layout manager
+    fireEvent.click(screen.getByTitle('Layout manager'));
+
+    // Click the delete button for the custom layout
+    const deleteBtn = screen.getByLabelText('Delete QA Layout');
+    fireEvent.click(deleteBtn);
+
+    // Confirmation dialog must be visible and contain the layout name
+    const dialog = screen.getByRole('alertdialog');
+    expect(dialog.textContent).toContain('QA Layout');
+    expect(dialog.textContent).toContain('cannot be undone');
+  });
+
+  // ── Test 2: Cancel retains the row and never calls onDeleteLayout ──
+
+  it('does not call onDeleteLayout and keeps the layout row when Cancel is clicked', () => {
+    const props = makeProps();
+    render(<LayoutEditor {...props} />);
+
+    fireEvent.click(screen.getByTitle('Layout manager'));
+    fireEvent.click(screen.getByLabelText('Delete QA Layout'));
+
+    // Cancel
+    fireEvent.click(screen.getByText('Cancel'));
+
+    // Store delete was never called
+    expect(props.onDeleteLayout).not.toHaveBeenCalled();
+
+    // Layout row is still present
+    expect(screen.getByText('QA Layout')).toBeTruthy();
+  });
+
+  // ── Test 3: Confirm calls onDeleteLayout exactly once ───────────────
+
+  it('calls onDeleteLayout exactly once with the correct id when Delete is confirmed', () => {
+    const props = makeProps();
+    render(<LayoutEditor {...props} />);
+
+    fireEvent.click(screen.getByTitle('Layout manager'));
+    fireEvent.click(screen.getByLabelText('Delete QA Layout'));
+
+    // Confirm deletion
+    // The confirm button is the one labeled "Delete" inside the dialog
+    const dialog = screen.getByRole('alertdialog');
+    const confirmBtn = dialog.querySelector('button.confirm-delete')!;
+    fireEvent.click(confirmBtn);
+
+    expect(props.onDeleteLayout).toHaveBeenCalledExactlyOnceWith('qa-layout');
+  });
+
+  // ── Test 4: Default layout exposes no delete control ────────────────
+
+  it('does not render a delete button for the default layout', () => {
+    render(<LayoutEditor {...makeProps()} />);
+
+    fireEvent.click(screen.getByTitle('Layout manager'));
+
+    // No accessible label for deleting the Default layout
+    expect(screen.queryByLabelText('Delete Default')).toBeNull();
+  });
+
+  // ── Test 5: Store deletion uses an explicit DELETE mock branch ──────
+  // This test lives alongside the useLayoutStore tests, but we verify here
+  // that the component correctly wires the store's delete through the guard
+  // by asserting the id passed matches what the store would send to DELETE.
+
+  it('passes the layout id that the store would use for the DELETE request', () => {
+    const props = makeProps();
+    render(<LayoutEditor {...props} />);
+
+    fireEvent.click(screen.getByTitle('Layout manager'));
+    fireEvent.click(screen.getByLabelText('Delete QA Layout'));
+
+    const dialog = screen.getByRole('alertdialog');
+    const confirmBtn = dialog.querySelector('button.confirm-delete')!;
+    fireEvent.click(confirmBtn);
+
+    // The id passed to onDeleteLayout is the same id the store uses to
+    // build the DELETE /api/layouts/:id route — verified by the store's
+    // own integration tests with an explicit DELETE mock branch.
+    expect(props.onDeleteLayout).toHaveBeenCalledWith('qa-layout');
+  });
+
+  // ── Regression: confirmation dialog closes after confirm ───────────
+
+  it('closes the confirmation dialog after confirmation', () => {
+    render(<LayoutEditor {...makeProps()} />);
+
+    fireEvent.click(screen.getByTitle('Layout manager'));
+    fireEvent.click(screen.getByLabelText('Delete QA Layout'));
+
+    const dialog = screen.getByRole('alertdialog');
+    const confirmBtn = dialog.querySelector('button.confirm-delete')!;
+    fireEvent.click(confirmBtn);
+
+    // Dialog should be gone
+    expect(screen.queryByRole('alertdialog')).toBeNull();
+  });
+
+  // ── Regression: confirmation dialog closes after cancel ────────────
+
+  it('closes the confirmation dialog after cancel', () => {
+    render(<LayoutEditor {...makeProps()} />);
+
+    fireEvent.click(screen.getByTitle('Layout manager'));
+    fireEvent.click(screen.getByLabelText('Delete QA Layout'));
+
+    fireEvent.click(screen.getByText('Cancel'));
+
+    expect(screen.queryByRole('alertdialog')).toBeNull();
+  });
+});

--- a/src/components/LayoutEditor.delete.test.tsx
+++ b/src/components/LayoutEditor.delete.test.tsx
@@ -75,7 +75,9 @@ function makeProps(overrides: Partial<Record<string, unknown>> = {}) {
     onSave: vi.fn(),
     onLoad: vi.fn(),
     onCreate: vi.fn(),
-    onDeleteLayout: vi.fn(),
+    // Strict-boolean result contract (Sophie review @78f2bc3): the barrier
+    // closes only on a literal `true`, so the default mock must resolve true.
+    onDeleteLayout: vi.fn().mockResolvedValue(true),
     onToggleEditor: vi.fn(),
     ...overrides,
   };
@@ -244,10 +246,12 @@ describe('Issue #109 — delete confirmation guard', () => {
     function Harness() {
       const [layouts, setLayouts] = useState([defaultLayout, customLayout]);
       const [active, setActive] = useState<LayoutDoc | null>(defaultLayout);
-      const handleDelete = (id: string) => {
+      const handleDelete = (id: string): boolean => {
         // Mirrors fetchLayouts() dropping the deleted layout from state.
         setLayouts(prev => prev.filter(l => l.id !== id));
         setActive(prev => (prev?.id === id ? null : prev));
+        // Strict-boolean contract: report success so the barrier closes.
+        return true;
       };
       return (
         <LayoutEditor
@@ -350,6 +354,33 @@ describe('Issue #109 — delete confirmation guard', () => {
     resolveDelete(true);
     await waitFor(() => expect(screen.queryByRole('alertdialog')).toBeNull());
     expect(document.activeElement).toBe(screen.getByTitle('Layout manager'));
+    expect(document.activeElement).not.toBe(document.body);
+  });
+
+  // ── Test 12d: Focus is anchored inside the dialog the instant a delete
+  //    goes in flight — before any Tab key (P2, Sophie review @78f2bc3) ──
+  //
+  // Real Chromium moves focus to <body> when the focused Delete button is
+  // disabled, with no focusin for the guard to catch; jsdom does not reproduce
+  // that blur, which is how the defect hid behind a green suite. This pins the
+  // POSITIVE invariant the useLayoutEffect fix guarantees: the moment
+  // `deleting` commits, focus lands on the always-focusable overlay inside the
+  // alertdialog — no Tab press required.
+
+  it('anchors focus to the overlay immediately after an in-flight delete begins (no Tab)', () => {
+    const onDeleteLayout = vi.fn().mockReturnValue(new Promise<boolean>(() => {}));
+    const props = makeProps({ onDeleteLayout });
+    openDeleteDialog(props);
+
+    const dialog = screen.getByRole('alertdialog');
+    fireEvent.click(dialog.querySelector('button.confirm-delete')!);
+
+    // In flight: the Delete control is disabled, yet focus is already inside
+    // the alertdialog (on the focusable overlay) — never on <body>, and no Tab
+    // key was pressed to get it there.
+    expect((dialog.querySelector('.confirm-delete') as HTMLButtonElement).disabled).toBe(true);
+    expect(document.activeElement).toBe(dialog);
+    expect(dialog.contains(document.activeElement)).toBe(true);
     expect(document.activeElement).not.toBe(document.body);
   });
 

--- a/src/components/LayoutEditor.delete.test.tsx
+++ b/src/components/LayoutEditor.delete.test.tsx
@@ -1,17 +1,22 @@
 /**
  * Issue #109 — Delete confirmation guard for custom layouts.
  *
- * Semantic anchors: Fail-Safe / Guard Pattern, Defense in Depth.
- * The component owns the user-facing confirmation barrier; the store and
- * server remain raw delete primitives. These tests pin the barrier so it
- * cannot be silently removed.
+ * Semantic anchors: Confirmation Barrier / Guard Pattern with a safe default.
+ * The component owns the sole user-facing confirmation barrier; the store and
+ * server remain raw delete primitives (one independent guard, not Defense in
+ * Depth). These tests pin the barrier so it cannot be silently removed.
  *
- * Test cases (mapped from issue #109):
+ * Test cases (mapped from issue #109 + Sophie's consolidated PR #122 review):
  *   1. Clicking Delete opens confirmation containing the layout name.
  *   2. Cancel retains the row and never calls onDeleteLayout.
  *   3. Confirm calls onDeleteLayout exactly once with the correct id.
  *   4. Default layout exposes no delete control.
  *   5. Store deletion tests use an explicit DELETE mock branch.
+ *   6. Dialog is portaled to document.body (escapes .app-main stacking context).
+ *   7. Escape closes the dialog without deleting.
+ *   8. Dialog has accessible name and description (aria-labelledby/describedby).
+ *   9. Focus is contained within the dialog (Tab trap).
+ *  10. Focus is restored to the invoking element on close.
  */
 
 import React from 'react';
@@ -69,22 +74,23 @@ function makeProps(overrides: Partial<Record<string, unknown>> = {}) {
   };
 }
 
+/** Helper: open layout manager and click the delete button for QA Layout. */
+function openDeleteDialog(props: ReturnType<typeof makeProps>) {
+  render(<LayoutEditor {...props} />);
+  fireEvent.click(screen.getByTitle('Layout manager'));
+  const deleteBtn = screen.getByLabelText('Delete QA Layout');
+  fireEvent.click(deleteBtn);
+  return deleteBtn;
+}
+
 describe('Issue #109 — delete confirmation guard', () => {
   afterEach(cleanup);
 
   // ── Test 1: Clicking Delete opens confirmation ─────────────────────
 
   it('opens a confirmation dialog containing the layout name when Delete is clicked', () => {
-    render(<LayoutEditor {...makeProps()} />);
+    openDeleteDialog(makeProps());
 
-    // Open the layout manager
-    fireEvent.click(screen.getByTitle('Layout manager'));
-
-    // Click the delete button for the custom layout
-    const deleteBtn = screen.getByLabelText('Delete QA Layout');
-    fireEvent.click(deleteBtn);
-
-    // Confirmation dialog must be visible and contain the layout name
     const dialog = screen.getByRole('alertdialog');
     expect(dialog.textContent).toContain('QA Layout');
     expect(dialog.textContent).toContain('cannot be undone');
@@ -94,18 +100,11 @@ describe('Issue #109 — delete confirmation guard', () => {
 
   it('does not call onDeleteLayout and keeps the layout row when Cancel is clicked', () => {
     const props = makeProps();
-    render(<LayoutEditor {...props} />);
+    openDeleteDialog(props);
 
-    fireEvent.click(screen.getByTitle('Layout manager'));
-    fireEvent.click(screen.getByLabelText('Delete QA Layout'));
-
-    // Cancel
     fireEvent.click(screen.getByText('Cancel'));
 
-    // Store delete was never called
     expect(props.onDeleteLayout).not.toHaveBeenCalled();
-
-    // Layout row is still present
     expect(screen.getByText('QA Layout')).toBeTruthy();
   });
 
@@ -113,13 +112,8 @@ describe('Issue #109 — delete confirmation guard', () => {
 
   it('calls onDeleteLayout exactly once with the correct id when Delete is confirmed', () => {
     const props = makeProps();
-    render(<LayoutEditor {...props} />);
+    openDeleteDialog(props);
 
-    fireEvent.click(screen.getByTitle('Layout manager'));
-    fireEvent.click(screen.getByLabelText('Delete QA Layout'));
-
-    // Confirm deletion
-    // The confirm button is the one labeled "Delete" inside the dialog
     const dialog = screen.getByRole('alertdialog');
     const confirmBtn = dialog.querySelector('button.confirm-delete')!;
     fireEvent.click(confirmBtn);
@@ -131,58 +125,117 @@ describe('Issue #109 — delete confirmation guard', () => {
 
   it('does not render a delete button for the default layout', () => {
     render(<LayoutEditor {...makeProps()} />);
-
     fireEvent.click(screen.getByTitle('Layout manager'));
 
-    // No accessible label for deleting the Default layout
     expect(screen.queryByLabelText('Delete Default')).toBeNull();
   });
 
   // ── Test 5: Store deletion uses an explicit DELETE mock branch ──────
-  // This test lives alongside the useLayoutStore tests, but we verify here
-  // that the component correctly wires the store's delete through the guard
-  // by asserting the id passed matches what the store would send to DELETE.
 
   it('passes the layout id that the store would use for the DELETE request', () => {
     const props = makeProps();
-    render(<LayoutEditor {...props} />);
-
-    fireEvent.click(screen.getByTitle('Layout manager'));
-    fireEvent.click(screen.getByLabelText('Delete QA Layout'));
+    openDeleteDialog(props);
 
     const dialog = screen.getByRole('alertdialog');
     const confirmBtn = dialog.querySelector('button.confirm-delete')!;
     fireEvent.click(confirmBtn);
 
-    // The id passed to onDeleteLayout is the same id the store uses to
-    // build the DELETE /api/layouts/:id route — verified by the store's
-    // own integration tests with an explicit DELETE mock branch.
     expect(props.onDeleteLayout).toHaveBeenCalledWith('qa-layout');
+  });
+
+  // ── Test 6: Dialog is portaled to document.body (P2 stacking fix) ───
+
+  it('renders the confirmation dialog as a direct child of document.body', () => {
+    openDeleteDialog(makeProps());
+
+    const dialog = screen.getByRole('alertdialog');
+    // The overlay must be portaled out of .app-main's stacking context.
+    expect(dialog.parentElement).toBe(document.body);
+  });
+
+  // ── Test 7: Escape closes the dialog without deleting ──────────────
+
+  it('closes the dialog on Escape without calling onDeleteLayout', () => {
+    const props = makeProps();
+    openDeleteDialog(props);
+
+    const dialog = screen.getByRole('alertdialog');
+    fireEvent.keyDown(dialog, { key: 'Escape' });
+
+    expect(screen.queryByRole('alertdialog')).toBeNull();
+    expect(props.onDeleteLayout).not.toHaveBeenCalled();
+  });
+
+  // ── Test 8: Accessible name and description (P2 alertdialog fix) ───
+
+  it('has an accessible name via aria-labelledby and description via aria-describedby', () => {
+    openDeleteDialog(makeProps());
+
+    const dialog = screen.getByRole('alertdialog');
+
+    // aria-labelledby must point to an element containing the layout name
+    const labelledBy = dialog.getAttribute('aria-labelledby');
+    expect(labelledBy).toBeTruthy();
+    const titleEl = document.getElementById(labelledBy!);
+    expect(titleEl).toBeTruthy();
+    expect(titleEl!.textContent).toContain('QA Layout');
+
+    // aria-describedby must point to an element describing the consequence
+    const describedBy = dialog.getAttribute('aria-describedby');
+    expect(describedBy).toBeTruthy();
+    const descEl = document.getElementById(describedBy!);
+    expect(descEl).toBeTruthy();
+    expect(descEl!.textContent).toContain('permanently');
+  });
+
+  // ── Test 9: Focus is contained within the dialog (Tab trap) ────────
+
+  it('traps Tab focus within the dialog', () => {
+    openDeleteDialog(makeProps());
+
+    const dialog = screen.getByRole('alertdialog');
+    const cancelBtn = dialog.querySelector('.confirm-cancel') as HTMLElement;
+    const deleteBtn = dialog.querySelector('.confirm-delete') as HTMLElement;
+
+    // Focus the last button (Delete), then Tab should wrap to first (Cancel)
+    deleteBtn.focus();
+    fireEvent.keyDown(dialog, { key: 'Tab' });
+    expect(document.activeElement).toBe(cancelBtn);
+
+    // Focus the first button (Cancel), then Shift+Tab should wrap to last (Delete)
+    cancelBtn.focus();
+    fireEvent.keyDown(dialog, { key: 'Tab', shiftKey: true });
+    expect(document.activeElement).toBe(deleteBtn);
+  });
+
+  // ── Test 10: Focus is restored to the invoking element on close ────
+
+  it('restores focus to the delete button after cancel', () => {
+    const props = makeProps();
+    const deleteBtn = openDeleteDialog(props);
+
+    fireEvent.click(screen.getByText('Cancel'));
+
+    // Focus should return to the trash button that opened the dialog
+    expect(document.activeElement).toBe(deleteBtn);
   });
 
   // ── Regression: confirmation dialog closes after confirm ───────────
 
   it('closes the confirmation dialog after confirmation', () => {
-    render(<LayoutEditor {...makeProps()} />);
-
-    fireEvent.click(screen.getByTitle('Layout manager'));
-    fireEvent.click(screen.getByLabelText('Delete QA Layout'));
+    openDeleteDialog(makeProps());
 
     const dialog = screen.getByRole('alertdialog');
     const confirmBtn = dialog.querySelector('button.confirm-delete')!;
     fireEvent.click(confirmBtn);
 
-    // Dialog should be gone
     expect(screen.queryByRole('alertdialog')).toBeNull();
   });
 
   // ── Regression: confirmation dialog closes after cancel ────────────
 
   it('closes the confirmation dialog after cancel', () => {
-    render(<LayoutEditor {...makeProps()} />);
-
-    fireEvent.click(screen.getByTitle('Layout manager'));
-    fireEvent.click(screen.getByLabelText('Delete QA Layout'));
+    openDeleteDialog(makeProps());
 
     fireEvent.click(screen.getByText('Cancel'));
 

--- a/src/components/LayoutEditor.delete.test.tsx
+++ b/src/components/LayoutEditor.delete.test.tsx
@@ -321,6 +321,38 @@ describe('Issue #109 — delete confirmation guard', () => {
     await waitFor(() => expect(screen.queryByRole('alertdialog')).toBeNull());
   });
 
+  // ── Test 12c: Escape is ignored while a delete is in flight (P2) ─────
+  //
+  // Sophie's final review: onDocKeyDown dismissed the barrier on Escape even
+  // while deletingRef was true. The DELETE is irreversible and uncancellable,
+  // so Escape posing as a cancellation hid the pending result, stranded focus
+  // when the row later unmounted, and could let a stale handler close a newer
+  // dialog. The fix mirrors the disabled Cancel button: ignore Escape in flight.
+
+  it('ignores Escape during an in-flight delete, then lands focus stably on success', async () => {
+    let resolveDelete: (v: boolean) => void = () => {};
+    const pending = new Promise<boolean>(resolve => { resolveDelete = resolve; });
+    const onDeleteLayout = vi.fn().mockReturnValue(pending);
+    const props = makeProps({ onDeleteLayout });
+    openDeleteDialog(props);
+
+    const dialog = screen.getByRole('alertdialog');
+    fireEvent.click(dialog.querySelector('button.confirm-delete')!);
+
+    // deleting === true: Escape is swallowed, the barrier stays up, and the
+    // request is NOT re-fired.
+    fireEvent.keyDown(document, { key: 'Escape', bubbles: true });
+    expect(screen.getByRole('alertdialog')).toBeTruthy();
+    expect(onDeleteLayout).toHaveBeenCalledTimes(1);
+
+    // On success the dialog closes and focus lands on the stable Layouts
+    // toggle — never on <body>, even though Escape was pressed mid-flight.
+    resolveDelete(true);
+    await waitFor(() => expect(screen.queryByRole('alertdialog')).toBeNull());
+    expect(document.activeElement).toBe(screen.getByTitle('Layout manager'));
+    expect(document.activeElement).not.toBe(document.body);
+  });
+
   // ── Test 13: Escape does not propagate to the App drawer (P3) ───────
 
   it('stops Escape propagation so a window-level listener is not also invoked', () => {

--- a/src/components/LayoutEditor.delete.test.tsx
+++ b/src/components/LayoutEditor.delete.test.tsx
@@ -220,6 +220,30 @@ describe('Issue #109 — delete confirmation guard', () => {
     expect(document.activeElement).toBe(deleteBtn);
   });
 
+  // ── Test 11: Confirm-path focus survives the trigger's unmount (P2) ──
+
+  it('restores focus to the Layouts toggle after confirm when the trigger unmounts', () => {
+    const props = makeProps();
+    // Simulate the real lifecycle: confirming deletes the layout row, which
+    // unmounts its trash button. The mock removes the trigger node so the
+    // cleanup's isConnected check falls back to the Layouts toggle instead of
+    // stranding focus on <body> (P2 from Sophie's re-review at b89818e).
+    props.onDeleteLayout = vi.fn(() => {
+      screen.getByLabelText('Delete QA Layout').remove();
+    });
+    openDeleteDialog(props);
+
+    const dialog = screen.getByRole('alertdialog');
+    const confirmBtn = dialog.querySelector('button.confirm-delete')!;
+    fireEvent.click(confirmBtn);
+
+    expect(props.onDeleteLayout).toHaveBeenCalledExactlyOnceWith('qa-layout');
+    // Trigger is detached, so focus must fall back to the Layouts toggle.
+    const layoutsToggle = document.querySelector<HTMLElement>('[title="Layout manager"]');
+    expect(layoutsToggle).toBeTruthy();
+    expect(document.activeElement).toBe(layoutsToggle);
+  });
+
   // ── Regression: confirmation dialog closes after confirm ───────────
 
   it('closes the confirmation dialog after confirmation', () => {

--- a/src/components/LayoutEditor.delete.test.tsx
+++ b/src/components/LayoutEditor.delete.test.tsx
@@ -287,6 +287,40 @@ describe('Issue #109 — delete confirmation guard', () => {
     expect(document.activeElement).toBe(cancelBtn);
   });
 
+  // ── Test 12b: Containment holds while a delete is in flight (Kody) ───
+  //
+  // Kody review @09653e5: both dialog buttons carry disabled={deleting}, so
+  // during the async delete the guard's .confirm-cancel.focus() is a silent
+  // no-op (disabled buttons can't take focus) and focus strands on <body> —
+  // the exact regression the guard exists to prevent. The fix focuses the
+  // tabIndex={-1} overlay itself as the fallback target.
+
+  it('keeps focus contained (on the overlay) when it escapes during an in-flight delete', async () => {
+    let resolveDelete: (v: boolean) => void = () => {};
+    const pending = new Promise<boolean>(resolve => { resolveDelete = resolve; });
+    const onDeleteLayout = vi.fn().mockReturnValue(pending);
+    const props = makeProps({ onDeleteLayout });
+    openDeleteDialog(props);
+
+    const dialog = screen.getByRole('alertdialog');
+    fireEvent.click(dialog.querySelector('button.confirm-delete')!);
+
+    // deleting === true now, so both buttons are disabled.
+    const cancel = dialog.querySelector('.confirm-cancel') as HTMLButtonElement;
+    expect(cancel.disabled).toBe(true);
+
+    // Focus escapes outside the overlay while the delete is in flight.
+    fireEvent.focusIn(screen.getByTitle('Furniture palette'));
+
+    // Cancel can't take focus, so the guard must fall back to the focusable
+    // overlay itself. Focus stays contained — never on <body>.
+    expect(document.activeElement).toBe(dialog);
+    expect(document.activeElement).not.toBe(document.body);
+
+    resolveDelete(true);
+    await waitFor(() => expect(screen.queryByRole('alertdialog')).toBeNull());
+  });
+
   // ── Test 13: Escape does not propagate to the App drawer (P3) ───────
 
   it('stops Escape propagation so a window-level listener is not also invoked', () => {

--- a/src/components/LayoutEditor.delete.test.tsx
+++ b/src/components/LayoutEditor.delete.test.tsx
@@ -16,11 +16,18 @@
  *   7. Escape closes the dialog without deleting.
  *   8. Dialog has accessible name and description (aria-labelledby/describedby).
  *   9. Focus is contained within the dialog (Tab trap).
- *  10. Focus is restored to the invoking element on close.
+ *  10. Focus is restored to the invoking element on cancel.
+ *  11. Confirm-path focus survives async row removal via a real parent
+ *      re-render (stateful harness — no imperative .remove()).
+ *  12. Focus escapes are recovered by the document focusin guard (P2).
+ *  13. Escape does not propagate to the App window listener (P3).
+ *  14. A failed delete keeps the barrier open and surfaces an inline error (P3).
+ *  15. Double submission is prevented while a delete is in flight.
+ *  16. Load controls expose an accessible name, not just an emoji (P3).
  */
 
-import React from 'react';
-import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import React, { useState } from 'react';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { LayoutEditor } from './LayoutEditor';
@@ -110,7 +117,7 @@ describe('Issue #109 — delete confirmation guard', () => {
 
   // ── Test 3: Confirm calls onDeleteLayout exactly once ───────────────
 
-  it('calls onDeleteLayout exactly once with the correct id when Delete is confirmed', () => {
+  it('calls onDeleteLayout exactly once with the correct id when Delete is confirmed', async () => {
     const props = makeProps();
     openDeleteDialog(props);
 
@@ -119,6 +126,8 @@ describe('Issue #109 — delete confirmation guard', () => {
     fireEvent.click(confirmBtn);
 
     expect(props.onDeleteLayout).toHaveBeenCalledExactlyOnceWith('qa-layout');
+    // Flush the async confirm so no state update lingers past cleanup.
+    await waitFor(() => expect(screen.queryByRole('alertdialog')).toBeNull());
   });
 
   // ── Test 4: Default layout exposes no delete control ────────────────
@@ -132,7 +141,7 @@ describe('Issue #109 — delete confirmation guard', () => {
 
   // ── Test 5: Store deletion uses an explicit DELETE mock branch ──────
 
-  it('passes the layout id that the store would use for the DELETE request', () => {
+  it('passes the layout id that the store would use for the DELETE request', async () => {
     const props = makeProps();
     openDeleteDialog(props);
 
@@ -141,6 +150,7 @@ describe('Issue #109 — delete confirmation guard', () => {
     fireEvent.click(confirmBtn);
 
     expect(props.onDeleteLayout).toHaveBeenCalledWith('qa-layout');
+    await waitFor(() => expect(screen.queryByRole('alertdialog')).toBeNull());
   });
 
   // ── Test 6: Dialog is portaled to document.body (P2 stacking fix) ───
@@ -220,40 +230,140 @@ describe('Issue #109 — delete confirmation guard', () => {
     expect(document.activeElement).toBe(deleteBtn);
   });
 
-  // ── Test 11: Confirm-path focus survives the trigger's unmount (P2) ──
+  // ── Test 11: Confirm-path focus survives async row removal (P2) ─────
+  //
+  // Sophie's re-review at d65fca7 showed the previous version was a false
+  // positive: it imperatively `.remove()`d the trash button to manufacture
+  // `isConnected === false`, an ordering production never produces. In the
+  // real lifecycle the DELETE resolves and `fetchLayouts()` re-renders the
+  // parent WITHOUT the deleted row, unmounting the trash button later. This
+  // harness reproduces that with a stateful parent re-render — React owns
+  // the row removal, never an imperative DOM mutation.
 
-  it('restores focus to the Layouts toggle after confirm when the trigger unmounts', () => {
-    const props = makeProps();
-    // Simulate the real lifecycle: confirming deletes the layout row, which
-    // unmounts its trash button. The mock removes the trigger node so the
-    // cleanup's isConnected check falls back to the Layouts toggle instead of
-    // stranding focus on <body> (P2 from Sophie's re-review at b89818e).
-    props.onDeleteLayout = vi.fn(() => {
-      screen.getByLabelText('Delete QA Layout').remove();
-    });
+  it('restores focus to a surviving control after the parent re-renders without the deleted row', async () => {
+    function Harness() {
+      const [layouts, setLayouts] = useState([defaultLayout, customLayout]);
+      const [active, setActive] = useState<LayoutDoc | null>(defaultLayout);
+      const handleDelete = (id: string) => {
+        // Mirrors fetchLayouts() dropping the deleted layout from state.
+        setLayouts(prev => prev.filter(l => l.id !== id));
+        setActive(prev => (prev?.id === id ? null : prev));
+      };
+      return (
+        <LayoutEditor
+          {...makeProps({ layouts, activeLayout: active, onDeleteLayout: handleDelete })}
+        />
+      );
+    }
+    render(<Harness />);
+    fireEvent.click(screen.getByTitle('Layout manager'));
+    fireEvent.click(screen.getByLabelText('Delete QA Layout'));
+
+    const dialog = screen.getByRole('alertdialog');
+    fireEvent.click(dialog.querySelector('button.confirm-delete')!);
+
+    // The async confirm closes the dialog and the parent drops the row.
+    await waitFor(() => expect(screen.queryByRole('alertdialog')).toBeNull());
+    await waitFor(() => expect(screen.queryByText('QA Layout')).toBeNull());
+
+    // Focus must land on a surviving control (the Layouts toggle), never on
+    // <body> or the now-unmounted trash button.
+    const layoutsToggle = screen.getByTitle('Layout manager');
+    expect(document.activeElement).toBe(layoutsToggle);
+  });
+
+  // ── Test 12: Focus escapes are recovered (P2 containment guard) ─────
+
+  it('returns focus inside the dialog when an outside control gains focus', () => {
+    openDeleteDialog(makeProps());
+    const dialog = screen.getByRole('alertdialog');
+    const cancelBtn = dialog.querySelector('.confirm-cancel') as HTMLElement;
+
+    // Focus escapes to a toolbar control outside the portaled overlay.
+    const outside = screen.getByTitle('Furniture palette');
+    fireEvent.focusIn(outside);
+
+    // The document focusin guard must immediately pull focus back inside.
+    expect(document.activeElement).toBe(cancelBtn);
+  });
+
+  // ── Test 13: Escape does not propagate to the App drawer (P3) ───────
+
+  it('stops Escape propagation so a window-level listener is not also invoked', () => {
+    openDeleteDialog(makeProps());
+
+    const windowSpy = vi.fn();
+    window.addEventListener('keydown', windowSpy);
+    try {
+      fireEvent.keyDown(document, { key: 'Escape', bubbles: true });
+    } finally {
+      window.removeEventListener('keydown', windowSpy);
+    }
+
+    // The document handler closed the dialog…
+    expect(screen.queryByRole('alertdialog')).toBeNull();
+    // …and the same event never reached the window listener (App drawer).
+    expect(windowSpy).not.toHaveBeenCalled();
+  });
+
+  // ── Test 14: Failed delete keeps the barrier open + inline error (P3) ──
+
+  it('keeps the dialog open and surfaces an error when deletion fails', async () => {
+    const onDeleteLayout = vi.fn().mockResolvedValue(false);
+    const props = makeProps({ onDeleteLayout });
     openDeleteDialog(props);
 
     const dialog = screen.getByRole('alertdialog');
-    const confirmBtn = dialog.querySelector('button.confirm-delete')!;
-    fireEvent.click(confirmBtn);
+    fireEvent.click(dialog.querySelector('button.confirm-delete')!);
 
-    expect(props.onDeleteLayout).toHaveBeenCalledExactlyOnceWith('qa-layout');
-    // Trigger is detached, so focus must fall back to the Layouts toggle.
-    const layoutsToggle = document.querySelector<HTMLElement>('[title="Layout manager"]');
-    expect(layoutsToggle).toBeTruthy();
-    expect(document.activeElement).toBe(layoutsToggle);
+    // The failure is announced inline and the barrier stays up.
+    await screen.findByRole('alert');
+    expect(screen.getByRole('alertdialog')).toBeTruthy();
+    expect(onDeleteLayout).toHaveBeenCalledExactlyOnceWith('qa-layout');
+  });
+
+  // ── Test 15: Double submission prevented while in flight ────────────
+
+  it('calls onDeleteLayout only once for repeated clicks during an in-flight delete', async () => {
+    let resolveDelete: (v: boolean) => void = () => {};
+    const pending = new Promise<boolean>(resolve => { resolveDelete = resolve; });
+    const onDeleteLayout = vi.fn().mockReturnValue(pending);
+    const props = makeProps({ onDeleteLayout });
+    openDeleteDialog(props);
+
+    const dialog = screen.getByRole('alertdialog');
+    const confirmBtn = dialog.querySelector('button.confirm-delete') as HTMLElement;
+    fireEvent.click(confirmBtn);
+    fireEvent.click(confirmBtn); // second click while the first is in flight
+
+    expect(onDeleteLayout).toHaveBeenCalledTimes(1);
+
+    resolveDelete(true);
+    await waitFor(() => expect(screen.queryByRole('alertdialog')).toBeNull());
+  });
+
+  // ── Test 16: Load controls expose an accessible name (P3) ───────────
+
+  it('gives the Load button an accessible name beyond the folder emoji', () => {
+    render(<LayoutEditor {...makeProps()} />);
+    fireEvent.click(screen.getByTitle('Layout manager'));
+
+    // The emoji-only content must be backed by an aria-label.
+    const loadBtn = screen.getByRole('button', { name: 'Load QA Layout' });
+    expect(loadBtn).toBeTruthy();
   });
 
   // ── Regression: confirmation dialog closes after confirm ───────────
 
-  it('closes the confirmation dialog after confirmation', () => {
+  it('closes the confirmation dialog after confirmation', async () => {
     openDeleteDialog(makeProps());
 
     const dialog = screen.getByRole('alertdialog');
     const confirmBtn = dialog.querySelector('button.confirm-delete')!;
     fireEvent.click(confirmBtn);
 
-    expect(screen.queryByRole('alertdialog')).toBeNull();
+    // Confirm is async (awaits the delete); the dialog closes on success.
+    await waitFor(() => expect(screen.queryByRole('alertdialog')).toBeNull());
   });
 
   // ── Regression: confirmation dialog closes after cancel ────────────

--- a/src/components/LayoutEditor.mobile.test.tsx
+++ b/src/components/LayoutEditor.mobile.test.tsx
@@ -217,3 +217,25 @@ describe('Issue #87 — mobile toolbar / room switcher overlap', () => {
     expect(screen.getByText('Default')).toBeTruthy();
   });
 });
+
+describe('Issue #109 — confirmation-dialog responsive contract', () => {
+  // Pins the narrow/short-viewport dialog fixes from PR #122 so they can't
+  // silently regress (Sophie review @78f2bc3). Scoped to the .confirm-dialog
+  // rule block (raw CSS text, not CSSOM) so a same-named declaration elsewhere
+  // can't satisfy the assertion by accident, and so min()/calc() serialization
+  // quirks in jsdom don't interfere.
+  const dialogBlock = layoutEditorCss.match(/\.confirm-dialog\s*\{([^}]*)\}/)?.[1] ?? '';
+
+  it('keeps padding and border inside the capped width (box-sizing)', () => {
+    expect(dialogBlock).toContain('box-sizing: border-box');
+  });
+
+  it('caps the dialog width to the viewport on narrow screens', () => {
+    expect(dialogBlock).toContain('width: min(340px, calc(100vw - 32px))');
+  });
+
+  it('caps height and scrolls on short landscape viewports', () => {
+    expect(dialogBlock).toContain('max-height: calc(100vh - 32px)');
+    expect(dialogBlock).toContain('overflow-y: auto');
+  });
+});

--- a/src/components/LayoutEditor.tsx
+++ b/src/components/LayoutEditor.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect, useCallback } from 'react';
+import React, { useState, useRef, useEffect, useLayoutEffect, useCallback } from 'react';
 import { createPortal } from 'react-dom';
 import type { PlacedFurniture } from '../../shared/types';
 import type { LayoutDoc, SaveStatus } from '../hooks/useLayoutStore';
@@ -172,6 +172,20 @@ export const LayoutEditor: React.FC<Props> = ({
       }
     }
   }, []);
+
+  // Real-browser focus containment (P2, Sophie review @78f2bc3): disabling the
+  // focused Delete button makes Chromium move focus to <body> with NO focusin
+  // event for the document guard to intercept — jsdom never reproduces that
+  // blur, so the suite looked green while the live browser stranded focus
+  // outside the aria-modal dialog for the whole in-flight request. Re-anchor
+  // focus to the always-focusable overlay the moment the disabled state
+  // commits. useLayoutEffect runs synchronously after the DOM mutation and
+  // before paint, so the correction is invisible and lands before any Tab key.
+  useLayoutEffect(() => {
+    if (deleting && overlayRef.current) {
+      overlayRef.current.focus();
+    }
+  }, [deleting]);
 
   useEffect(() => {
     if (!pendingDelete) return;
@@ -480,17 +494,20 @@ export const LayoutEditor: React.FC<Props> = ({
                   deletingRef.current = true;
                   setDeleting(true);
                   setDeleteError(false);
-                  let ok = true;
+                  let ok = false;
                   try {
-                    ok = await Promise.resolve(onDeleteLayout(pendingDelete.id));
+                    ok = (await Promise.resolve(onDeleteLayout(pendingDelete.id))) === true;
                   } catch {
                     ok = false;
                   }
                   deletingRef.current = false;
                   setDeleting(false);
-                  if (ok === false) {
-                    // Keep the barrier open and surface the failure instead of
-                    // closing optimistically on a silent store error (P3).
+                  // Fail closed: only a strict `true` closes the barrier. Any
+                  // other result — false, undefined, a thrown error — keeps it
+                  // open and surfaces the inline alert, so a future adapter or
+                  // mock that forgets to return a boolean can never delete
+                  // without confirmation (P3 fail-safe defaults, Sophie review).
+                  if (ok !== true) {
                     setDeleteError(true);
                     return;
                   }

--- a/src/components/LayoutEditor.tsx
+++ b/src/components/LayoutEditor.tsx
@@ -1,4 +1,5 @@
-import React, { useState } from 'react';
+import React, { useState, useRef, useEffect, useCallback } from 'react';
+import { createPortal } from 'react-dom';
 import type { PlacedFurniture } from '../../shared/types';
 import type { LayoutDoc, SaveStatus } from '../hooks/useLayoutStore';
 import './LayoutEditor.css';
@@ -130,6 +131,50 @@ export const LayoutEditor: React.FC<Props> = ({
   const [showLayouts, setShowLayouts] = useState(false);
   const [newName, setNewName] = useState('');
   const [pendingDelete, setPendingDelete] = useState<LayoutDoc | null>(null);
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLElement | null>(null);
+
+  // Focus trap + Escape handling for the confirmation dialog (WAI-ARIA APG).
+  // Runs while pendingDelete is set; restores focus on cleanup.
+  const handleDialogKeyDown = useCallback((e: React.KeyboardEvent) => {
+    if (e.key === 'Escape') {
+      e.preventDefault();
+      setPendingDelete(null);
+      return;
+    }
+    if (e.key === 'Tab') {
+      const dialog = dialogRef.current;
+      if (!dialog) return;
+      const focusable = dialog.querySelectorAll<HTMLElement>(
+        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+      );
+      if (focusable.length === 0) return;
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!pendingDelete) return;
+    // Move focus into the dialog (autoFocus handles the initial focus,
+    // but this ensures it even if autoFocus is suppressed by the browser).
+    const timer = setTimeout(() => {
+      const cancel = dialogRef.current?.querySelector<HTMLElement>('.confirm-cancel');
+      cancel?.focus();
+    }, 0);
+    return () => {
+      clearTimeout(timer);
+      // Restore focus to the element that opened the dialog.
+      triggerRef.current?.focus();
+    };
+  }, [pendingDelete]);
 
   if (!editorMode) return null;
 
@@ -272,7 +317,10 @@ export const LayoutEditor: React.FC<Props> = ({
                   {layout.id !== 'default' && (
                     <button
                       className="danger"
-                      onClick={() => setPendingDelete(layout)}
+                      onClick={(e) => {
+                        triggerRef.current = e.currentTarget;
+                        setPendingDelete(layout);
+                      }}
                       aria-label={`Delete ${layout.name}`}
                       title={`Delete ${layout.name}`}
                     >🗑️</button>
@@ -301,15 +349,29 @@ export const LayoutEditor: React.FC<Props> = ({
         </div>
       )}
 
-      {/* Delete confirmation dialog — Fail-Safe guard (issue #109):
-          irreversible server-side unlinkSync must clear a confirmation barrier
-          before the raw store delete is invoked. The store/server remain
-          unguarded primitives; the component owns the user-facing gate. */}
-      {pendingDelete && (
-        <div className="confirm-overlay" role="alertdialog" aria-modal="true">
-          <div className="confirm-dialog">
-            <p className="confirm-message">
-              Delete <strong>{pendingDelete.name}</strong>? This cannot be undone.
+      {/* Delete confirmation dialog — Confirmation Barrier / Guard Pattern
+          (issue #109): irreversible server-side unlinkSync must clear a
+          confirmation barrier before the raw store delete is invoked. The
+          store/server remain unguarded primitives; the component owns the
+          sole user-facing gate (not Defense in Depth — one independent guard).
+          Portaled to document.body to escape the .app-main stacking context
+          and use the --z-modal token (P2 fix, Codex + Sophie review). */}
+      {pendingDelete && createPortal(
+        <div
+          className="confirm-overlay"
+          role="alertdialog"
+          aria-modal="true"
+          aria-labelledby="confirm-delete-title"
+          aria-describedby="confirm-delete-desc"
+          onKeyDown={handleDialogKeyDown}
+        >
+          <div className="confirm-dialog" ref={dialogRef}>
+            <p className="confirm-message" id="confirm-delete-title">
+              Delete <strong>{pendingDelete.name}</strong>?
+            </p>
+            <p className="confirm-description" id="confirm-delete-desc">
+              This will permanently remove the layout and all its furniture
+              placements. This cannot be undone.
             </p>
             <div className="confirm-actions">
               <button
@@ -330,7 +392,8 @@ export const LayoutEditor: React.FC<Props> = ({
               </button>
             </div>
           </div>
-        </div>
+        </div>,
+        document.body,
       )}
     </div>
   );

--- a/src/components/LayoutEditor.tsx
+++ b/src/components/LayoutEditor.tsx
@@ -129,6 +129,7 @@ export const LayoutEditor: React.FC<Props> = ({
   const [showPalette, setShowPalette] = useState(false);
   const [showLayouts, setShowLayouts] = useState(false);
   const [newName, setNewName] = useState('');
+  const [pendingDelete, setPendingDelete] = useState<LayoutDoc | null>(null);
 
   if (!editorMode) return null;
 
@@ -267,9 +268,14 @@ export const LayoutEditor: React.FC<Props> = ({
                   {layout.furniture.length} items · {new Date(layout.updatedAt).toLocaleDateString()}
                 </span>
                 <div className="layout-actions">
-                  <button onClick={() => onLoad(layout.id)}>📂</button>
+                  <button onClick={() => onLoad(layout.id)} title={`Load ${layout.name}`}>📂</button>
                   {layout.id !== 'default' && (
-                    <button className="danger" onClick={() => onDeleteLayout(layout.id)}>🗑️</button>
+                    <button
+                      className="danger"
+                      onClick={() => setPendingDelete(layout)}
+                      aria-label={`Delete ${layout.name}`}
+                      title={`Delete ${layout.name}`}
+                    >🗑️</button>
                   )}
                 </div>
               </div>
@@ -291,6 +297,38 @@ export const LayoutEditor: React.FC<Props> = ({
             <button onClick={() => { if (newName.trim()) { onCreate(newName.trim()); setNewName(''); } }}>
               ➕ Create
             </button>
+          </div>
+        </div>
+      )}
+
+      {/* Delete confirmation dialog — Fail-Safe guard (issue #109):
+          irreversible server-side unlinkSync must clear a confirmation barrier
+          before the raw store delete is invoked. The store/server remain
+          unguarded primitives; the component owns the user-facing gate. */}
+      {pendingDelete && (
+        <div className="confirm-overlay" role="alertdialog" aria-modal="true">
+          <div className="confirm-dialog">
+            <p className="confirm-message">
+              Delete <strong>{pendingDelete.name}</strong>? This cannot be undone.
+            </p>
+            <div className="confirm-actions">
+              <button
+                className="confirm-cancel"
+                onClick={() => setPendingDelete(null)}
+                autoFocus
+              >
+                Cancel
+              </button>
+              <button
+                className="confirm-delete danger"
+                onClick={() => {
+                  onDeleteLayout(pendingDelete.id);
+                  setPendingDelete(null);
+                }}
+              >
+                Delete
+              </button>
+            </div>
           </div>
         </div>
       )}

--- a/src/components/LayoutEditor.tsx
+++ b/src/components/LayoutEditor.tsx
@@ -134,14 +134,10 @@ export const LayoutEditor: React.FC<Props> = ({
   const dialogRef = useRef<HTMLDivElement>(null);
   const triggerRef = useRef<HTMLElement | null>(null);
 
-  // Focus trap + Escape handling for the confirmation dialog (WAI-ARIA APG).
-  // Runs while pendingDelete is set; restores focus on cleanup.
+  // Focus trap for the confirmation dialog (WAI-ARIA APG). Escape is handled
+  // separately via a document-level listener in the effect below so it fires
+  // reliably regardless of which descendant currently holds focus.
   const handleDialogKeyDown = useCallback((e: React.KeyboardEvent) => {
-    if (e.key === 'Escape') {
-      e.preventDefault();
-      setPendingDelete(null);
-      return;
-    }
     if (e.key === 'Tab') {
       const dialog = dialogRef.current;
       if (!dialog) return;
@@ -163,16 +159,37 @@ export const LayoutEditor: React.FC<Props> = ({
 
   useEffect(() => {
     if (!pendingDelete) return;
+
+    // Document-level Escape: closes the dialog no matter where focus is. A
+    // listener on the overlay alone misses Escape when focus sits on a button
+    // inside the portaled dialog (P2 fix from Sophie's re-review).
+    const onDocKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        setPendingDelete(null);
+      }
+    };
+    document.addEventListener('keydown', onDocKeyDown);
+
     // Move focus into the dialog (autoFocus handles the initial focus,
     // but this ensures it even if autoFocus is suppressed by the browser).
     const timer = setTimeout(() => {
       const cancel = dialogRef.current?.querySelector<HTMLElement>('.confirm-cancel');
       cancel?.focus();
     }, 0);
+
     return () => {
       clearTimeout(timer);
-      // Restore focus to the element that opened the dialog.
-      triggerRef.current?.focus();
+      document.removeEventListener('keydown', onDocKeyDown);
+      // Restore focus to the invoking element. After a confirmed delete the
+      // trash button unmounts with the layout row, so its node is detached;
+      // fall back to the Layouts toggle so focus never lands on <body> (P2).
+      if (triggerRef.current && triggerRef.current.isConnected) {
+        triggerRef.current.focus();
+      } else {
+        const layoutsToggle = document.querySelector<HTMLElement>('[title="Layout manager"]');
+        layoutsToggle?.focus();
+      }
     };
   }, [pendingDelete]);
 

--- a/src/components/LayoutEditor.tsx
+++ b/src/components/LayoutEditor.tsx
@@ -204,7 +204,16 @@ export const LayoutEditor: React.FC<Props> = ({
     const onFocusIn = (e: FocusEvent) => {
       const overlay = overlayRef.current;
       if (overlay && e.target instanceof Node && !overlay.contains(e.target)) {
-        overlay.querySelector<HTMLElement>('.confirm-cancel')?.focus();
+        const cancel = overlay.querySelector<HTMLButtonElement>('.confirm-cancel');
+        // Cancel is disabled while a delete is in flight, and a disabled
+        // button cannot receive focus — so fall back to the focusable
+        // overlay itself (tabIndex={-1}) to guarantee containment (Kody
+        // review @09653e5).
+        if (cancel && !cancel.disabled) {
+          cancel.focus();
+        } else {
+          overlay.focus();
+        }
       }
     };
     document.addEventListener('focusin', onFocusIn);
@@ -426,6 +435,7 @@ export const LayoutEditor: React.FC<Props> = ({
           aria-describedby="confirm-delete-desc"
           onKeyDown={handleDialogKeyDown}
           ref={overlayRef}
+          tabIndex={-1}
         >
           <div className="confirm-dialog" ref={dialogRef}>
             <p className="confirm-message" id="confirm-delete-title">

--- a/src/components/LayoutEditor.tsx
+++ b/src/components/LayoutEditor.tsx
@@ -25,7 +25,7 @@ interface Props {
   onSave: () => void;
   onLoad: (id: string) => void;
   onCreate: (name: string) => void;
-  onDeleteLayout: (id: string) => void | Promise<unknown>;
+  onDeleteLayout: (id: string) => boolean | Promise<boolean>;
   onToggleEditor: () => void;
 }
 
@@ -155,9 +155,11 @@ export const LayoutEditor: React.FC<Props> = ({
     if (e.key === 'Tab') {
       const dialog = dialogRef.current;
       if (!dialog) return;
-      const focusable = dialog.querySelectorAll<HTMLElement>(
-        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
-      );
+      const focusable = Array.from(
+        dialog.querySelectorAll<HTMLElement>(
+          'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+        )
+      ).filter(el => !el.hasAttribute('disabled')); // skip disabled controls (Sophie review)
       if (focusable.length === 0) return;
       const first = focusable[0];
       const last = focusable[focusable.length - 1];
@@ -191,6 +193,12 @@ export const LayoutEditor: React.FC<Props> = ({
         // Stop the same Escape from also closing the App agents drawer, whose
         // window-level listener sits above document in the bubble path (P3).
         e.stopPropagation();
+        // While a delete is in flight the work is irreversible and cannot be
+        // cancelled; dismissing the barrier would hide the pending result,
+        // strand focus when the row later unmounts, and let a stale handler
+        // close a newly opened confirmation. Mirror the disabled Cancel button
+        // and ignore Escape until the request settles (P2, Sophie review).
+        if (deletingRef.current) return;
         setPendingDelete(null);
       }
     };
@@ -472,7 +480,7 @@ export const LayoutEditor: React.FC<Props> = ({
                   deletingRef.current = true;
                   setDeleting(true);
                   setDeleteError(false);
-                  let ok: unknown = true;
+                  let ok = true;
                   try {
                     ok = await Promise.resolve(onDeleteLayout(pendingDelete.id));
                   } catch {

--- a/src/components/LayoutEditor.tsx
+++ b/src/components/LayoutEditor.tsx
@@ -25,7 +25,7 @@ interface Props {
   onSave: () => void;
   onLoad: (id: string) => void;
   onCreate: (name: string) => void;
-  onDeleteLayout: (id: string) => void;
+  onDeleteLayout: (id: string) => void | Promise<unknown>;
   onToggleEditor: () => void;
 }
 
@@ -131,8 +131,22 @@ export const LayoutEditor: React.FC<Props> = ({
   const [showLayouts, setShowLayouts] = useState(false);
   const [newName, setNewName] = useState('');
   const [pendingDelete, setPendingDelete] = useState<LayoutDoc | null>(null);
+  // Confirm lifecycle: disables the buttons while the async delete is in
+  // flight (double-submit guard) and surfaces a failure without closing.
+  const [deleting, setDeleting] = useState(false);
+  const [deleteError, setDeleteError] = useState(false);
+  const deletingRef = useRef(false);
   const dialogRef = useRef<HTMLDivElement>(null);
+  const overlayRef = useRef<HTMLDivElement>(null);
   const triggerRef = useRef<HTMLElement | null>(null);
+  // Stable toolbar toggle used as the focus-restore target after a confirmed
+  // delete, when the trash button unmounts with its layout row (P2).
+  const layoutsToggleRef = useRef<HTMLButtonElement>(null);
+  // The control to refocus on close, chosen by CLOSE REASON rather than by
+  // probing DOM connectedness at cleanup time (P2 close-reason fix):
+  //   cancel / escape → the invoking trash button (still mounted)
+  //   confirm         → the stable Layouts toggle (survives the row removal)
+  const restoreTargetRef = useRef<HTMLElement | null>(null);
 
   // Focus trap for the confirmation dialog (WAI-ARIA APG). Escape is handled
   // separately via a document-level listener in the effect below so it fires
@@ -160,16 +174,40 @@ export const LayoutEditor: React.FC<Props> = ({
   useEffect(() => {
     if (!pendingDelete) return;
 
+    // Reset transient confirm state for each fresh dialog open.
+    deletingRef.current = false;
+    setDeleting(false);
+    setDeleteError(false);
+    // Default restore target is the invoking control; the confirm path
+    // overrides it to a stable surviving control before closing.
+    restoreTargetRef.current = triggerRef.current;
+
     // Document-level Escape: closes the dialog no matter where focus is. A
     // listener on the overlay alone misses Escape when focus sits on a button
     // inside the portaled dialog (P2 fix from Sophie's re-review).
     const onDocKeyDown = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
         e.preventDefault();
+        // Stop the same Escape from also closing the App agents drawer, whose
+        // window-level listener sits above document in the bubble path (P3).
+        e.stopPropagation();
         setPendingDelete(null);
       }
     };
     document.addEventListener('keydown', onDocKeyDown);
+
+    // Focus-containment guard (P2): the Tab trap on the overlay only wraps
+    // while focus is already on the first/last dialog control. If focus
+    // escapes the portaled overlay entirely (programmatic focus, a stray
+    // Tab, or a browser quirk), pull it straight back inside so the
+    // aria-modal dialog never strands focus on <body> or an outside control.
+    const onFocusIn = (e: FocusEvent) => {
+      const overlay = overlayRef.current;
+      if (overlay && e.target instanceof Node && !overlay.contains(e.target)) {
+        overlay.querySelector<HTMLElement>('.confirm-cancel')?.focus();
+      }
+    };
+    document.addEventListener('focusin', onFocusIn);
 
     // Move focus into the dialog (autoFocus handles the initial focus,
     // but this ensures it even if autoFocus is suppressed by the browser).
@@ -180,15 +218,20 @@ export const LayoutEditor: React.FC<Props> = ({
 
     return () => {
       clearTimeout(timer);
+      // Remove the containment guard BEFORE moving focus so the restore
+      // target (which lives outside the overlay) is not intercepted.
       document.removeEventListener('keydown', onDocKeyDown);
-      // Restore focus to the invoking element. After a confirmed delete the
-      // trash button unmounts with the layout row, so its node is detached;
-      // fall back to the Layouts toggle so focus never lands on <body> (P2).
-      if (triggerRef.current && triggerRef.current.isConnected) {
-        triggerRef.current.focus();
+      document.removeEventListener('focusin', onFocusIn);
+      // Restore focus to the control chosen at close time. After a confirmed
+      // delete the trash button unmounts with its layout row, so the confirm
+      // path points restoreTargetRef at the stable Layouts toggle; cancel and
+      // Escape keep the original trigger. The isConnected probe is now only a
+      // defensive fallback, not the selection mechanism (P2 close-reason fix).
+      const target = restoreTargetRef.current;
+      if (target && target.isConnected) {
+        target.focus();
       } else {
-        const layoutsToggle = document.querySelector<HTMLElement>('[title="Layout manager"]');
-        layoutsToggle?.focus();
+        layoutsToggleRef.current?.focus();
       }
     };
   }, [pendingDelete]);
@@ -237,6 +280,7 @@ export const LayoutEditor: React.FC<Props> = ({
           🗑️ Delete
         </button>
         <button
+          ref={layoutsToggleRef}
           className={`toolbar-btn ${showLayouts ? 'active' : ''}`}
           onClick={() => { setShowLayouts(!showLayouts); setShowPalette(false); }}
           title="Layout manager"
@@ -330,7 +374,7 @@ export const LayoutEditor: React.FC<Props> = ({
                   {layout.furniture.length} items · {new Date(layout.updatedAt).toLocaleDateString()}
                 </span>
                 <div className="layout-actions">
-                  <button onClick={() => onLoad(layout.id)} title={`Load ${layout.name}`}>📂</button>
+                  <button onClick={() => onLoad(layout.id)} title={`Load ${layout.name}`} aria-label={`Load ${layout.name}`}>📂</button>
                   {layout.id !== 'default' && (
                     <button
                       className="danger"
@@ -381,6 +425,7 @@ export const LayoutEditor: React.FC<Props> = ({
           aria-labelledby="confirm-delete-title"
           aria-describedby="confirm-delete-desc"
           onKeyDown={handleDialogKeyDown}
+          ref={overlayRef}
         >
           <div className="confirm-dialog" ref={dialogRef}>
             <p className="confirm-message" id="confirm-delete-title">
@@ -390,22 +435,55 @@ export const LayoutEditor: React.FC<Props> = ({
               This will permanently remove the layout and all its furniture
               placements. This cannot be undone.
             </p>
+            {deleteError && (
+              <p className="confirm-error" role="alert">
+                Couldn't delete the layout. Please try again.
+              </p>
+            )}
             <div className="confirm-actions">
               <button
                 className="confirm-cancel"
-                onClick={() => setPendingDelete(null)}
+                onClick={() => {
+                  // Cancel/Escape keep the original trigger as the restore
+                  // target — it stays mounted because nothing is deleted.
+                  restoreTargetRef.current = triggerRef.current;
+                  setPendingDelete(null);
+                }}
+                disabled={deleting}
                 autoFocus
               >
                 Cancel
               </button>
               <button
                 className="confirm-delete danger"
-                onClick={() => {
-                  onDeleteLayout(pendingDelete.id);
+                disabled={deleting}
+                onClick={async () => {
+                  if (deletingRef.current) return; // double-submit guard
+                  deletingRef.current = true;
+                  setDeleting(true);
+                  setDeleteError(false);
+                  let ok: unknown = true;
+                  try {
+                    ok = await Promise.resolve(onDeleteLayout(pendingDelete.id));
+                  } catch {
+                    ok = false;
+                  }
+                  deletingRef.current = false;
+                  setDeleting(false);
+                  if (ok === false) {
+                    // Keep the barrier open and surface the failure instead of
+                    // closing optimistically on a silent store error (P3).
+                    setDeleteError(true);
+                    return;
+                  }
+                  // Success: the layout row will unmount, taking its trash
+                  // button with it. Restore focus to the stable Layouts toggle
+                  // so focus never lands on <body> (P2 close-reason fix).
+                  restoreTargetRef.current = layoutsToggleRef.current;
                   setPendingDelete(null);
                 }}
               >
-                Delete
+                {deleting ? 'Deleting…' : 'Delete'}
               </button>
             </div>
           </div>

--- a/src/hooks/useLayoutStore.test.tsx
+++ b/src/hooks/useLayoutStore.test.tsx
@@ -235,6 +235,44 @@ describe('useLayoutStore', () => {
     expect(putCalls.length).toBe(0);
   });
 
+  // ── deleteLayout result contract (Sophie review @78f2bc3, fail-safe) ──
+  //
+  // The confirmation barrier in LayoutEditor closes ONLY on a strict `true`,
+  // so the store must return a real boolean for every outcome. These pin that
+  // contract — success → true, non-2xx → false, rejected fetch → false — so a
+  // future route change can't turn the destructive delete into a fail-open.
+
+  describe('deleteLayout result contract', () => {
+    it('resolves true on a successful (2xx) delete', async () => {
+      await renderStoreProbe();
+      let result: boolean | undefined;
+      await act(async () => {
+        result = await latest(snapshots).deleteLayout('default');
+      });
+      expect(result).toBe(true);
+    });
+
+    it('resolves false on a non-2xx response', async () => {
+      await renderStoreProbe();
+      let result: boolean | undefined;
+      await act(async () => {
+        // 'missing' is not in the mock store, so DELETE returns 404.
+        result = await latest(snapshots).deleteLayout('missing');
+      });
+      expect(result).toBe(false);
+    });
+
+    it('resolves false when the fetch rejects (network error)', async () => {
+      await renderStoreProbe();
+      (fetch as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error('network down'));
+      let result: boolean | undefined;
+      await act(async () => {
+        result = await latest(snapshots).deleteLayout('default');
+      });
+      expect(result).toBe(false);
+    });
+  });
+
   it('updateFurniture applies functional updater to current layout', async () => {
     await renderStoreProbe();
 

--- a/src/hooks/useLayoutStore.test.tsx
+++ b/src/hooks/useLayoutStore.test.tsx
@@ -100,9 +100,22 @@ function makeFetchMock(
       });
     }
 
+    // DELETE /api/layouts/:id — delete layout (issue #109: explicit branch
+    // so deletion tests cannot pass through a generic GET fallback)
+    const deleteMatch = url.match(/\/api\/layouts\/([^/?]+)$/);
+    if (deleteMatch && init?.method === 'DELETE') {
+      const id = deleteMatch[1];
+      const existed = id in layouts;
+      delete layouts[id];
+      return new Response(JSON.stringify({ ok: existed }), {
+        status: existed ? 200 : 404,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
     // GET /api/layouts/:id — load specific layout
     const getMatch = url.match(/\/api\/layouts\/([^/?]+)$/);
-    if (getMatch) {
+    if (getMatch && (!init || init.method === undefined || init.method === 'GET')) {
       const id = getMatch[1];
       const layout = layouts[id];
       if (layout) {

--- a/src/hooks/useLayoutStore.ts
+++ b/src/hooks/useLayoutStore.ts
@@ -325,20 +325,25 @@ export function useLayoutStore() {
     }
   }, [fetchLayouts, setActiveLayoutProgrammatic]);
 
-  const deleteLayout = useCallback(async (id: string) => {
+  // Returns true on success and false on failure so the confirmation barrier
+  // in LayoutEditor can keep the dialog open and surface an error instead of
+  // closing optimistically on a silent store failure (PR #122 P3 fix).
+  const deleteLayout = useCallback(async (id: string): Promise<boolean> => {
     try {
       const res = await fetch(`${API_BASE}/layouts/${id}`, { method: 'DELETE' });
       if (!res.ok) {
         const err = await res.json().catch(() => ({ error: 'Failed to delete layout' }));
         console.error('Failed to delete layout:', err.error);
-        return;
+        return false;
       }
       if (activeLayout?.id === id) {
         setActiveLayoutProgrammatic(null);
       }
       fetchLayouts();
+      return true;
     } catch (err) {
       console.error('Failed to delete layout:', err);
+      return false;
     }
   }, [activeLayout, fetchLayouts, setActiveLayoutProgrammatic]);
 


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
## Analysis of Code Changes

### `src/components/LayoutEditor.tsx`
Introduces a `pendingDelete` state variable to hold the `LayoutDoc` awaiting confirmation. The trash button's `onClick` is rewired from calling `onDeleteLayout(layout.id)` directly to `setPendingDelete(layout)`. Accessibility improvements (`aria-label`, `title`) are added to both the load and delete buttons. A modal `alertdialog` is conditionally rendered when `pendingDelete` is non-null, displaying the layout name in `<strong>` tags along with the warning "This cannot be undone." Cancel clears the state; confirm invokes `onDeleteLayout(pendingDelete.id)` and then clears the state.

### `src/components/LayoutEditor.css`
Adds styling for the new confirmation modal: a fixed full-screen `.confirm-overlay` (semi-transparent black backdrop, z-index 9999), a glass-paneled `.confirm-dialog`, and `.confirm-message` / `.confirm-actions` layouts. Cancel uses cyan hover accents; the destructive Delete button uses pink (`var(--acc-pink)`) with elevated red on hover.

### `src/components/LayoutEditor.delete.test.tsx` (new)
A dedicated test suite covering all 5 issue cases plus 2 regression checks for dialog closure:
1. Confirmation dialog appears with layout name and "cannot be undone" text.
2. Cancel does not invoke `onDeleteLayout` and retains the layout row.
3. Confirm invokes `onDeleteLayout` exactly once with the correct id.
4. Default layout row renders no delete button.
5. The id passed matches what the store would use for its DELETE request.
6. Dialog closes after confirm.
7. Dialog closes after cancel.

### `src/hooks/useLayoutStore.test.tsx`
Adds an explicit DELETE branch to the `makeFetchMock` helper, mapping `DELETE /api/layouts/:id` to a 200/404 response based on existence. The GET branch is tightened to only match when method is undefined or `GET`, preventing deletion tests from accidentally passing through the GET fallback.

### Functional Summary

This PR inserts a mandatory confirmation step between the user clicking the trash icon and the layout being permanently deleted. Previously, a single click triggered an irreversible server-side `unlinkSync()` with no recourse. Now:

- The trash button opens a modal dialog naming the specific layout and warning that deletion cannot be undone.
- The user must explicitly click **Delete** in the dialog to invoke `onDeleteLayout`; **Cancel** or closing the dialog aborts the operation harmlessly.
- The store and server delete endpoints remain raw primitives — the barrier lives entirely in the UI layer, consistent with the **Defense in Depth** principle that the component owns the user-facing gate.
- Accessibility is improved via `aria-label`, `title`, and `role="alertdialog"` / `aria-modal="true"`.
- Test coverage explicitly pins the barrier (7 new component tests) and the store's DELETE routing (explicit mock branch) so neither can be silently regressed.

---

## Pull Request Summary

This PR improves the delete confirmation dialog for custom layouts in the Layout Editor, addressing issue #109 and incorporating review feedback from PR #122.

### Key Changes

**Component (`LayoutEditor.tsx`)**
- **Portal rendering**: The confirmation dialog is now rendered via `createPortal` to `document.body`, escaping the `.app-main` stacking context so the overlay can correctly sit above all app chrome.
- **Accessibility (ARIA)**: The dialog now provides an accessible name via `aria-labelledby` and an accessible description via `aria-describedby`, pointing to the layout name and a new explanatory paragraph that describes the permanent consequence of deletion.
- **Keyboard interaction**:
  - **Escape** closes the dialog without deleting.
  - **Tab / Shift+Tab** cycles focus within the dialog (focus trap).
- **Focus management**: Focus is programmatically moved into the dialog when it opens, and restored to the trash button that invoked it when the dialog closes (via a ref on the trigger).
- **Clarified intent**: Comments now document that this is a single Confirmation Barrier / Guard Pattern (not Defense in Depth), so future contributors don't accidentally remove the only user-facing gate.

**Styles (`LayoutEditor.css`)**
- Overlay uses the `--z-modal` token instead of a hard-coded `z-index: 9999`.
- Dialog width adapts to small viewports (`width: min(340px, calc(100vw - 32px))`).
- Added a `.confirm-description` style for the new secondary explanatory paragraph.
- Layout name in the title uses `overflow-wrap: anywhere` to handle long names gracefully.

**Tests (`LayoutEditor.delete.test.tsx`)**
- Added a shared `openDeleteDialog` helper to reduce duplication.
- New coverage for the portal behavior, Escape-to-close, ARIA labelling, focus trapping, and focus restoration.
- Doc comments updated to reflect the new expanded test list and the single-guard model.

---

This PR fixes focus-restoration bugs in the layout-deletion confirmation dialog (issue #109), addressing two P2 issues found in a re-review:

1. **Escape key on dialog buttons**: Escape was previously only handled by a `keydown` listener on the overlay element. When focus was on a button inside the portaled dialog (e.g., the confirm or cancel button), pressing Escape did nothing because the event didn't bubble through the overlay. Escape handling is now moved to a document-level listener attached while the dialog is open, ensuring the dialog closes from any focus location.

2. **Focus stranded on `<body>` after confirmed delete**: The cleanup used to call `triggerRef.current?.focus()`, but after a confirmed deletion the trash button (the trigger) is removed along with its layout row, so its node is detached and calling `.focus()` on it would silently no-op, leaving focus on `<body>`. The cleanup now checks `triggerRef.current.isConnected` and falls back to the Layouts toggle button (`[title="Layout manager"]`) when the original trigger is no longer in the DOM.

A new test ("restores focus to the Layouts toggle after confirm when the trigger unmounts") verifies the fallback by simulating the trigger removal on delete and asserting focus lands on the Layouts toggle.

---

# Pull Request Summary

## Purpose
Fixes and hardens the custom layout deletion confirmation flow in the LayoutEditor, addressing issues identified across P2/P3 review rounds and preventing silent failures.

## Key Changes

### Confirmation Lifecycle
- **`onDeleteLayout`** signature now accepts `void | Promise<unknown>`, allowing async delete handlers
- Added `deleting`/`deleteError` state plus a `deletingRef` to track in-flight deletes
- Double-submit guard: the confirm button is disabled and the handler short-circuits while a delete is in flight
- Button label changes to "Deleting…" during the async operation

### Failure Handling (P3)
- If the delete promise resolves to `false` or rejects, the dialog **stays open** and an inline `role="alert"` error ("Couldn't delete the layout. Please try again.") is rendered
- `useLayoutStore.deleteLayout` now returns `Promise<boolean>` — `true` on success, `false` on HTTP/network errors — so the editor can react accordingly

### Focus Management (P2)
- Introduced a `restoreTargetRef` chosen at close time by **reason** rather than by probing `isConnected` after the fact:
  - Cancel/Escape → the original trash button (still mounted)
  - Confirm → the stable Layouts toggle (survives row removal)
- Added a document-level `focusin` guard that pulls focus back into the portaled dialog if it escapes to an outside control
- The guard is removed **before** focus restoration so the restore target isn't intercepted
- Added an `overlayRef` for the containment check
- `layoutsToggleRef` provides a stable fallback target

### Event Isolation (P3)
- Escape now calls `e.stopPropagation()` in addition to `e.preventDefault()`, preventing the same keystroke from also closing the App agents drawer via its window-level listener

### Accessibility (P3)
- The Load button now exposes an `aria-label` (`"Load {name}"`) in addition to its emoji content, so screen readers announce it correctly
- CSS added `box-sizing: border-box` on `.confirm-dialog` so padding/border stay within the width cap on narrow viewports

## Test Updates
Replaced the prior imperative-`.remove()` test (a false positive from Sophie's review) with a **stateful harness** that mirrors the real lifecycle: a parent re-render drops the deleted layout from state, React unmounts the trash button. Added six new tests covering:
- Async confirm closes the dialog on success
- Focus containment via `focusin` guard
- Escape stop-propagation
- Failed delete keeps dialog open and surfaces the alert
- Double-submit prevention
- Accessible name on Load button

---

## Summary

This PR fixes a focus-containment bug in the layout delete confirmation dialog uncovered during code review (Kody review @09653e5).

## Problem

While a layout deletion is in flight, the Cancel button is disabled alongside the Delete button. The dialog's focus-containment guard was trying to restore focus to the Cancel button whenever focus escaped the overlay, but a disabled button cannot receive focus — so the `.focus()` call silently no-op'd and focus dropped to `<body>`, defeating the guard's purpose.

## Changes

**`src/components/LayoutEditor.tsx`** — The `onFocusIn` handler now checks whether the Cancel button is disabled before focusing it. If Cancel is disabled (because a delete is in flight), the guard falls back to focusing the overlay element itself, which is made programmatically focusable via `tabIndex={-1}` on the dialog `role="alertdialog"`.

**`src/components/LayoutEditor.delete.test.tsx`** — Added a new test (Test 12b) that simulates focus escaping the dialog while a delete is in flight, and asserts that focus stays contained on the overlay rather than falling through to `<body>`.

---

## Summary

This PR fixes UX and focus-management issues around the custom layout deletion confirmation dialog, building on prior work for issue #109.

### Changes

- **Escape during in-flight delete is ignored**: Pressing Escape while a delete request is pending no longer dismisses the confirmation barrier. Since the deletion is irreversible and uncancellable, this prevents Escape from hiding the pending result, stranding focus when the layout row unmounts, or letting a stale handler close a newer dialog. This mirrors the already-disabled Cancel button during the in-flight state.
- **Disabled-button visual treatment**: The dialog's buttons now show a proper disabled appearance (reduced opacity, default cursor, no hover effects) while a delete is pending, so "Deleting…" reads as non-interactive.
- **Focus trap respects disabled controls**: The focus-trap logic inside the dialog now filters out disabled elements, matching the disabled-button state.
- **Type tightening for `onDeleteLayout`**: The callback signature now explicitly returns `boolean | Promise<boolean>`, reflecting the actual success/failure contract used by the delete handler.
- **Dialog fits short landscape viewports**: The confirmation dialog now caps its height to the viewport and scrolls internally, preventing it from being clipped on short landscape screens.
- **New regression test**: Adds a test verifying that Escape during an in-flight delete is ignored, the barrier stays up, the delete request is not re-fired, and focus lands on the stable Layouts toggle (not `<body>`) once the deletion resolves.

---

## Summary

This change hardens the custom-layout deletion flow so the confirmation barrier **only closes on an explicit success signal**, preventing accidental permanent removal from silent store errors, malformed adapter returns, or future refactors that forget the result contract.

## What's changing

### Stricter result contract (fail-closed by default)
Previously, the delete handler treated any non-`false` return as success, including `undefined`. Now, the barrier closes **only** on a strict `=== true`:
- `true` → close the dialog (success)
- `false`, `undefined`, or thrown error → keep the barrier open and surface the inline error alert

This protects against any future adapter or mock that returns a non-boolean and would otherwise bypass user confirmation.

### Real-browser focus containment during in-flight delete
When the Delete button is disabled, Chromium moves focus to `<body>` without firing a `focusin` event — a defect jsdom never reproduced, so the test suite stayed green while real users lost focus outside the dialog. A `useLayoutEffect` now re-anchors focus to the always-focusable overlay the instant the in-flight state commits, restoring correct modal focus before paint.

### Responsive dialog regression guard
Adds tests pinning the narrow/short-viewport dialog CSS (capped width via `min()/calc()`, `box-sizing: border-box`, capped height with overflow) so PR #122's responsive fixes can't silently regress.

### Store contract tests
The `useLayoutStore.deleteLayout` method now has explicit tests guaranteeing it returns a real boolean — `true` on 2xx, `false` on non-2xx, `false` on network error — so a future route change can't turn destructive deletes into a fail-open.
<!-- kody-pr-summary:end -->