### PR TITLE
fix(server): make DATA_SOURCE=auto honor fallback contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,13 +210,21 @@ Furniture uses per-type directories with `manifest.json` for dimensions and rota
 | `PORT` | `3001` | Backend server port (`3000` in production) |
 | `NODE_ENV` | *(set to `production` by `npm start`)* | Runtime mode; production requires `CORS_ORIGIN` for WebSocket origin checks |
 | `CORS_ORIGIN` | *(none)* | Comma-separated browser origins allowed to open Socket.IO connections and to send state-mutating REST requests in production |
-| `DATA_SOURCE` | `auto` | Data mode: `auto`, `cli` (local polling), or `ingest` (push-based) |
-| `OPENCLAW_CLI` | `openclaw` | Path to OpenClaw CLI binary (cli mode only) |
+| `DATA_SOURCE` | `auto` | Data mode: `auto`, `cli` (local polling), or `ingest` (push-based); invalid values fail safe to `auto` |
+| `OPENCLAW_BIN` | `openclaw` | Path to OpenClaw CLI binary (CLI polling modes only) |
 | `POLL_INTERVAL` | `3000` | Agent state poll interval in ms (cli mode only) |
 | `ACTIVE_MINUTES` | `30` | Session staleness threshold |
 | `INGEST_API_TOKEN` | *(none)* | Shared secret for ingest API auth (required for ingest mode) |
 | `OPENCLAW_AGENTS_DIR` | `~/.openclaw/agents` | Path to agent session transcripts |
 | `DATA_DIR` | `./data` | Persistence directory for preferences and layouts |
+
+### Agent data-source modes
+
+The server follows a finite-state machine and the single-writer principle: CLI polling and ingest writes are never active at the same time. `cli` always keeps CLI polling active, and `ingest` starts ingest-only without polling. Ingest mode requires `INGEST_API_TOKEN`.
+
+`auto` starts with CLI polling. When an ingest token is configured and CLI execution fails specifically because `OPENCLAW_BIN` is missing (`ENOENT` or `ENOTDIR`), the server makes an at-most-once, sticky transition to ingest-only. This hysteresis prevents later polling from taking ownership back. Transient failures—including non-zero exits, timeouts, permission errors, malformed output, and unknown errors—preserve the previous snapshot and do not switch modes. Without an ingest token, `auto` remains in CLI mode even when the executable is missing.
+
+While CLI polling owns agent state, authenticated ingest requests are rejected with `409 Conflict` before rate limiting or payload validation. `/api/status` reports the compatibility `dataSource` field (`cli-poll` or `ingest`) plus `dataSourceConfig`, `dataSourceEffective`, `dataSourceTransitioned`, `cliPolling`, and `lastIngestAt`.
 
 ### Reverse-proxy deployments
 

--- a/README.md
+++ b/README.md
@@ -224,7 +224,9 @@ The server follows a finite-state machine and the single-writer principle: CLI p
 
 `auto` starts with CLI polling. When an ingest token is configured and CLI execution fails specifically because `OPENCLAW_BIN` is missing (`ENOENT` or `ENOTDIR`), the server makes an at-most-once, sticky transition to ingest-only. This hysteresis prevents later polling from taking ownership back. Transient failures—including non-zero exits, timeouts, permission errors, malformed output, and unknown errors—preserve the previous snapshot and do not switch modes. Without an ingest token, `auto` remains in CLI mode even when the executable is missing.
 
-While CLI polling owns agent state, authenticated ingest requests are rejected with `409 Conflict` before rate limiting or payload validation. `/api/status` reports the compatibility `dataSource` field (`cli-poll` or `ingest`) plus `dataSourceConfig`, `dataSourceEffective`, `dataSourceTransitioned`, `cliPolling`, and `lastIngestAt`.
+While CLI polling owns agent state, authenticated ingest requests are rejected with `409 Conflict` before rate limiting or payload validation. `/api/status` reports `dataSourceConfig`, `dataSourceEffective`, `dataSourceTransitioned`, `cliPolling`, and `lastIngestAt`.
+
+The legacy `dataSource` field remains a compatibility alias for **effective ownership**: `cli-poll` while polling owns state, and `ingest` while ingest-only owns state. It no longer means that an ingest push happened at any point in the process lifetime; use `lastIngestAt` for accepted-push history and migrate mode checks to `dataSourceEffective`.
 
 ### Reverse-proxy deployments
 

--- a/README.md
+++ b/README.md
@@ -220,9 +220,9 @@ Furniture uses per-type directories with `manifest.json` for dimensions and rota
 
 ### Agent data-source modes
 
-The server follows a finite-state machine and the single-writer principle: CLI polling and ingest writes are never active at the same time. `cli` always keeps CLI polling active, and `ingest` starts ingest-only without polling. Ingest mode requires `INGEST_API_TOKEN`.
+The server follows a finite-state machine and the single-writer principle: CLI polling and ingest writes are never active at the same time. `cli` always keeps CLI polling active, and `ingest` starts ingest-only without polling. Ingest mode requires `INGEST_API_TOKEN`. Configuring a token does not enable pushes in explicit `cli` mode; use `ingest` or `auto` when collector delivery should own agent state.
 
-`auto` starts with CLI polling. When an ingest token is configured and CLI execution fails specifically because `OPENCLAW_BIN` is missing (`ENOENT` or `ENOTDIR`), the server makes an at-most-once, sticky transition to ingest-only. This hysteresis prevents later polling from taking ownership back. Transient failures—including non-zero exits, timeouts, permission errors, malformed output, and unknown errors—preserve the previous snapshot and do not switch modes. Without an ingest token, `auto` remains in CLI mode even when the executable is missing.
+`auto` starts with CLI polling. When an ingest token is configured and CLI execution fails specifically because `OPENCLAW_BIN` is missing (`ENOENT` or `ENOTDIR`), the server makes an at-most-once, sticky transition to ingest-only. This hysteresis prevents later polling from taking ownership back; returning to CLI ownership after fallback requires restarting the server once the executable is available. Transient failures—including non-zero exits, timeouts, permission errors, malformed output, and unknown errors—preserve the previous snapshot and do not switch modes. Without an ingest token, `auto` remains in CLI mode even when the executable is missing.
 
 While CLI polling owns agent state, authenticated ingest requests are rejected with `409 Conflict` before rate limiting or payload validation. `/api/status` reports `dataSourceConfig`, `dataSourceEffective`, `dataSourceTransitioned`, `cliPolling`, and `lastIngestAt`.
 

--- a/server/dataSource.http.test.ts
+++ b/server/dataSource.http.test.ts
@@ -1,0 +1,66 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { Express } from "express";
+import type { Server as SocketIOServer } from "socket.io";
+import request from "supertest";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+
+describe("data-source HTTP contract", () => {
+  let app: Express;
+  let io: SocketIOServer;
+  let dataDir: string;
+
+  beforeAll(async () => {
+    dataDir = mkdtempSync(join(tmpdir(), "pixel-agents-data-source-test-"));
+    vi.stubEnv("DATA_DIR", dataDir);
+    vi.stubEnv("DATA_SOURCE", "cli");
+    vi.stubEnv("INGEST_API_TOKEN", "test-secret");
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("CORS_ORIGIN", "https://pixel.test");
+
+    vi.resetModules();
+    const serverModule = await import("./index");
+    app = serverModule.app;
+    io = serverModule.io;
+  });
+
+  afterAll(() => {
+    io.close();
+    rmSync(dataDir, { recursive: true, force: true });
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+
+  it("authenticates before applying the CLI ownership gate", async () => {
+    await request(app)
+      .post("/api/ingest/agents")
+      .send({ sessions: [] })
+      .expect(401)
+      .expect({ error: "Unauthorized" });
+  });
+
+  it("rejects authenticated ingest before payload validation while CLI owns state", async () => {
+    await request(app)
+      .post("/api/ingest/agents")
+      .set("Authorization", "Bearer test-secret")
+      .send({ invalid: true })
+      .expect(409)
+      .expect({ error: "Ingest unavailable while CLI polling is active" });
+  });
+
+  it("reports configured and effective ownership separately", async () => {
+    const response = await request(app)
+      .get("/api/status")
+      .expect(200);
+
+    expect(response.body).toMatchObject({
+      dataSource: "cli-poll",
+      dataSourceConfig: "cli",
+      dataSourceEffective: "cli-poll",
+      dataSourceTransitioned: false,
+      lastIngestAt: null,
+      cliPolling: true,
+    });
+  });
+});

--- a/server/dataSource.http.test.ts
+++ b/server/dataSource.http.test.ts
@@ -6,6 +6,8 @@ import type { Server as SocketIOServer } from "socket.io";
 import request from "supertest";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 
+const TEST_INGEST_TOKEN = "data-source-http-test-token";
+
 describe("data-source HTTP contract", () => {
   let app: Express;
   let io: SocketIOServer;
@@ -15,7 +17,7 @@ describe("data-source HTTP contract", () => {
     dataDir = mkdtempSync(join(tmpdir(), "pixel-agents-data-source-test-"));
     vi.stubEnv("DATA_DIR", dataDir);
     vi.stubEnv("DATA_SOURCE", "cli");
-    vi.stubEnv("INGEST_API_TOKEN", "test-secret");
+    vi.stubEnv("INGEST_API_TOKEN", TEST_INGEST_TOKEN);
     vi.stubEnv("NODE_ENV", "production");
     vi.stubEnv("CORS_ORIGIN", "https://pixel.test");
 
@@ -43,7 +45,7 @@ describe("data-source HTTP contract", () => {
   it("rejects authenticated ingest before payload validation while CLI owns state", async () => {
     await request(app)
       .post("/api/ingest/agents")
-      .set("Authorization", "Bearer test-secret")
+      .set("Authorization", `Bearer ${TEST_INGEST_TOKEN}`)
       .send({ invalid: true })
       .expect(409)
       .expect({ error: "Ingest unavailable while CLI polling is active" });

--- a/server/dataSource.test.ts
+++ b/server/dataSource.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+import {
+  applyCliFailure,
+  classifyCliExecError,
+  createInitialDataSourceState,
+  isCliPollingActive,
+  isIngestWritesActive,
+  type CliFailureKind,
+  type ConfiguredDataSource,
+} from "./dataSource";
+
+describe("data-source policy", () => {
+  it.each([
+    ["auto", false, "cli-poll"],
+    ["auto", true, "cli-poll"],
+    ["cli", false, "cli-poll"],
+    ["cli", true, "cli-poll"],
+    ["ingest", false, "ingest-only"],
+    ["ingest", true, "ingest-only"],
+  ] as const)(
+    "initializes %s with token=%s as %s",
+    (configured, hasIngestToken, effective) => {
+      const state = createInitialDataSourceState(configured, hasIngestToken);
+
+      expect(state).toEqual({
+        configured,
+        effective,
+        hasIngestToken,
+        transitioned: false,
+      });
+      expect(Object.isFrozen(state)).toBe(true);
+    },
+  );
+
+  it.each([
+    ["auto", false, "missing-executable", "cli-poll", false],
+    ["auto", false, "transient", "cli-poll", false],
+    ["auto", true, "missing-executable", "ingest-only", true],
+    ["auto", true, "transient", "cli-poll", false],
+    ["cli", false, "missing-executable", "cli-poll", false],
+    ["cli", true, "missing-executable", "cli-poll", false],
+    ["cli", true, "transient", "cli-poll", false],
+    ["ingest", false, "missing-executable", "ingest-only", false],
+    ["ingest", true, "missing-executable", "ingest-only", false],
+    ["ingest", true, "transient", "ingest-only", false],
+  ] as const)(
+    "%s with token=%s and %s remains/transitions to %s",
+    (configured, hasIngestToken, failure, effective, transitioned) => {
+      const initial = createInitialDataSourceState(configured, hasIngestToken);
+      const next = applyCliFailure(initial, failure);
+
+      expect(next.effective).toBe(effective);
+      expect(next.transitioned).toBe(transitioned);
+      expect(Object.isFrozen(next)).toBe(true);
+    },
+  );
+
+  it("makes the fallback transition sticky and idempotent", () => {
+    const initial = createInitialDataSourceState("auto", true);
+    const transitioned = applyCliFailure(initial, "missing-executable");
+
+    expect(applyCliFailure(transitioned, "missing-executable")).toBe(transitioned);
+    expect(applyCliFailure(transitioned, "transient")).toBe(transitioned);
+    expect(transitioned.effective).toBe("ingest-only");
+  });
+
+  it.each([
+    [{ code: "ENOENT" }, "missing-executable"],
+    [{ code: "ENOTDIR" }, "missing-executable"],
+    [{ code: 1 }, "transient"],
+    [{ code: "EACCES" }, "transient"],
+    [{ code: "ETIMEDOUT", killed: true }, "transient"],
+    [{ killed: true, signal: "SIGTERM" }, "transient"],
+    [new SyntaxError("bad JSON"), "transient"],
+    [new Error("unknown"), "transient"],
+    [null, "transient"],
+  ] as const)("classifies %# as %s", (error, expected) => {
+    expect(classifyCliExecError(error)).toBe(expected);
+  });
+
+  it.each([
+    ["auto", false, undefined, true, false],
+    ["auto", true, undefined, true, false],
+    ["auto", true, "transient", true, false],
+    ["auto", true, "missing-executable", false, true],
+    ["cli", true, "missing-executable", true, false],
+    ["ingest", true, undefined, false, true],
+  ] as const)(
+    "enforces one writer for %s with token=%s and failure=%s",
+    (configured, hasIngestToken, failure, cliActive, ingestActive) => {
+      let state = createInitialDataSourceState(
+        configured as ConfiguredDataSource,
+        hasIngestToken,
+      );
+      if (failure) state = applyCliFailure(state, failure as CliFailureKind);
+
+      expect(isCliPollingActive(state)).toBe(cliActive);
+      expect(isIngestWritesActive(state)).toBe(ingestActive);
+      expect(Number(cliActive) + Number(ingestActive)).toBe(1);
+    },
+  );
+});

--- a/server/dataSource.ts
+++ b/server/dataSource.ts
@@ -1,0 +1,67 @@
+export type ConfiguredDataSource = "auto" | "cli" | "ingest";
+export type EffectiveDataSource = "cli-poll" | "ingest-only";
+export type CliFailureKind = "missing-executable" | "transient";
+
+export type DataSourceState = Readonly<{
+  configured: ConfiguredDataSource;
+  effective: EffectiveDataSource;
+  hasIngestToken: boolean;
+  transitioned: boolean;
+}>;
+
+/** Create the initial state for the data-source finite-state machine. */
+export function createInitialDataSourceState(
+  configured: ConfiguredDataSource,
+  hasIngestToken: boolean,
+): DataSourceState {
+  return Object.freeze({
+    configured,
+    effective: configured === "ingest" ? "ingest-only" : "cli-poll",
+    hasIngestToken,
+    transitioned: false,
+  });
+}
+
+/** Only path-resolution failures prove that the configured CLI is unavailable. */
+export function classifyCliExecError(error: unknown): CliFailureKind {
+  if (typeof error === "object" && error !== null && "code" in error) {
+    const code = error.code;
+    if (code === "ENOENT" || code === "ENOTDIR") {
+      return "missing-executable";
+    }
+  }
+  return "transient";
+}
+
+/**
+ * Apply CLI failure policy with hysteresis: auto mode may transition once and
+ * then remains ingest-only, preventing ownership from oscillating.
+ */
+export function applyCliFailure(
+  state: DataSourceState,
+  failure: CliFailureKind,
+): DataSourceState {
+  if (
+    state.configured !== "auto"
+    || !state.hasIngestToken
+    || state.effective !== "cli-poll"
+    || state.transitioned
+    || failure !== "missing-executable"
+  ) {
+    return state;
+  }
+
+  return Object.freeze({
+    ...state,
+    effective: "ingest-only",
+    transitioned: true,
+  });
+}
+
+export function isCliPollingActive(state: DataSourceState): boolean {
+  return state.effective === "cli-poll";
+}
+
+export function isIngestWritesActive(state: DataSourceState): boolean {
+  return state.effective === "ingest-only";
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -18,6 +18,15 @@ import { createInterface } from "node:readline";
 import { applyAgentSnapshot } from "./agentSnapshots";
 import { correlationMiddleware, httpRequestLogMiddleware } from "./correlation";
 import { createCorsConfig, isOriginAllowed } from "./cors";
+import {
+  applyCliFailure,
+  classifyCliExecError,
+  createInitialDataSourceState,
+  isCliPollingActive,
+  isIngestWritesActive,
+  type CliFailureKind,
+  type ConfiguredDataSource,
+} from "./dataSource";
 import { apiErrorHandler, registerProcessErrorHandlers } from "./errors";
 import {
   isTranscriptPathContained,
@@ -101,6 +110,7 @@ const ACTIVE_THRESHOLD_MIN = parseInt(process.env.ACTIVE_MINUTES || "30", 10);
 const OPENCLAW_BIN = process.env.OPENCLAW_BIN || "openclaw";
 const DATA_DIR = process.env.DATA_DIR || join(__dirname, "data");
 const PERSIST_PATH = join(DATA_DIR, "agent-prefs.json");
+const INGEST_TOKEN = process.env.INGEST_API_TOKEN || "";
 /** Base directory for OpenClaw agent session transcripts */
 const AGENTS_DIR = process.env.OPENCLAW_AGENTS_DIR || join(process.env.HOME || "/root", ".openclaw", "agents");
 
@@ -110,7 +120,13 @@ const AGENTS_DIR = process.env.OPENCLAW_AGENTS_DIR || join(process.env.HOME || "
  *   "cli"     — always poll via local openclaw CLI (original behavior)
  *   "ingest"  — only accept pushed data via the ingest API (no local CLI needed)
  */
-const DATA_SOURCE = (process.env.DATA_SOURCE || "auto").toLowerCase() as "auto" | "cli" | "ingest";
+const configuredDataSource = (process.env.DATA_SOURCE || "auto").toLowerCase();
+// Unknown values fail safe to auto, which keeps CLI as the initial writer.
+const DATA_SOURCE: ConfiguredDataSource = configuredDataSource === "cli"
+  || configuredDataSource === "ingest"
+  ? configuredDataSource
+  : "auto";
+let dataSourceState = createInitialDataSourceState(DATA_SOURCE, !!INGEST_TOKEN);
 
 // ---- Known agents from config ----
 
@@ -208,6 +224,7 @@ interface CliSessionsResult {
   sessions: CliSession[];
   count: number;
   sourceError?: boolean;
+  cliFailureKind?: CliFailureKind;
 }
 
 /**
@@ -227,8 +244,9 @@ function pollSessions(): Promise<CliSessionsResult> {
 
     execFile(OPENCLAW_BIN, args, { timeout: 10000 }, (err, stdout, stderr) => {
       if (err) {
+        const cliFailureKind = classifyCliExecError(err);
         logger.error({ err, subsystem: "poll" }, "cli error");
-        resolve({ sessions: [], count: 0, sourceError: true });
+        resolve({ sessions: [], count: 0, sourceError: true, cliFailureKind });
         return;
       }
 
@@ -240,7 +258,7 @@ function pollSessions(): Promise<CliSessionsResult> {
         });
       } catch (parseErr) {
         logger.error({ err: parseErr, subsystem: "poll" }, "json parse error");
-        resolve({ sessions: [], count: 0, sourceError: true });
+        resolve({ sessions: [], count: 0, sourceError: true, cliFailureKind: "transient" });
       }
     });
   });
@@ -603,11 +621,27 @@ async function pollMessages(): Promise<void> {
 let isPolling = false;
 
 async function pollAndBroadcast(): Promise<void> {
-  if (isPolling) return;
+  if (!isCliPollingActive(dataSourceState) || isPolling) return;
   isPolling = true;
   const cycleLog = logger.child({ cycleId: randomUUID(), subsystem: "poll" });
   try {
-    const { sessions, sourceError } = await pollSessions();
+    const { sessions, sourceError, cliFailureKind } = await pollSessions();
+    if (sourceError && cliFailureKind) {
+      const nextState = applyCliFailure(dataSourceState, cliFailureKind);
+      if (nextState !== dataSourceState) {
+        dataSourceState = nextState;
+        if (pollTimer) {
+          clearInterval(pollTimer);
+          pollTimer = undefined;
+        }
+        cycleLog.warn({
+          configured: dataSourceState.configured,
+          effective: dataSourceState.effective,
+          failureKind: cliFailureKind,
+        }, "CLI executable unavailable; transitioned permanently to ingest-only");
+        return;
+      }
+    }
     const agentMap = sourceError ? undefined : mapToAgentStates(sessions);
     const { applied, snapshot } = applyAgentSnapshot(agentStates, agentMap, { sourceError });
 
@@ -629,7 +663,6 @@ async function pollAndBroadcast(): Promise<void> {
 
 // ---- Ingest API (receives data from OpenClaw host collector) ----
 
-const INGEST_TOKEN = process.env.INGEST_API_TOKEN || "";
 export type IngestTokenCrypto = Readonly<{
   digestToken: (token: string) => Buffer;
   compareDigests: (configured: Buffer, provided: Buffer) => boolean;
@@ -703,6 +736,12 @@ app.post("/api/ingest/agents", (req, res) => {
   }
   if (!authenticateIngest(req, res)) {
     res.status(401).json({ error: "Unauthorized" });
+    return;
+  }
+
+  // Single-writer principle: authenticated pushes cannot race CLI snapshots.
+  if (!isIngestWritesActive(dataSourceState)) {
+    res.status(409).json({ error: "Ingest unavailable while CLI polling is active" });
     return;
   }
 
@@ -782,16 +821,18 @@ app.get("/api/agents", (_req, res) => {
 
 app.get("/api/status", (_req, res) => {
   const agents = Array.from(agentStates.values());
-  const effectiveSource = useCli && !ingestExplicit ? "cli-poll" : "ingest";
+  const cliPolling = isCliPollingActive(dataSourceState);
   res.json({
     connected: true,
     agentCount: agents.length,
     activeCount: agents.filter((a) => a.active).length,
     uptime: process.uptime(),
-    dataSource: lastIngestAt > 0 ? "ingest" : effectiveSource,
-    dataSourceConfig: DATA_SOURCE,
+    dataSource: cliPolling ? "cli-poll" : "ingest",
+    dataSourceConfig: dataSourceState.configured,
+    dataSourceEffective: dataSourceState.effective,
+    dataSourceTransitioned: dataSourceState.transitioned,
     lastIngestAt: lastIngestAt || null,
-    cliPolling: useCli && !ingestExplicit,
+    cliPolling,
   });
 });
 
@@ -1164,12 +1205,6 @@ app.use(apiErrorHandler);
 
 const PORT = parseInt(process.env.PORT || "3001", 10);
 
-// Determine effective data source
-const hasIngestToken = !!INGEST_TOKEN;
-const cliExplicit = DATA_SOURCE === "cli";
-const ingestExplicit = DATA_SOURCE === "ingest";
-const useCli = cliExplicit || (DATA_SOURCE === "auto" && !ingestExplicit);
-
 // ---- Graceful Shutdown ----
 
 let isShuttingDown = false;
@@ -1237,20 +1272,20 @@ function startServer(): void {
   server.listen(PORT, () => {
     logger.info({
       port: PORT,
-      dataSource: DATA_SOURCE,
-      effective: useCli && !ingestExplicit ? "cli-poll" : "ingest-only",
+      dataSource: dataSourceState.configured,
+      effective: dataSourceState.effective,
       subsystem: "server",
     }, "🖥️  OpenClaw Pixel Agents server running");
 
-    if (useCli && !ingestExplicit) {
+    if (isCliPollingActive(dataSourceState)) {
       logger.info({
         bin: OPENCLAW_BIN,
         activeThresholdMin: ACTIVE_THRESHOLD_MIN,
         pollIntervalMs: POLL_INTERVAL,
         subsystem: "server",
       }, "📡 Polling via CLI");
-      pollAndBroadcast();
       pollTimer = setInterval(pollAndBroadcast, POLL_INTERVAL);
+      void pollAndBroadcast();
     } else {
       logger.info({ subsystem: "server" }, "📡 Awaiting ingest data from collector (no local CLI polling)");
     }


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
## Data-source ownership finite-state machine

This change introduces an immutable `DataSourceState` (`server/dataSource.ts`) that models the configured vs effective ownership between CLI polling and ingest writes, along with pure helpers (`applyCliFailure`, `classifyCliExecError`, `isCliPollingActive`, `isIngestWritesActive`) that drive the policy. A frozen state object is returned from `createInitialDataSourceState`, with `effective` derived as `ingest-only` only when `configured === "ingest"` and otherwise `cli-poll`.

### Failure classification

`classifyCliExecError` restricts "missing-executable" to `ENOENT`/`ENOTDIR` codes and treats everything else (non-zero exits, timeouts, `EACCES`, malformed JSON, etc.) as `transient`. This is what allows the runtime to react only to genuinely missing CLI binaries.

### Hysteresis in `applyCliFailure`

The transition function only fires when **all** of the following hold:
- `configured === "auto"`
- `hasIngestToken === true`
- `effective === "cli-poll"`
- `!transitioned`
- `failure === "missing-executable"`

The result is an at-most-once, sticky transition: once `effective` flips to `ingest-only` and `transitioned` is `true`, subsequent failures (including further missing-executable errors) return the same frozen state object, preventing oscillation between CLI and ingest writers.

## Server integration (`server/index.ts`)

- `DATA_SOURCE` parsing now normalizes unknown values back to `auto` (fail-safe) and seeds `dataSourceState` once at module load.
- `pollSessions` reports the classified `cliFailureKind` back to the poll loop.
- `pollAndBroadcast` early-exits when `isCliPollingActive` is false (so polling is never re-scheduled after a transition), and on `sourceError + cliFailureKind === "missing-executable"` it calls `applyCliFailure`; if the state changes, it clears `pollTimer` and logs a one-time warn event. Transient failures keep the previous snapshot via the existing `sourceError` path.
- `POST /api/ingest/agents` now rejects with `409 Conflict` ("Ingest unavailable while CLI polling is active") when `!isIngestWritesActive(dataSourceState)`, before rate limiting or payload validation, enforcing the single-writer principle.
- `/api/status` exposes the new fields: `dataSource` (back-compat `"cli-poll" | "ingest"`), `dataSourceConfig`, `dataSourceEffective`, `dataSourceTransitioned`, and `cliPolling`. The `lastIngestAt > 0` heuristic that previously flipped the compatibility field has been removed.
- Startup logging now sources `effective` from `dataSourceState.effective`, and CLI polling is gated by `isCliPollingActive(dataSourceState)`; the `useCli`/`cliExplicit`/`ingestExplicit`/`hasIngestToken` block at the bottom of the file was deleted.

## Tests (`server/dataSource.test.ts`)

A new vitest suite covers:
- Initial state for every `(configured, hasIngestToken)` permutation, asserting the object is frozen.
- `applyCliFailure` over the full matrix of configuration × token × failure, plus a sticky/idempotence check proving that once transitioned, neither `missing-executable` nor `transient` failures alter the state.
- `classifyCliExecError` over `ENOENT`, `ENOTDIR`, numeric `code`, `EACCES`, `ETIMEDOUT`, killed-by-signal, `SyntaxError`, generic `Error`, and `null`.
- Single-writer invariant: for every `(configured, hasIngestToken, failure)` combination, `isCliPollingActive` and `isIngestWritesActive` are mutually exclusive and exactly one is true.

## Documentation

`README.md` now describes the FSM, replaces the `OPENCLAW_CLI` row with `OPENCLAW_BIN`, notes that invalid `DATA_SOURCE` values fail safe to `auto`, and adds an "Agent data-source modes" section explaining the `auto`→`ingest-only` sticky transition, which failures qualify (only `ENOENT`/`ENOTDIR`), how transient failures preserve the snapshot, the 409 rejection behavior, and the new `/api/status` fields.

---

Update README to clarify the `dataSource` field's compatibility semantics and document the migration path for mode checks.

---

### Summary

This pull request clarifies and verifies the contract for the server's `DATA_SOURCE=auto` mode, ensuring it honors the documented fallback behavior from CLI polling to ingest when the OpenClaw binary is unavailable.

### Changes

**Documentation (`README.md`)**
- Clarifies that configuring `INGEST_API_TOKEN` alone does not enable ingest pushes in explicit `cli` mode — collectors must use `ingest` or `auto` to take ownership of agent state.
- Adds an explicit note that returning to CLI ownership after fallback requires restarting the server, since the fallback transition is sticky.

**Test Coverage (`server/dataSource.http.test.ts`)**
- New HTTP integration test suite covering the data-source ownership contract:
  - **Authentication gate**: Confirms unauthenticated ingest requests are rejected with `401` before any ownership check runs.
  - **Ownership gate**: Confirms authenticated requests are rejected with `409 Conflict` (and a specific error message) before payload validation when CLI owns state, matching the documented single-writer principle.
  - **Status reporting**: Verifies `/api/status` independently reports `dataSourceConfig` (configured value) and `dataSourceEffective` (runtime value), along with `dataSourceTransitioned`, `lastIngestAt`, and `cliPolling` flags.

### Impact

The changes make the documented fallback semantics more precise and add regression coverage to ensure the authentication and ownership gating order is preserved on the HTTP boundary. This protects against future changes that could accidentally validate ingest payloads before checking CLI ownership or process ingest requests when no token is configured.

---

## Summary

This PR updates the `dataSource.http.test.ts` file to use a shared `TEST_INGEST_TOKEN` constant instead of a hardcoded string literal for the ingest API token in test setup and assertions.

## Changes

- Introduced a `TEST_INGEST_TOKEN` constant at the top of the test file for the ingest token value (`"data-source-http-test-token"`).
- Replaced the hardcoded `"test-secret"` string used in the `INGEST_API_TOKEN` environment stub with the new constant.
- Updated the `Authorization: Bearer` header in the authenticated ingest request assertion to reference the same constant.

## Purpose

The change improves maintainability by centralizing the test token value in a single named constant, reducing the risk of drift between the environment stub and the header assertion in the test.
<!-- kody-pr-summary:end -->

## Maintainer summary

- add a small immutable data-source **finite-state machine** for configured vs effective ownership
- make `DATA_SOURCE=auto` transition once from CLI polling to ingest-only only when `OPENCLAW_BIN` is genuinely unavailable (`ENOENT`/`ENOTDIR`) and an ingest token exists
- enforce the **single-writer principle** by rejecting authenticated ingest writes with `409 Conflict` while CLI polling owns agent state
- keep transient CLI failures on the existing snapshot-preservation path without oscillating sources
- expose configured/effective/transition status through `/api/status` and align README/configuration docs

## Runtime contract

| Configuration | Initial owner | Missing executable | Transient CLI error |
|---|---|---|---|
| `auto` + ingest token | CLI | sticky transition to ingest-only | remain CLI |
| `auto` without token | CLI | remain CLI | remain CLI |
| `cli` | CLI | remain CLI | remain CLI |
| `ingest` | ingest-only | CLI never started | CLI never started |

The transition uses **hysteresis**: it is at-most-once and never returns ownership to polling. Unknown `DATA_SOURCE` values fail safe to `auto`.

## Verification

### Automated

- `npm run build` ✅
- `npm test` ✅ — 26 files, 261/261 tests
- `npm run test:coverage` ✅ — 44.41% statements, 44.99% branches, 43.06% functions, 46.37% lines
- `npm run typecheck` ✅
- `npm audit --omit=dev --audit-level=high` ✅ — 0 vulnerabilities
- `git diff --check` ✅
- changed-file diagnostics: 0 errors / 0 warnings ✅
- HTTP contract regression coverage: auth → ownership gate ordering, pre-validation `409`, and configured/effective status fields ✅

### Live process-level probes

Ran the compiled server in five disposable configurations and queried `/api/status` plus the ingest endpoint:

- `auto` + token + missing binary → `ingest-only`, transition count 1, CLI error count 1, ingest `200` ✅
- `auto` + token + transient non-zero exit → stays `cli-poll`, ingest `409` ✅
- explicit `cli` + token + missing binary → stays `cli-poll`, ingest `409` ✅
- explicit `ingest` + sentinel CLI → `ingest-only`, sentinel never executed, ingest `200` ✅
- `auto` + missing binary + no token → stays `cli-poll`, ingest `501` ✅

This is a headless server reliability change; visual/vision testing would not add evidence beyond the process and HTTP state probes.

Closes #98

