### PR TITLE
chore(tsconfig): split browser and test configs to enforce Node/browser ambient boundary

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "dev:server": "npx tsx watch server/index.ts",
     "build": "vite build && tsc -p tsconfig.server.json",
     "start": "NODE_ENV=production node dist/server/server/index.js",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.test.json",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage"

--- a/server/auth.test.ts
+++ b/server/auth.test.ts
@@ -2,7 +2,7 @@ import { createHmac, timingSafeEqual } from "node:crypto";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import type { Express } from "express";
+import type { Express, Request, Response } from "express";
 import type { Server as SocketIOServer } from "socket.io";
 import request from "supertest";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
@@ -11,7 +11,7 @@ describe("API auth boundaries", () => {
   let app: Express;
   let io: SocketIOServer;
   let dataDir: string;
-  let authenticateIngest: (req: Express.Request, res: Express.Response) => boolean;
+  let authenticateIngest: (req: Request, res: Response) => boolean;
   let createIngestAuthenticator: typeof import("./index").createIngestAuthenticator;
   let defaultIngestTokenCrypto: typeof import("./index").defaultIngestTokenCrypto;
   let ingestTokenDigestContext: typeof import("./index").INGEST_TOKEN_DIGEST_CONTEXT;
@@ -212,19 +212,19 @@ describe("API auth boundaries", () => {
     const authenticate = authenticateIngest;
     expect(authenticate).toBeDefined();
 
-    const makeReq = (token: string): Express.Request =>
-      ({ headers: { authorization: `Bearer ${token}` } }) as unknown as Express.Request;
+    const makeReq = (token: string): Request =>
+      ({ headers: { authorization: `Bearer ${token}` } }) as unknown as Request;
 
     // Correct token (matches INGEST_API_TOKEN="test-secret" from beforeAll)
-    expect(authenticate(makeReq("test-secret"), {} as Express.Response)).toBe(true);
+    expect(authenticate(makeReq("test-secret"), {} as Response)).toBe(true);
 
     // Wrong content, same length — the comparison must still reject
-    expect(authenticate(makeReq("not-a-secr"), {} as Express.Response)).toBe(false);
+    expect(authenticate(makeReq("not-a-secr"), {} as Response)).toBe(false);
 
     // Shorter, longer, much longer
-    expect(authenticate(makeReq("X"), {} as Express.Response)).toBe(false);
-    expect(authenticate(makeReq("X".repeat(100)), {} as Express.Response)).toBe(false);
-    expect(authenticate(makeReq("X".repeat(1000)), {} as Express.Response)).toBe(false);
+    expect(authenticate(makeReq("X"), {} as Response)).toBe(false);
+    expect(authenticate(makeReq("X".repeat(100)), {} as Response)).toBe(false);
+    expect(authenticate(makeReq("X".repeat(1000)), {} as Response)).toBe(false);
 
     // Unicode token (UTF-8 must be handled consistently between env var
     // and Bearer header — both are normalized through HMAC-SHA-256, whose
@@ -233,8 +233,8 @@ describe("API auth boundaries", () => {
     vi.resetModules();
     return import("./index").then((mod) => {
       const unicodeAuth = mod.authenticateIngest;
-      expect(unicodeAuth(makeReq("café-secret"), {} as Express.Response)).toBe(true);
-      expect(unicodeAuth(makeReq("cafe-secret"), {} as Express.Response)).toBe(false);
+      expect(unicodeAuth(makeReq("café-secret"), {} as Response)).toBe(true);
+      expect(unicodeAuth(makeReq("cafe-secret"), {} as Response)).toBe(false);
 
       // Restore the test secret for the deterministic crypto-path test below.
       vi.stubEnv("INGEST_API_TOKEN", "test-secret");
@@ -243,9 +243,9 @@ describe("API auth boundaries", () => {
         // Re-bind the describe-scoped binding to the re-imported function
         // so the crypto-path test sees the restored token.
         authenticateIngest = mod2.authenticateIngest;
-        expect(authenticateIngest(makeReq("test-secret"), {} as Express.Response)).toBe(true);
-        expect(authenticateIngest(makeReq("not-a-secr"), {} as Express.Response)).toBe(false);
-        expect(authenticateIngest(makeReq("X"), {} as Express.Response)).toBe(false);
+        expect(authenticateIngest(makeReq("test-secret"), {} as Response)).toBe(true);
+        expect(authenticateIngest(makeReq("not-a-secr"), {} as Response)).toBe(false);
+        expect(authenticateIngest(makeReq("X"), {} as Response)).toBe(false);
       });
     });
   });
@@ -255,8 +255,8 @@ describe("API auth boundaries", () => {
     // valid Bearer token must reach the same hash-and-compare path regardless
     // of its length or content. Wall-clock ratios are too sensitive to runner
     // contention to serve as a reliable correctness oracle.
-    const makeReq = (token: string): Express.Request =>
-      ({ headers: { authorization: `Bearer ${token}` } }) as unknown as Express.Request;
+    const makeReq = (token: string): Request =>
+      ({ headers: { authorization: `Bearer ${token}` } }) as unknown as Request;
 
     const digestToken = vi.fn((token: string) =>
       createHmac("sha256", token)
@@ -275,7 +275,7 @@ describe("API auth boundaries", () => {
 
     const tokens = ["", "X", "not-a-secr", "test-secret", "café-secret", "X".repeat(1000)];
     const results = tokens.map((token) =>
-      authenticate(makeReq(token), {} as Express.Response),
+      authenticate(makeReq(token), {} as Response),
     );
 
     expect(results).toEqual([false, false, false, true, false, false]);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,10 @@
     "isolatedModules": true,
     "noEmit": true,
     "moduleDetection": "force",
-    "types": ["node"]
+    // Browser code gets Vite client types (import.meta.env, CSS module
+    // declarations) but NOT Node globals — enforcing the ambient boundary.
+    "types": ["vite/client"]
   },
-  "include": ["src", "shared"]
+  "include": ["src", "shared"],
+  "exclude": ["**/*.test.ts", "**/*.test.tsx", "**/*.spec.ts", "**/*.spec.tsx", "src/test"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,5 +18,5 @@
     "types": ["vite/client"]
   },
   "include": ["src", "shared"],
-  "exclude": ["**/*.test.ts", "**/*.test.tsx", "**/*.spec.ts", "**/*.spec.tsx", "src/test"]
+  "exclude": ["**/*.test.*", "**/*.spec.*", "src/test"]
 }

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -7,16 +7,16 @@
     // Node/browser ambient boundary — code that uses process.cwd() in a
     // React component will fail typecheck there, catching the class of bug
     // that passes Vite's build but explodes at browser runtime.
-    "types": ["node", "vite/client"]
+    "types": ["node", "vite/client"],
+    // Server code uses Error.cause, while jsdom-backed client tests need DOM.
+    "lib": ["ES2020", "ES2022.Error", "DOM"]
   },
   "include": [
-    "src/**/*.test.ts",
-    "src/**/*.test.tsx",
-    "src/**/*.spec.ts",
-    "src/**/*.spec.tsx",
+    "**/*.test.*",
+    "**/*.spec.*",
     "src/test"
   ],
   // Override the parent's exclude (which strips test files from the browser
-  // config) so this config actually sees them.
-  "exclude": []
+  // config) while mirroring Vitest's repository-wide discovery boundaries.
+  "exclude": ["node_modules", "dist", ".worktrees"]
 }

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,22 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    // Test files run in Node (vitest + jsdom), so they legitimately need
+    // Node globals (process, Buffer, node:fs, etc.). The browser config
+    // (root tsconfig.json) intentionally omits these to enforce the
+    // Node/browser ambient boundary — code that uses process.cwd() in a
+    // React component will fail typecheck there, catching the class of bug
+    // that passes Vite's build but explodes at browser runtime.
+    "types": ["node", "vite/client"]
+  },
+  "include": [
+    "src/**/*.test.ts",
+    "src/**/*.test.tsx",
+    "src/**/*.spec.ts",
+    "src/**/*.spec.tsx",
+    "src/test"
+  ],
+  // Override the parent's exclude (which strips test files from the browser
+  // config) so this config actually sees them.
+  "exclude": []
+}


### PR DESCRIPTION
## What

Splits the single root `tsconfig.json` into a **browser** config and a **test** config to enforce the Node/browser ambient boundary.

Non-blocking follow-up from the #128 (TypeScript 7) review.

## Why

The root tsconfig carried `"types": ["node"]`, which exposed Node ambient globals (`process`, `Buffer`, `node:fs`, …) to browser-targeted source under `src/`. As flagged in the #128 review, this defeats the purpose of the boundary: code like `process.cwd()` in a React component **passed both `tsc --noEmit` and `vite build`**, then failed at browser runtime where those globals don't exist. Kilo's claim that "Vite catches it" was disproved by that evidence.

## How

- `tsconfig.json` (browser): `"types": ["vite/client"]` only — Vite client types (`import.meta.env`, CSS module declarations) but **no** Node globals. Test files excluded.
- `tsconfig.test.json` (new): extends root, re-enables `"types": ["node", "vite/client"]` for the vitest/jsdom test files that legitimately run in Node. Includes only test files + `src/test`; overrides the parent `exclude`.
- `package.json`: `typecheck` now runs both — `tsc --noEmit && tsc --noEmit -p tsconfig.test.json`.

## Verification

- Dual typecheck (browser + test): clean
- `vite build`: clean
- Full suite: **263/263** across 27 files
- Boundary probe (both directions):
  - `process.cwd()` in a browser component → **fails** browser typecheck with TS2591 ✅
  - same code in a `.test.ts` file → **passes** test typecheck ✅
- `git diff --check`: clean

## Summary by Sourcery

Split TypeScript configuration into separate browser and test configs to enforce a strict Node/browser ambient boundary and update typechecking to cover both targets.

Enhancements:
- Restrict the main tsconfig to Vite client types and exclude test files from browser-targeted compilation.
- Introduce tsconfig.test.json that re-enables Node and Vite client types for test files only and scopes its includes accordingly.
- Update the package typecheck script to run both browser and test TypeScript checks.