### PR TITLE
refactor(game): harden pure-module contracts with readonly types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ collector/.env.collector
 .codegraph/
 .cortexkit/
 .slim/
+
+# graphify analysis artifacts (never commit)
+graphify-out/

--- a/src/game/Schedule.test.ts
+++ b/src/game/Schedule.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest';
-import { getDayPhase } from './Schedule';
+import { describe, it, expect, expectTypeOf } from 'vitest';
+import { getDayPhase, DAY_PHASES, type DayPhase } from './Schedule';
 
 describe('Schedule.getDayPhase', () => {
   it('returns exact Morning values at progress=0', () => {
@@ -60,5 +60,30 @@ describe('Schedule.getDayPhase', () => {
     expect(phase.alpha.toString()).toMatch(/^0\.135$/);
     // And the overlay string embeds the formatted alpha
     expect(phase.overlay).toContain('0.135');
+  });
+});
+
+describe('Schedule pure-module contract (issue #82)', () => {
+  it('DAY_PHASES is an immutable readonly table (compile-time contract)', () => {
+    // Compile-time: DAY_PHASES must be a readonly array. If it is ever
+    // reverted to a mutable DayPhase[], this assertion fails `tsc --noEmit`
+    // (test files are typechecked via tsconfig.test.json — see #129).
+    expectTypeOf(DAY_PHASES).toEqualTypeOf<readonly DayPhase[]>();
+    // Runtime: the table is the fixed 7-phase schedule.
+    expect(DAY_PHASES).toHaveLength(7);
+    expect(DAY_PHASES[0].label).toBe('Morning');
+    expect(DAY_PHASES[DAY_PHASES.length - 1].label).toBe('Late Night');
+  });
+
+  it('getDayPhase returns a fresh object per call (no shared aliasing)', () => {
+    const a = getDayPhase(0.3);
+    const b = getDayPhase(0.3);
+    expect(a).toEqual(b);
+    expect(a).not.toBe(b); // distinct references, not a shared cached object
+    a.light = -999;
+    a.r = -1;
+    const c = getDayPhase(0.3);
+    expect(c.light).not.toBe(-999); // module state is unaffected by mutation
+    expect(c.r).not.toBe(-1);
   });
 });

--- a/src/game/Schedule.test.ts
+++ b/src/game/Schedule.test.ts
@@ -64,7 +64,7 @@ describe('Schedule.getDayPhase', () => {
 });
 
 describe('Schedule pure-module contract (issue #82)', () => {
-  it('DAY_PHASES is an immutable readonly table (compile-time contract)', () => {
+  it('DAY_PHASES is a shallow-readonly table (compile-time contract)', () => {
     // Compile-time: DAY_PHASES must be a readonly array. If it is ever
     // reverted to a mutable DayPhase[], this assertion fails `tsc --noEmit`
     // (test files are typechecked via tsconfig.test.json — see #129).

--- a/src/game/Schedule.ts
+++ b/src/game/Schedule.ts
@@ -21,7 +21,9 @@ interface ParsedDayPhase {
   label: string;
 }
 
-export const DAY_PHASES: DayPhase[] = [
+// `readonly` enforces the pure-module contract at compile time: the phase
+// table is shared module state and must never be mutated by consumers (issue #82).
+export const DAY_PHASES: readonly DayPhase[] = [
   { overlay: 'rgba(255, 200, 100, 0.06)', light: 0.95, label: 'Morning' },
   { overlay: 'rgba(255, 255, 240, 0.02)', light: 1.0, label: 'Midday' },
   { overlay: 'rgba(255, 160, 60, 0.08)', light: 0.9, label: 'Afternoon' },
@@ -31,7 +33,7 @@ export const DAY_PHASES: DayPhase[] = [
   { overlay: 'rgba(15, 10, 40, 0.3)', light: 0.25, label: 'Late Night' },
 ];
 
-const PARSED_PHASES: ParsedDayPhase[] = DAY_PHASES.map(p => {
+const PARSED_PHASES: readonly ParsedDayPhase[] = DAY_PHASES.map(p => {
   const [r, g, b, a] = parseRgbaStatic(p.overlay);
   return { r, g, b, a, light: p.light, label: p.label };
 });

--- a/src/game/Schedule.ts
+++ b/src/game/Schedule.ts
@@ -21,8 +21,10 @@ interface ParsedDayPhase {
   label: string;
 }
 
-// `readonly` enforces the pure-module contract at compile time: the phase
-// table is shared module state and must never be mutated by consumers (issue #82).
+// `readonly` enforces array-shape immutability at compile time: the table
+// cannot be reassigned or structurally mutated (push/splice/index-assign).
+// Element fields (DayPhase.overlay, .light, .label) remain mutable under
+// shallow readonly — deep-freezing is tracked in #132 (follow-up to #82).
 export const DAY_PHASES: readonly DayPhase[] = [
   { overlay: 'rgba(255, 200, 100, 0.06)', light: 0.95, label: 'Morning' },
   { overlay: 'rgba(255, 255, 240, 0.02)', light: 1.0, label: 'Midday' },

--- a/src/game/Schedule.ts
+++ b/src/game/Schedule.ts
@@ -24,7 +24,7 @@ interface ParsedDayPhase {
 // `readonly` enforces array-shape immutability at compile time: the table
 // cannot be reassigned or structurally mutated (push/splice/index-assign).
 // Element fields (DayPhase.overlay, .light, .label) remain mutable under
-// shallow readonly — deep-freezing is tracked in #132 (follow-up to #82).
+// shallow readonly — deep-readonly typing (readonly fields / DeepReadonly) is tracked in #132.
 export const DAY_PHASES: readonly DayPhase[] = [
   { overlay: 'rgba(255, 200, 100, 0.06)', light: 0.95, label: 'Morning' },
   { overlay: 'rgba(255, 255, 240, 0.02)', light: 1.0, label: 'Midday' },

--- a/src/game/SubAgentFSM.test.ts
+++ b/src/game/SubAgentFSM.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest';
-import { tickSubAgent, SUBAGENT_FADE_DURATION } from './SubAgentFSM';
+import { describe, it, expect, expectTypeOf } from 'vitest';
+import { tickSubAgent, SUBAGENT_FADE_DURATION, type SubAgentInput } from './SubAgentFSM';
 
 describe('tickSubAgent', () => {
   it('returns fadeAlpha unchanged, dying=false, shouldRemove=false for a live sub-agent', () => {
@@ -62,5 +62,27 @@ describe('tickSubAgent', () => {
 describe('SUBAGENT_FADE_DURATION constant', () => {
   it('is 2000ms', () => {
     expect(SUBAGENT_FADE_DURATION).toBe(2_000);
+  });
+});
+
+describe('tickSubAgent pure-module contract (issue #82)', () => {
+  it('accepts a Readonly input (compile-time no-mutation contract)', () => {
+    // tickSubAgent must take Readonly<SubAgentInput>: the planner reads its
+    // input and never mutates the caller's character. Reverting the parameter
+    // to a mutable SubAgentInput makes this assertion fail `tsc --noEmit`.
+    expectTypeOf(tickSubAgent).parameter(0).toEqualTypeOf<Readonly<SubAgentInput>>();
+  });
+
+  it('returns a fresh tick per call (no shared reference)', () => {
+    // Guards against the stale EMPTY_ACTIONS shared-return pattern: each call
+    // must yield a distinct tick object, and mutating one must not alias state
+    // observed by a later call.
+    const t1 = tickSubAgent({ dying: true, fadeAlpha: 1 }, 0.5);
+    const t2 = tickSubAgent({ dying: true, fadeAlpha: 1 }, 0.5);
+    expect(t1).toEqual(t2);
+    expect(t1).not.toBe(t2);
+    t1.fadeAlpha = -42;
+    const t3 = tickSubAgent({ dying: true, fadeAlpha: 1 }, 0.5);
+    expect(t3.fadeAlpha).not.toBe(-42);
   });
 });

--- a/src/game/SubAgentFSM.test.ts
+++ b/src/game/SubAgentFSM.test.ts
@@ -74,9 +74,11 @@ describe('tickSubAgent pure-module contract (issue #82)', () => {
   });
 
   it('returns a fresh tick per call (no shared reference)', () => {
-    // Guards against the stale EMPTY_ACTIONS shared-return pattern: each call
-    // must yield a distinct tick object, and mutating one must not alias state
-    // observed by a later call.
+    // Top-level freshness guard: each call returns a distinct tick object, and
+    // mutating a returned tick does not alias state seen by a later call. This
+    // pins top-level non-aliasing only — the historical EMPTY_ACTIONS bug was a
+    // shared *nested* actions array (removed in #102), which this test would not
+    // detect; that field no longer exists.
     const t1 = tickSubAgent({ dying: true, fadeAlpha: 1 }, 0.5);
     const t2 = tickSubAgent({ dying: true, fadeAlpha: 1 }, 0.5);
     expect(t1).toEqual(t2);

--- a/src/game/SubAgentFSM.ts
+++ b/src/game/SubAgentFSM.ts
@@ -21,8 +21,11 @@ export interface SubAgentTick {
   shouldRemove: boolean;
 }
 
+// `Readonly<SubAgentInput>` makes the pure-planner contract compiler-enforced:
+// tickSubAgent reads its input and returns a fresh tick, never mutating the
+// caller's character (issue #82).
 export function tickSubAgent(
-  char: SubAgentInput,
+  char: Readonly<SubAgentInput>,
   dtSec: number,
 ): SubAgentTick {
   if (!char.dying) {

--- a/src/game/inputGeometry.test.ts
+++ b/src/game/inputGeometry.test.ts
@@ -1,6 +1,6 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, expectTypeOf, it } from 'vitest';
 
-import { screenToGrid, touchDistance, type CanvasMetrics } from './inputGeometry';
+import { screenToGrid, touchDistance, type CanvasMetrics, type ClientPoint } from './inputGeometry';
 
 const BASE_METRICS: CanvasMetrics = {
   rect: { left: 10, top: 20, width: 240, height: 160 },
@@ -51,5 +51,18 @@ describe('screenToGrid', () => {
 describe('touchDistance', () => {
   it('returns Euclidean distance between client points', () => {
     expect(touchDistance({ clientX: 1, clientY: 2 }, { clientX: 4, clientY: 6 })).toBe(5);
+  });
+});
+
+describe('inputGeometry pure-module contract (issue #82)', () => {
+  it('screenToGrid accepts Readonly<CanvasMetrics> (compile-time no-mutation contract)', () => {
+    // Reverting screenToGrid's metrics param to mutable CanvasMetrics makes this
+    // fail `tsc --noEmit` (test files are typechecked via tsconfig.test.json — #129).
+    expectTypeOf(screenToGrid).parameter(2).toEqualTypeOf<Readonly<CanvasMetrics>>();
+  });
+
+  it('touchDistance accepts Readonly<ClientPoint> for both params (compile-time no-mutation contract)', () => {
+    expectTypeOf(touchDistance).parameter(0).toEqualTypeOf<Readonly<ClientPoint>>();
+    expectTypeOf(touchDistance).parameter(1).toEqualTypeOf<Readonly<ClientPoint>>();
   });
 });

--- a/src/game/inputGeometry.ts
+++ b/src/game/inputGeometry.ts
@@ -25,8 +25,8 @@ export interface GridPoint {
 /** Map client coordinates into the canvas grid, accounting for object-fit bars. */
 // `Readonly<CanvasMetrics>` enforces top-level immutability at compile time:
 // screenToGrid cannot reassign metrics.rect, .canvasWidth, etc. Nested fields
-// (e.g. metrics.rect.left) remain mutable under shallow Readonly — deep-freezing
-// is tracked in #132 (follow-up to #82).
+// (e.g. metrics.rect.left) remain mutable under shallow Readonly — deep-readonly
+// typing (a DeepReadonly type) is tracked in #132.
 export function screenToGrid(
   clientX: number,
   clientY: number,

--- a/src/game/inputGeometry.ts
+++ b/src/game/inputGeometry.ts
@@ -23,8 +23,10 @@ export interface GridPoint {
 }
 
 /** Map client coordinates into the canvas grid, accounting for object-fit bars. */
-// `Readonly<CanvasMetrics>` enforces the pure-helper contract: screenToGrid
-// reads its inputs and returns a fresh GridPoint, never mutating them (issue #82).
+// `Readonly<CanvasMetrics>` enforces top-level immutability at compile time:
+// screenToGrid cannot reassign metrics.rect, .canvasWidth, etc. Nested fields
+// (e.g. metrics.rect.left) remain mutable under shallow Readonly — deep-freezing
+// is tracked in #132 (follow-up to #82).
 export function screenToGrid(
   clientX: number,
   clientY: number,

--- a/src/game/inputGeometry.ts
+++ b/src/game/inputGeometry.ts
@@ -23,10 +23,12 @@ export interface GridPoint {
 }
 
 /** Map client coordinates into the canvas grid, accounting for object-fit bars. */
+// `Readonly<CanvasMetrics>` enforces the pure-helper contract: screenToGrid
+// reads its inputs and returns a fresh GridPoint, never mutating them (issue #82).
 export function screenToGrid(
   clientX: number,
   clientY: number,
-  metrics: CanvasMetrics,
+  metrics: Readonly<CanvasMetrics>,
 ): GridPoint | null {
   const { rect, canvasWidth, canvasHeight, tileSize } = metrics;
   const cssRatio = rect.width / rect.height;
@@ -67,7 +69,7 @@ export function screenToGrid(
 }
 
 /** Euclidean distance between two client-coordinate points. */
-export function touchDistance(a: ClientPoint, b: ClientPoint): number {
+export function touchDistance(a: Readonly<ClientPoint>, b: Readonly<ClientPoint>): number {
   const dx = a.clientX - b.clientX;
   const dy = a.clientY - b.clientY;
   return Math.sqrt(dx * dx + dy * dy);


### PR DESCRIPTION
Closes #82.

<!-- kody-pr-summary:start -->
## Summary

Hardens the pure modules extracted in #51 with `readonly` types, enforcing the architectural guarantee **"pure — no mutation of inputs"** at compile time. Zero runtime behavior change (`readonly`/`Readonly<>` are erased at compile time; the base-vs-head production build is byte-identical).

## Pure-module type hardening

| Module | Change |
|---|---|
| `Schedule.ts` | `DAY_PHASES` and `PARSED_PHASES` → `readonly` arrays |
| `SubAgentFSM.ts` | `tickSubAgent(char: Readonly<SubAgentInput>)` |
| `inputGeometry.ts` | `screenToGrid(metrics: Readonly<CanvasMetrics>)`, `touchDistance(a/b: Readonly<ClientPoint>)` |

`EditorController` (a stateful class with intentionally-mutable instance state) is deliberately excluded.

## Stale finding resolved

Issue #82's second finding — a shared mutable `EMPTY_ACTIONS` array in `SubAgentFSM` — no longer exists: the FSM was refactored in #102 to return a **fresh tick per call**, removing the `actions` field entirely. This PR hardens the **input** (`Readonly<SubAgentInput>`) and adds a behavioral "fresh tick per call" test pinning top-level non-aliasing. (Note: that test pins *top-level* freshness only — the historical bug was a shared *nested* `actions` array, which the field's removal already eliminates.)

## Regression protection (compile-time `expectTypeOf` guards + behavioral tests)

All three modules now have symmetric `expectTypeOf` compile-time guards that fail `tsc --noEmit` (enforced via the test tsconfig from #129) if the readonly contract is reverted:
- `Schedule.test.ts` — `DAY_PHASES` is `readonly DayPhase[]`.
- `SubAgentFSM.test.ts` — `tickSubAgent` param 0 is `Readonly<SubAgentInput>`.
- `inputGeometry.test.ts` — `screenToGrid` param 2 is `Readonly<CanvasMetrics>`; `touchDistance` params 0 and 1 are `Readonly<ClientPoint>`.

Plus no-aliasing behavioral tests: `getDayPhase` and `tickSubAgent` each return a fresh object per call; mutating a returned object does not poison subsequent calls.

## Verification

- ✅ Dual typecheck (browser + test configs): clean
- ✅ Full suite: **269/269** across 27 files
- ✅ Build: clean; base-vs-head `dist/` byte-identical (no runtime change)
- ✅ `git diff --check origin/main...HEAD`: clean

## Independent review

Sophie's independent review (head `2ba0a12`): **merge-ready, three non-blocking P3 findings** — all three are addressed in this head: (1) the SubAgentFSM no-aliasing comment now accurately describes a top-level freshness guard; (2) `inputGeometry` gained the `expectTypeOf` input-readonly regression oracle (negative-control-confirmed gap closed); (3) shallow-vs-deep readonly terminology corrected in the source comments (deep-readonly *typing*, not runtime `Object.freeze`) and in this body. Two fresh-context adversarial reviews also returned MERGE-READY with zero blockers.

## Non-blocking follow-ups (tracked, not in this PR)

1. **#132 — deep-readonly typing:** `DayPhase`/`ParsedDayPhase`/`CanvasMetrics` element/nested fields remain mutable under shallow `readonly`/`Readonly<>` (compile-time array-shape only; `Object.isFrozen(DAY_PHASES) === false`). Closing that needs `readonly` interface fields or a `DeepReadonly` type. This is compile-time deep-readonly *typing*, not runtime `Object.freeze`.
2. **SubAgentFSM `dying: false` branch coverage** — the no-aliasing test exercises the `dying: true` fade path; the `dying: false` early-return branch is not separately pinned (Kilo).
3. **(Separate ticket)** `CharacterComposer.DEFAULT_RECIPES` and `SpriteLoader` cache getters return shared mutable references — not #51 pure modules.
<!-- kody-pr-summary:end -->
