### PR TITLE
fix(collector): bound execution and require secure transport (#99)

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,11 +124,12 @@ Just run it on the same machine as OpenClaw. No extra configuration needed.
 
 1. Set `DATA_SOURCE=ingest` and `INGEST_API_TOKEN=<secret>` on the pixel-agents server
 2. On the OpenClaw host, copy `collector/.env.collector.example` to `.env.collector` and configure:
-   - `PIXEL_AGENTS_URL` — URL of the pixel-agents server
+   - `PIXEL_AGENTS_URL` — HTTPS URL of the pixel-agents server (loopback HTTP is allowed for local development)
    - `PIXEL_INGEST_TOKEN` — same secret as `INGEST_API_TOKEN`
+   - `OPENCLAW_BIN` — absolute path returned by `command -v openclaw`
 3. Install the systemd timer from `collector/systemd/`:
    ```bash
-   # Edit the .service file to match your install path
+   # Edit User and all installation paths in the .service file first
    sudo cp collector/systemd/openclaw-pixel-collector.* /etc/systemd/system/
    sudo systemctl daemon-reload
    sudo systemctl enable --now openclaw-pixel-collector.timer

--- a/collector/.env.collector.example
+++ b/collector/.env.collector.example
@@ -1,11 +1,15 @@
 # Collector configuration
 # Copy this to .env.collector and fill in the values.
 
-# URL of the pixel-agents server (required)
-PIXEL_AGENTS_URL=http://your-server:3000
+# URL of the pixel-agents server (required).
+# Remote servers must use HTTPS. Plain HTTP is accepted only on loopback.
+PIXEL_AGENTS_URL=https://pixel-agents.example.com
 
 # Shared secret — must match INGEST_API_TOKEN on the server (required)
 PIXEL_INGEST_TOKEN=change-me
+
+# Absolute path from `command -v openclaw` (required)
+OPENCLAW_BIN=/usr/local/bin/openclaw
 
 # How many minutes back to consider sessions "active" (optional, default 30)
 # ACTIVE_MINUTES=30

--- a/collector/README.md
+++ b/collector/README.md
@@ -7,7 +7,7 @@ The collector reads live OpenClaw sessions on the OpenClaw host and sends them t
 - A Node.js version allowed by the repository's `package.json#engines`
 - A non-root OS account that can read the required OpenClaw state
 - The absolute paths returned by `command -v node` and `command -v openclaw`
-- HTTPS access to the pixel-agents server; plain HTTP is accepted only for `localhost`, `127.0.0.0/8`, and `::1`
+- HTTPS access to the pixel-agents server; plain HTTP is accepted only for `localhost`, `127.0.0.0/8`, and `::1`. Ingest redirects are rejected, so configure the final server URL directly.
 
 ## Configure the collector
 

--- a/collector/README.md
+++ b/collector/README.md
@@ -1,35 +1,72 @@
 # Collector
 
-Pushes live OpenClaw session data to a remote pixel-agents server running in `ingest` mode.
-
-## Setup
-
-1. Copy `.env.collector.example` to `.env.collector` and fill in your values:
-   ```bash
-   cp .env.collector.example .env.collector
-   nano .env.collector
-   ```
-
-2. Test it:
-   ```bash
-   set -a; source .env.collector; set +a
-   node collector/push-pixel-agents.mjs --dry-run
-   ```
-
-3. Install the systemd timer (adjust paths in the `.service` file first):
-   ```bash
-   sudo cp collector/systemd/openclaw-pixel-collector.* /etc/systemd/system/
-   sudo systemctl daemon-reload
-   sudo systemctl enable --now openclaw-pixel-collector.timer
-   ```
-
-4. Verify:
-   ```bash
-   sudo journalctl -u openclaw-pixel-collector.service -n 5
-   ```
+The collector reads live OpenClaw sessions on the OpenClaw host and sends them to a pixel-agents server running in `ingest` mode. CLI collection and HTTP delivery are each limited to 10 seconds, with a 30-second systemd limit as the outer recovery boundary.
 
 ## Requirements
 
-- `openclaw` CLI available in PATH on the host machine
-- Node.js 20+
-- Network access to the pixel-agents server
+- A Node.js version allowed by the repository's `package.json#engines`
+- A non-root OS account that can read the required OpenClaw state
+- The absolute paths returned by `command -v node` and `command -v openclaw`
+- HTTPS access to the pixel-agents server; plain HTTP is accepted only for `localhost`, `127.0.0.0/8`, and `::1`
+
+## Configure the collector
+
+1. Create a private local configuration for the dry run:
+
+   ```bash
+   install -m 0600 collector/.env.collector.example collector/.env.collector
+   ${EDITOR:-nano} collector/.env.collector
+   ```
+
+2. Set these required values:
+
+   - `PIXEL_AGENTS_URL`: HTTPS URL of the pixel-agents server. For local development only, loopback HTTP is allowed.
+   - `PIXEL_INGEST_TOKEN`: shared secret matching the server's `INGEST_API_TOKEN`.
+   - `OPENCLAW_BIN`: absolute, reviewed path returned by `command -v openclaw`. The collector does not resolve this executable through `PATH`.
+
+   `ACTIVE_MINUTES` is optional and defaults to `30`.
+
+3. Test the configuration as the same account that will run the service:
+
+   ```bash
+   set -a
+   source collector/.env.collector
+   set +a
+   node collector/push-pixel-agents.mjs --dry-run
+   ```
+
+   Dry-run mode still executes the OpenClaw CLI and validates the destination, but does not send the token or payload.
+
+## Install the systemd timer
+
+The checked-in unit is a portable template with generic `/opt` and `/etc` paths. Before installing it, edit a copy and set:
+
+- `User` to the non-root account that owns the OpenClaw state. Do not use `root`.
+- `WorkingDirectory` and the script path in `ExecStart` to this repository's absolute path.
+- `EnvironmentFile` to the protected configuration file created above.
+- The absolute Node executable in `ExecStart` if `command -v node` is not `/usr/bin/node`.
+
+Do not set `HOME` manually. systemd derives it from `User`, keeping the unit portable across home-directory layouts.
+
+```bash
+sudo install -d -m 0750 /etc/openclaw-pixel-agents
+sudo install -m 0600 collector/.env.collector /etc/openclaw-pixel-agents/collector.env
+cp collector/systemd/openclaw-pixel-collector.service /tmp/openclaw-pixel-collector.service
+sudoedit /tmp/openclaw-pixel-collector.service
+sudo install -m 0644 /tmp/openclaw-pixel-collector.service /etc/systemd/system/
+sudo install -m 0644 collector/systemd/openclaw-pixel-collector.timer /etc/systemd/system/
+sudo systemd-analyze verify /etc/systemd/system/openclaw-pixel-collector.service /etc/systemd/system/openclaw-pixel-collector.timer
+sudo systemctl daemon-reload
+sudo systemctl enable --now openclaw-pixel-collector.timer
+```
+
+The service includes conservative hardening that preserves the OpenClaw CLI's access to its owning account's home directory and allows only Unix, IPv4, and IPv6 sockets. Review additional restrictions with `systemd-analyze security openclaw-pixel-collector.service` on the deployment host before tightening filesystem access.
+
+## Verify operation
+
+```bash
+systemctl status openclaw-pixel-collector.timer
+sudo journalctl -u openclaw-pixel-collector.service -n 20
+```
+
+A hung CLI is killed after 10 seconds, a stalled HTTP request aborts after 10 seconds, and systemd stops any unexpected overrun after 30 seconds. The next timer activation can then proceed instead of remaining blocked indefinitely.

--- a/collector/README.md
+++ b/collector/README.md
@@ -1,6 +1,6 @@
 # Collector
 
-The collector reads live OpenClaw sessions on the OpenClaw host and sends them to a pixel-agents server running in `ingest` mode. CLI collection and HTTP delivery are each limited to 10 seconds, with a 30-second systemd limit as the outer recovery boundary.
+The collector reads live OpenClaw sessions on the OpenClaw host and sends them to a pixel-agents server running in `ingest` mode. CLI collection and HTTP delivery are each limited to 10 seconds. systemd begins terminating an unexpected overrun after 25 seconds and force-stops the complete control group within 5 more seconds.
 
 ## Requirements
 
@@ -45,6 +45,7 @@ The checked-in unit is a portable template with generic `/opt` and `/etc` paths.
 - `WorkingDirectory` and the script path in `ExecStart` to this repository's absolute path.
 - `EnvironmentFile` to the protected configuration file created above.
 - The absolute Node executable in `ExecStart` if `command -v node` is not `/usr/bin/node`.
+- The first directory in `Environment=PATH` to `dirname "$(command -v node)"`. Keep only that reviewed Node directory plus the minimal system directories needed by OpenClaw. This is required when the `openclaw` launcher uses `#!/usr/bin/env node`.
 
 Do not set `HOME` manually. systemd derives it from `User`, keeping the unit portable across home-directory layouts.
 
@@ -69,4 +70,4 @@ systemctl status openclaw-pixel-collector.timer
 sudo journalctl -u openclaw-pixel-collector.service -n 20
 ```
 
-A hung CLI is killed after 10 seconds, a stalled HTTP request aborts after 10 seconds, and systemd stops any unexpected overrun after 30 seconds. The next timer activation can then proceed instead of remaining blocked indefinitely.
+A hung CLI is killed after 10 seconds and a stalled HTTP request aborts after 10 seconds. If either mechanism fails unexpectedly, systemd begins termination after 25 seconds, gives the full service control group 5 seconds to stop, and then sends SIGKILL. The next timer activation can then proceed instead of remaining blocked indefinitely.

--- a/collector/push-pixel-agents.mjs
+++ b/collector/push-pixel-agents.mjs
@@ -155,7 +155,6 @@ export async function runCollector({
   if (dryRun) {
     stdout("[dry-run] Would POST to:", ingestEndpoint.href);
     stdout("[dry-run] Payload sessions:", sessions.length);
-    stdout(JSON.stringify(payload, null, 2));
     return;
   }
 

--- a/collector/push-pixel-agents.mjs
+++ b/collector/push-pixel-agents.mjs
@@ -14,14 +14,20 @@
  *   node collector/push-pixel-agents.mjs
  *
  * Required env vars:
- *   PIXEL_AGENTS_URL   — e.g. http://your-server:3000
+ *   PIXEL_AGENTS_URL   — HTTPS server URL, or loopback HTTP for local testing
  *   PIXEL_INGEST_TOKEN — shared secret matching the server's INGEST_API_TOKEN
+ *   OPENCLAW_BIN       — absolute path to the reviewed OpenClaw executable
  *
  * Optional:
  *   ACTIVE_MINUTES     — --active threshold (default 30)
  */
 
 import { execFileSync } from "node:child_process";
+import { isAbsolute } from "node:path";
+import { pathToFileURL } from "node:url";
+
+export const OPENCLAW_TIMEOUT_MS = 10_000;
+export const INGEST_TIMEOUT_MS = 10_000;
 
 function parseArgs(argv) {
   const args = { dryRun: false };
@@ -31,19 +37,49 @@ function parseArgs(argv) {
   return args;
 }
 
-async function main() {
-  const { dryRun } = parseArgs(process.argv.slice(2));
+function isLoopbackHostname(hostname) {
+  const normalized = hostname.toLowerCase().replace(/^\[|\]$/g, "");
+  if (normalized === "localhost" || normalized === "::1") return true;
 
-  const pixelUrl = process.env.PIXEL_AGENTS_URL;
-  const ingestToken = process.env.PIXEL_INGEST_TOKEN;
-  const activeMinutes = process.env.ACTIVE_MINUTES || "30";
+  const octets = normalized.split(".");
+  if (octets.length !== 4 || octets.some((octet) => !/^\d{1,3}$/.test(octet))) {
+    return false;
+  }
 
-  if (!pixelUrl) throw new Error("Missing PIXEL_AGENTS_URL env var");
-  if (!ingestToken) throw new Error("Missing PIXEL_INGEST_TOKEN env var");
+  const numbers = octets.map(Number);
+  return numbers[0] === 127 && numbers.every((octet) => octet <= 255);
+}
 
-  // Fetch live session data from OpenClaw
-  console.error("Fetching OpenClaw sessions...");
-  const raw = execFileSync("openclaw", [
+export function getIngestEndpoint(pixelUrl) {
+  let endpoint;
+  try {
+    endpoint = new URL(pixelUrl);
+  } catch {
+    throw new Error("PIXEL_AGENTS_URL must be a valid absolute URL");
+  }
+
+  if (endpoint.username || endpoint.password) {
+    throw new Error("PIXEL_AGENTS_URL must not contain credentials");
+  }
+
+  const loopbackHttp = endpoint.protocol === "http:" && isLoopbackHostname(endpoint.hostname);
+  if (endpoint.protocol !== "https:" && !loopbackHttp) {
+    throw new Error("PIXEL_AGENTS_URL must use HTTPS; HTTP is allowed only for localhost, 127.0.0.0/8, or ::1");
+  }
+
+  endpoint.pathname = `${endpoint.pathname.replace(/\/+$/, "")}/api/ingest/agents`;
+  endpoint.search = "";
+  endpoint.hash = "";
+  return endpoint;
+}
+
+export function fetchOpenClawSessions({
+  openclawBin,
+  activeMinutes,
+  execFile = execFileSync,
+  timeoutMs = OPENCLAW_TIMEOUT_MS,
+}) {
+  const raw = execFile(openclawBin, [
     "sessions",
     "--all-agents",
     "--json",
@@ -51,46 +87,97 @@ async function main() {
   ], {
     encoding: "utf8",
     maxBuffer: 10 * 1024 * 1024,
+    timeout: timeoutMs,
+    killSignal: "SIGKILL",
   });
 
   const data = JSON.parse(raw);
-  const sessions = data.sessions || [];
+  return data.sessions || [];
+}
 
-  console.error(`Found ${sessions.length} active sessions`);
-
-  const payload = {
-    sessions,
-    generatedAt: new Date().toISOString(),
-  };
-
-  if (dryRun) {
-    console.log("[dry-run] Would POST to:", `${pixelUrl}/api/ingest/agents`);
-    console.log("[dry-run] Payload sessions:", sessions.length);
-    console.log(JSON.stringify(payload, null, 2));
-    return;
-  }
-
-  const ingestEndpoint = `${pixelUrl.replace(/\/$/, "")}/api/ingest/agents`;
-
-  const response = await fetch(ingestEndpoint, {
+export async function postSnapshot({
+  endpoint,
+  ingestToken,
+  payload,
+  fetchImpl = fetch,
+  timeoutMs = INGEST_TIMEOUT_MS,
+}) {
+  const response = await fetchImpl(endpoint, {
     method: "POST",
     headers: {
       "content-type": "application/json",
       authorization: `Bearer ${ingestToken}`,
     },
     body: JSON.stringify(payload),
+    signal: AbortSignal.timeout(timeoutMs),
   });
 
   const result = await response.json().catch(() => ({}));
-
   if (!response.ok) {
     throw new Error(`Ingest failed (${response.status}): ${JSON.stringify(result)}`);
   }
 
-  console.log(`Pixel agents ingest OK: ${result.agents} agents from ${result.received} sessions`);
+  return result;
 }
 
-main().catch((error) => {
-  console.error("Pixel agents collector failed:", error.message);
-  process.exitCode = 1;
-});
+export async function runCollector({
+  argv = process.argv.slice(2),
+  env = process.env,
+  execFile = execFileSync,
+  fetchImpl = fetch,
+  now = () => new Date(),
+  stdout = console.log,
+  stderr = console.error,
+} = {}) {
+  const { dryRun } = parseArgs(argv);
+
+  const pixelUrl = env.PIXEL_AGENTS_URL;
+  const ingestToken = env.PIXEL_INGEST_TOKEN;
+  const openclawBin = env.OPENCLAW_BIN;
+  const activeMinutes = env.ACTIVE_MINUTES || "30";
+
+  if (!pixelUrl) throw new Error("Missing PIXEL_AGENTS_URL env var");
+  if (!ingestToken) throw new Error("Missing PIXEL_INGEST_TOKEN env var");
+  if (!openclawBin) throw new Error("Missing OPENCLAW_BIN env var");
+  if (!isAbsolute(openclawBin)) throw new Error("OPENCLAW_BIN must be an absolute path");
+
+  const ingestEndpoint = getIngestEndpoint(pixelUrl);
+
+  // Fetch live session data from OpenClaw
+  stderr("Fetching OpenClaw sessions...");
+  const sessions = fetchOpenClawSessions({
+    openclawBin,
+    activeMinutes,
+    execFile,
+  });
+
+  stderr(`Found ${sessions.length} active sessions`);
+
+  const payload = {
+    sessions,
+    generatedAt: now().toISOString(),
+  };
+
+  if (dryRun) {
+    stdout("[dry-run] Would POST to:", ingestEndpoint.href);
+    stdout("[dry-run] Payload sessions:", sessions.length);
+    stdout(JSON.stringify(payload, null, 2));
+    return;
+  }
+
+  const result = await postSnapshot({
+    endpoint: ingestEndpoint,
+    ingestToken,
+    payload,
+    fetchImpl,
+  });
+
+  stdout(`Pixel agents ingest OK: ${result.agents} agents from ${result.received} sessions`);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  runCollector().catch((error) => {
+    console.error("Pixel agents collector failed:", error.message);
+    process.exitCode = 1;
+  });
+}

--- a/collector/push-pixel-agents.mjs
+++ b/collector/push-pixel-agents.mjs
@@ -25,7 +25,6 @@
 import { execFileSync } from "node:child_process";
 import { isIP } from "node:net";
 import { isAbsolute } from "node:path";
-import { pathToFileURL } from "node:url";
 
 export const OPENCLAW_TIMEOUT_MS = 10_000;
 export const INGEST_TIMEOUT_MS = 10_000;
@@ -70,9 +69,13 @@ export function getIngestEndpoint(pixelUrl) {
 export function fetchOpenClawSessions({
   openclawBin,
   activeMinutes,
+  env = process.env,
   execFile = execFileSync,
   timeoutMs = OPENCLAW_TIMEOUT_MS,
 }) {
+  const childEnv = { ...env };
+  delete childEnv.PIXEL_INGEST_TOKEN;
+
   const raw = execFile(openclawBin, [
     "sessions",
     "--all-agents",
@@ -83,10 +86,14 @@ export function fetchOpenClawSessions({
     maxBuffer: 10 * 1024 * 1024,
     timeout: timeoutMs,
     killSignal: "SIGKILL",
+    env: childEnv,
   });
 
   const data = JSON.parse(raw);
-  return data.sessions || [];
+  if (!Array.isArray(data?.sessions)) {
+    throw new Error("OpenClaw sessions JSON must contain a sessions array");
+  }
+  return data.sessions;
 }
 
 export async function postSnapshot({
@@ -104,9 +111,16 @@ export async function postSnapshot({
     },
     body: JSON.stringify(payload),
     signal: AbortSignal.timeout(timeoutMs),
+    redirect: "error",
   });
 
-  const result = await response.json().catch(() => ({}));
+  let result;
+  try {
+    result = await response.json();
+  } catch (error) {
+    if (response.ok) throw error;
+    result = {};
+  }
   if (!response.ok) {
     throw new Error(`Ingest failed (${response.status}): ${JSON.stringify(result)}`);
   }
@@ -142,6 +156,7 @@ export async function runCollector({
   const sessions = fetchOpenClawSessions({
     openclawBin,
     activeMinutes,
+    env,
     execFile,
   });
 
@@ -168,7 +183,7 @@ export async function runCollector({
   stdout(`Pixel agents ingest OK: ${result.agents} agents from ${result.received} sessions`);
 }
 
-if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+if (import.meta.main) {
   runCollector().catch((error) => {
     console.error("Pixel agents collector failed:", error.message);
     process.exitCode = 1;

--- a/collector/push-pixel-agents.mjs
+++ b/collector/push-pixel-agents.mjs
@@ -23,6 +23,7 @@
  */
 
 import { execFileSync } from "node:child_process";
+import { isIP } from "node:net";
 import { isAbsolute } from "node:path";
 import { pathToFileURL } from "node:url";
 
@@ -40,14 +41,7 @@ function parseArgs(argv) {
 function isLoopbackHostname(hostname) {
   const normalized = hostname.toLowerCase().replace(/^\[|\]$/g, "");
   if (normalized === "localhost" || normalized === "::1") return true;
-
-  const octets = normalized.split(".");
-  if (octets.length !== 4 || octets.some((octet) => !/^\d{1,3}$/.test(octet))) {
-    return false;
-  }
-
-  const numbers = octets.map(Number);
-  return numbers[0] === 127 && numbers.every((octet) => octet <= 255);
+  return isIP(normalized) === 4 && Number(normalized.split(".", 1)[0]) === 127;
 }
 
 export function getIngestEndpoint(pixelUrl) {

--- a/collector/push-pixel-agents.test.mjs
+++ b/collector/push-pixel-agents.test.mjs
@@ -1,0 +1,136 @@
+import { chmod, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { createServer } from "node:http";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  fetchOpenClawSessions,
+  getIngestEndpoint,
+  postSnapshot,
+  runCollector,
+} from "./push-pixel-agents.mjs";
+
+describe("collector URL policy (issue #99)", () => {
+  it.each([
+    ["https://agents.example.com", "https://agents.example.com/api/ingest/agents"],
+    ["https://agents.example.com/base/", "https://agents.example.com/base/api/ingest/agents"],
+    ["http://localhost:3000", "http://localhost:3000/api/ingest/agents"],
+    ["http://127.42.0.7:3000", "http://127.42.0.7:3000/api/ingest/agents"],
+    ["http://[::1]:3000", "http://[::1]:3000/api/ingest/agents"],
+  ])("accepts secure or explicit loopback endpoint %s", (input, expected) => {
+    expect(getIngestEndpoint(input).href).toBe(expected);
+  });
+
+  it.each([
+    "http://agents.example.com",
+    "http://10.0.0.5:3000",
+    "http://127.0.0.1.example.com",
+    "ftp://agents.example.com",
+  ])("rejects unsafe endpoint %s", (input) => {
+    expect(() => getIngestEndpoint(input)).toThrow(/must use HTTPS/);
+  });
+
+  it("rejects credentials embedded in the collector URL", () => {
+    expect(() => getIngestEndpoint("https://user:secret@agents.example.com"))
+      .toThrow(/must not contain credentials/);
+  });
+});
+
+describe("collector execution bounds (issue #99)", () => {
+  it("terminates a sleeping OpenClaw executable at the child timeout", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "pixel-collector-"));
+    const executable = join(directory, "openclaw-sleep");
+
+    try {
+      await writeFile(executable, "#!/usr/bin/env node\nsetTimeout(() => {}, 1_000);\n");
+      await chmod(executable, 0o755);
+
+      const startedAt = Date.now();
+      let failure;
+      try {
+        fetchOpenClawSessions({
+          openclawBin: executable,
+          activeMinutes: "30",
+          timeoutMs: 50,
+        });
+      } catch (error) {
+        failure = error;
+      }
+
+      expect(failure).toMatchObject({ code: "ETIMEDOUT" });
+      expect(Date.now() - startedAt).toBeLessThan(500);
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
+  it("aborts a non-responsive ingest endpoint at the HTTP timeout", async () => {
+    const server = createServer(() => {});
+    await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+    let watchdogTimer;
+
+    try {
+      const address = server.address();
+      const endpoint = new URL(`http://127.0.0.1:${address.port}/api/ingest/agents`);
+      const startedAt = Date.now();
+
+      const request = postSnapshot({
+        endpoint,
+        ingestToken: "test-token",
+        payload: { sessions: [], generatedAt: "2026-08-02T00:00:00.000Z" },
+        timeoutMs: 50,
+      });
+      const watchdog = new Promise((_, reject) => {
+        watchdogTimer = setTimeout(
+          () => reject(new Error("HTTP timeout regression watchdog fired")),
+          1_000,
+        );
+      });
+
+      await expect(Promise.race([request, watchdog]))
+        .rejects.toMatchObject({ name: "TimeoutError" });
+      expect(Date.now() - startedAt).toBeLessThan(1_000);
+    } finally {
+      clearTimeout(watchdogTimer);
+      server.closeAllConnections();
+      await new Promise((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
+    }
+  });
+
+  it("passes the reviewed absolute CLI path and timeout to execFileSync", async () => {
+    const calls = [];
+    await runCollector({
+      argv: ["--dry-run"],
+      env: {
+        PIXEL_AGENTS_URL: "http://localhost:3000",
+        PIXEL_INGEST_TOKEN: "test-token",
+        OPENCLAW_BIN: "/opt/openclaw/bin/openclaw",
+      },
+      execFile: (...args) => {
+        calls.push(args);
+        return JSON.stringify({ sessions: [] });
+      },
+      stdout: () => {},
+      stderr: () => {},
+    });
+
+    expect(calls).toEqual([[
+      "/opt/openclaw/bin/openclaw",
+      ["sessions", "--all-agents", "--json", "--active", "30"],
+      expect.objectContaining({ timeout: 10_000, killSignal: "SIGKILL" }),
+    ]]);
+  });
+
+  it("rejects a PATH-resolved OpenClaw executable", async () => {
+    await expect(runCollector({
+      argv: ["--dry-run"],
+      env: {
+        PIXEL_AGENTS_URL: "http://localhost:3000",
+        PIXEL_INGEST_TOKEN: "test-token",
+        OPENCLAW_BIN: "openclaw",
+      },
+    })).rejects.toThrow(/must be an absolute path/);
+  });
+});

--- a/collector/push-pixel-agents.test.mjs
+++ b/collector/push-pixel-agents.test.mjs
@@ -1,7 +1,8 @@
-import { chmod, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { execFileSync as runProcess } from "node:child_process";
+import { chmod, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
 import { createServer } from "node:http";
 import { tmpdir } from "node:os";
-import { join, resolve } from "node:path";
+import { dirname, join, resolve } from "node:path";
 
 import { describe, expect, it } from "vitest";
 
@@ -35,6 +36,43 @@ describe("collector URL policy (issue #99)", () => {
   it("rejects credentials embedded in the collector URL", () => {
     expect(() => getIngestEndpoint("https://user:secret@agents.example.com"))
       .toThrow(/must not contain credentials/);
+  });
+
+  it("rejects redirects without replaying the snapshot to the target", async () => {
+    let targetRequests = 0;
+    const target = createServer((_request, response) => {
+      targetRequests += 1;
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end(JSON.stringify({ agents: 1, received: 1 }));
+    });
+    await new Promise((resolve) => target.listen(0, "127.0.0.1", resolve));
+    const targetAddress = target.address();
+
+    const redirector = createServer((_request, response) => {
+      response.writeHead(307, {
+        location: `http://127.0.0.1:${targetAddress.port}/outside-policy`,
+      });
+      response.end();
+    });
+    await new Promise((resolve) => redirector.listen(0, "127.0.0.1", resolve));
+    const redirectorAddress = redirector.address();
+
+    try {
+      await expect(postSnapshot({
+        endpoint: new URL(`http://127.0.0.1:${redirectorAddress.port}/api/ingest/agents`),
+        ingestToken: "test-token",
+        payload: { sessions: [{ sessionId: "sensitive-session" }] },
+        timeoutMs: 500,
+      })).rejects.toThrow();
+      expect(targetRequests).toBe(0);
+    } finally {
+      redirector.closeAllConnections();
+      target.closeAllConnections();
+      await Promise.all([
+        new Promise((resolve, reject) => redirector.close((error) => error ? reject(error) : resolve())),
+        new Promise((resolve, reject) => target.close((error) => error ? reject(error) : resolve())),
+      ]);
+    }
   });
 });
 
@@ -95,15 +133,70 @@ describe("collector execution bounds (issue #99)", () => {
     }
   });
 
+  it("propagates a timeout while reading a successful response body", async () => {
+    const server = createServer((_request, response) => {
+      response.writeHead(200, { "content-type": "application/json" });
+      response.write('{"agents":');
+    });
+    await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+    let watchdogTimer;
+
+    try {
+      const address = server.address();
+      const request = postSnapshot({
+        endpoint: new URL(`http://127.0.0.1:${address.port}/api/ingest/agents`),
+        ingestToken: "test-token",
+        payload: { sessions: [] },
+        timeoutMs: 50,
+      });
+      const watchdog = new Promise((_, reject) => {
+        watchdogTimer = setTimeout(
+          () => reject(new Error("response-body timeout regression watchdog fired")),
+          2_000,
+        );
+      });
+
+      await expect(Promise.race([request, watchdog]))
+        .rejects.toMatchObject({ name: "TimeoutError" });
+    } finally {
+      clearTimeout(watchdogTimer);
+      server.closeAllConnections();
+      await new Promise((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
+    }
+  });
+
+  it("rejects malformed JSON from a successful response", async () => {
+    const server = createServer((_request, response) => {
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end("not-json");
+    });
+    await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+
+    try {
+      const address = server.address();
+      await expect(postSnapshot({
+        endpoint: new URL(`http://127.0.0.1:${address.port}/api/ingest/agents`),
+        ingestToken: "test-token",
+        payload: { sessions: [] },
+        timeoutMs: 500,
+      })).rejects.toBeInstanceOf(SyntaxError);
+    } finally {
+      server.closeAllConnections();
+      await new Promise((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
+    }
+  });
+
   it("passes the reviewed absolute CLI path and timeout to execFileSync", async () => {
     const calls = [];
+    const collectorEnv = {
+      PIXEL_AGENTS_URL: "http://localhost:3000",
+      PIXEL_INGEST_TOKEN: "test-token",
+      OPENCLAW_BIN: "/opt/openclaw/bin/openclaw",
+      PATH: "/usr/bin:/bin",
+    };
     await runCollector({
       argv: ["--dry-run"],
-      env: {
-        PIXEL_AGENTS_URL: "http://localhost:3000",
-        PIXEL_INGEST_TOKEN: "test-token",
-        OPENCLAW_BIN: "/opt/openclaw/bin/openclaw",
-      },
+      env: collectorEnv,
       execFile: (...args) => {
         calls.push(args);
         return JSON.stringify({ sessions: [] });
@@ -117,6 +210,48 @@ describe("collector execution bounds (issue #99)", () => {
       ["sessions", "--all-agents", "--json", "--active", "30"],
       expect.objectContaining({ timeout: 10_000, killSignal: "SIGKILL" }),
     ]]);
+    expect(calls[0][2].env).toEqual({
+      PIXEL_AGENTS_URL: "http://localhost:3000",
+      OPENCLAW_BIN: "/opt/openclaw/bin/openclaw",
+      PATH: "/usr/bin:/bin",
+    });
+  });
+
+  it("runs through a symlinked entrypoint instead of exiting successfully as a no-op", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "pixel-collector-entrypoint-"));
+    const linkedCollector = join(directory, "collector-link.mjs");
+    const fakeOpenClaw = join(directory, "openclaw-fixture");
+
+    try {
+      await symlink(resolve(process.cwd(), "collector/push-pixel-agents.mjs"), linkedCollector);
+      await writeFile(
+        fakeOpenClaw,
+        "#!/usr/bin/env node\nprocess.stdout.write(JSON.stringify({ sessions: [] }));\n",
+      );
+      await chmod(fakeOpenClaw, 0o755);
+      const env = {
+        ...process.env,
+        PIXEL_AGENTS_URL: "http://localhost:3000",
+        PIXEL_INGEST_TOKEN: "test-token",
+        OPENCLAW_BIN: fakeOpenClaw,
+      };
+
+      const directOutput = runProcess(
+        process.execPath,
+        [resolve(process.cwd(), "collector/push-pixel-agents.mjs"), "--dry-run"],
+        { encoding: "utf8", env },
+      );
+      const symlinkOutput = runProcess(
+        process.execPath,
+        [linkedCollector, "--dry-run"],
+        { encoding: "utf8", env },
+      );
+
+      expect(directOutput).toContain("[dry-run] Payload sessions: 0");
+      expect(symlinkOutput).toBe(directOutput);
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
   });
 
   it("keeps session metadata out of dry-run output", async () => {
@@ -155,6 +290,25 @@ describe("collector execution bounds (issue #99)", () => {
       },
     })).rejects.toThrow(/must be an absolute path/);
   });
+
+  it.each([
+    ["an object without sessions", "{}"],
+    ["a top-level array", "[]"],
+  ])("rejects %s instead of clearing the current snapshot", (_label, raw) => {
+    expect(() => fetchOpenClawSessions({
+      openclawBin: "/opt/openclaw/bin/openclaw",
+      activeMinutes: "30",
+      execFile: () => raw,
+    })).toThrow(/sessions array/);
+  });
+
+  it("accepts an explicitly empty sessions array", () => {
+    expect(fetchOpenClawSessions({
+      openclawBin: "/opt/openclaw/bin/openclaw",
+      activeMinutes: "30",
+      execFile: () => JSON.stringify({ sessions: [] }),
+    })).toEqual([]);
+  });
 });
 
 describe("collector systemd boundary (issue #99)", () => {
@@ -170,13 +324,18 @@ describe("collector systemd boundary (issue #99)", () => {
     expect(unit).toContain("SendSIGKILL=true");
   });
 
-  it("provides a minimal reviewed PATH for env-based Node launchers", async () => {
+  it("aligns the first PATH directory with the reviewed ExecStart Node", async () => {
     const unit = await readFile(
       resolve(process.cwd(), "collector/systemd/openclaw-pixel-collector.service"),
       "utf8",
     );
 
-    expect(unit).toContain("Environment=PATH=/usr/local/bin:/usr/bin:/bin");
+    const execStartNode = unit.match(/^ExecStart=(\S+)/m)?.[1];
+    const servicePath = unit.match(/^Environment=PATH=(.+)$/m)?.[1];
+
+    expect(execStartNode).toBeTruthy();
+    expect(servicePath).toBeTruthy();
+    expect(servicePath.split(":")[0]).toBe(dirname(execStartNode));
     expect(unit).not.toContain(".npm-global");
   });
 });

--- a/collector/push-pixel-agents.test.mjs
+++ b/collector/push-pixel-agents.test.mjs
@@ -119,6 +119,32 @@ describe("collector execution bounds (issue #99)", () => {
     ]]);
   });
 
+  it("keeps session metadata out of dry-run output", async () => {
+    const output = [];
+    await runCollector({
+      argv: ["--dry-run"],
+      env: {
+        PIXEL_AGENTS_URL: "http://localhost:3000",
+        PIXEL_INGEST_TOKEN: "test-token",
+        OPENCLAW_BIN: "/opt/openclaw/bin/openclaw",
+      },
+      execFile: () => JSON.stringify({
+        sessions: [{ sessionId: "private-session-metadata" }],
+      }),
+      fetchImpl: () => {
+        throw new Error("dry-run must not send an HTTP request");
+      },
+      stdout: (...parts) => output.push(parts.join(" ")),
+      stderr: () => {},
+    });
+
+    expect(output).toEqual([
+      "[dry-run] Would POST to: http://localhost:3000/api/ingest/agents",
+      "[dry-run] Payload sessions: 1",
+    ]);
+    expect(JSON.stringify(output)).not.toContain("private-session-metadata");
+  });
+
   it("rejects a PATH-resolved OpenClaw executable", async () => {
     await expect(runCollector({
       argv: ["--dry-run"],

--- a/collector/push-pixel-agents.test.mjs
+++ b/collector/push-pixel-agents.test.mjs
@@ -47,7 +47,6 @@ describe("collector execution bounds (issue #99)", () => {
       await writeFile(executable, "#!/usr/bin/env node\nsetTimeout(() => {}, 1_000);\n");
       await chmod(executable, 0o755);
 
-      const startedAt = Date.now();
       let failure;
       try {
         fetchOpenClawSessions({
@@ -60,7 +59,6 @@ describe("collector execution bounds (issue #99)", () => {
       }
 
       expect(failure).toMatchObject({ code: "ETIMEDOUT" });
-      expect(Date.now() - startedAt).toBeLessThan(500);
     } finally {
       await rm(directory, { recursive: true, force: true });
     }
@@ -74,7 +72,6 @@ describe("collector execution bounds (issue #99)", () => {
     try {
       const address = server.address();
       const endpoint = new URL(`http://127.0.0.1:${address.port}/api/ingest/agents`);
-      const startedAt = Date.now();
 
       const request = postSnapshot({
         endpoint,
@@ -85,13 +82,12 @@ describe("collector execution bounds (issue #99)", () => {
       const watchdog = new Promise((_, reject) => {
         watchdogTimer = setTimeout(
           () => reject(new Error("HTTP timeout regression watchdog fired")),
-          1_000,
+          2_000,
         );
       });
 
       await expect(Promise.race([request, watchdog]))
         .rejects.toMatchObject({ name: "TimeoutError" });
-      expect(Date.now() - startedAt).toBeLessThan(1_000);
     } finally {
       clearTimeout(watchdogTimer);
       server.closeAllConnections();

--- a/collector/push-pixel-agents.test.mjs
+++ b/collector/push-pixel-agents.test.mjs
@@ -1,7 +1,7 @@
-import { chmod, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { chmod, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { createServer } from "node:http";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 
 import { describe, expect, it } from "vitest";
 
@@ -154,5 +154,29 @@ describe("collector execution bounds (issue #99)", () => {
         OPENCLAW_BIN: "openclaw",
       },
     })).rejects.toThrow(/must be an absolute path/);
+  });
+});
+
+describe("collector systemd boundary (issue #99)", () => {
+  it("bounds startup and full-control-group termination to 30 seconds", async () => {
+    const unit = await readFile(
+      resolve(process.cwd(), "collector/systemd/openclaw-pixel-collector.service"),
+      "utf8",
+    );
+
+    expect(unit).toContain("TimeoutStartSec=25s");
+    expect(unit).toContain("TimeoutStopSec=5s");
+    expect(unit).toContain("KillMode=control-group");
+    expect(unit).toContain("SendSIGKILL=true");
+  });
+
+  it("provides a minimal reviewed PATH for env-based Node launchers", async () => {
+    const unit = await readFile(
+      resolve(process.cwd(), "collector/systemd/openclaw-pixel-collector.service"),
+      "utf8",
+    );
+
+    expect(unit).toContain("Environment=PATH=/usr/local/bin:/usr/bin:/bin");
+    expect(unit).not.toContain(".npm-global");
   });
 });

--- a/collector/systemd/openclaw-pixel-collector.service
+++ b/collector/systemd/openclaw-pixel-collector.service
@@ -14,7 +14,7 @@ EnvironmentFile=/etc/openclaw-pixel-agents/collector.env
 ExecStart=/usr/bin/node /opt/openclaw-pixel-agents/collector/push-pixel-agents.mjs
 # Keep this minimal and reviewed. Its first entry must contain the Node binary
 # selected for ExecStart so npm launchers using `#!/usr/bin/env node` work.
-Environment=PATH=/usr/local/bin:/usr/bin:/bin
+Environment=PATH=/usr/bin:/bin
 
 # The collector bounds the CLI and HTTP operations to 10 seconds each. Give
 # their combined normal failure path 5 seconds of headroom, then bound the

--- a/collector/systemd/openclaw-pixel-collector.service
+++ b/collector/systemd/openclaw-pixel-collector.service
@@ -1,14 +1,37 @@
 [Unit]
 Description=Push OpenClaw session data to pixel-agents server
-After=network.target
+Wants=network-online.target
+After=network-online.target
 
 [Service]
 Type=oneshot
-User=niya
-WorkingDirectory=/path/to/openclaw-pixel-agents
-EnvironmentFile=/path/to/openclaw-pixel-agents/collector/.env.collector
-ExecStart=/usr/bin/node collector/push-pixel-agents.mjs
-Environment=PATH=/home/niya/.npm-global/bin:/usr/local/bin:/usr/bin:/bin
-Environment=HOME=/home/niya
+# Replace this account and these installation paths before installing the unit.
+# The account must be the non-root user that owns the OpenClaw state queried by
+# `openclaw sessions`; systemd derives HOME from that account.
+User=openclaw
+WorkingDirectory=/opt/openclaw-pixel-agents
+EnvironmentFile=/etc/openclaw-pixel-agents/collector.env
+ExecStart=/usr/bin/node /opt/openclaw-pixel-agents/collector/push-pixel-agents.mjs
+
+# The collector bounds the CLI and HTTP operations to 10 seconds each. Keep
+# this outer bound above their combined worst case so systemd can recover from
+# unexpected hangs without racing the application's normal timeout handling.
+TimeoutStartSec=30s
+
+NoNewPrivileges=true
+PrivateDevices=true
+PrivateTmp=true
+ProtectClock=true
+ProtectControlGroups=true
+ProtectKernelLogs=true
+ProtectKernelModules=true
+ProtectKernelTunables=true
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
+RestrictRealtime=true
+RestrictSUIDSGID=true
+LockPersonality=true
+CapabilityBoundingSet=
+SystemCallArchitectures=native
+UMask=0077
 StandardOutput=journal
 StandardError=journal

--- a/collector/systemd/openclaw-pixel-collector.service
+++ b/collector/systemd/openclaw-pixel-collector.service
@@ -12,11 +12,17 @@ User=openclaw
 WorkingDirectory=/opt/openclaw-pixel-agents
 EnvironmentFile=/etc/openclaw-pixel-agents/collector.env
 ExecStart=/usr/bin/node /opt/openclaw-pixel-agents/collector/push-pixel-agents.mjs
+# Keep this minimal and reviewed. Its first entry must contain the Node binary
+# selected for ExecStart so npm launchers using `#!/usr/bin/env node` work.
+Environment=PATH=/usr/local/bin:/usr/bin:/bin
 
-# The collector bounds the CLI and HTTP operations to 10 seconds each. Keep
-# this outer bound above their combined worst case so systemd can recover from
-# unexpected hangs without racing the application's normal timeout handling.
-TimeoutStartSec=30s
+# The collector bounds the CLI and HTTP operations to 10 seconds each. Give
+# their combined normal failure path 5 seconds of headroom, then bound the
+# termination phase too so the complete outer recovery limit is 30 seconds.
+TimeoutStartSec=25s
+TimeoutStopSec=5s
+KillMode=control-group
+SendSIGKILL=true
 
 NoNewPrivileges=true
 PrivateDevices=true


### PR DESCRIPTION
## Summary

- bound the OpenClaw CLI and ingest request to 10 seconds each, with a complete 30-second systemd recovery limit
- require HTTPS for remote ingest targets while preserving explicit loopback HTTP for local development
- require an absolute reviewed `OPENCLAW_BIN` path and replace host-specific systemd identity/home/PATH values with a documented portable template
- keep a minimal reviewed Node PATH for env-based launchers and add conservative systemd hardening
- reject ingest redirects, successful malformed or stalled response bodies, and malformed OpenClaw session envelopesn- keep the ingest token out of the OpenClaw child environment and make direct and symlinked entrypoints equivalentn- suppress session metadata from dry-run output and add focused timeout, transport, output, and unit-file regression tests
- update collector configuration and installation documentation

## Security and reliability boundary

The reusable bearer token can no longer be sent to a non-loopback plaintext endpoint. A sleeping CLI and stalled response each terminate after 10 seconds. If application timeout handling fails unexpectedly, systemd begins termination at 25 seconds and force-stops the complete control group within 5 more seconds, allowing later timer activations to proceed.

## Verification

- `npm test` — 29 files, 310 tests pass
- `npm run typecheck` — pass
- `npm run build` — pass
- real `openclaw sessions` dry-run — pass with count-only output and no session metadata
- `systemd-analyze verify` — pass
- `systemd-analyze security --offline=yes` — exposure 4.1, OK
- staged secret and host-private path scans — clean

Closes #99

<!-- kody-pr-summary:start -->
## Summary

This PR addresses issue #99 by tightening the collector's execution boundaries and securing its transport and environment configuration.

### Changes

**Service-level timeout configuration**
- Lowered `TimeoutStartSec` from 30s to 25s and added `TimeoutStopSec=5s`, keeping the outer recovery bound at 30s but splitting it into startup and termination phases.
- Added `KillMode=control-group` and `SendSIGKILL=yes` so systemd can reliably recover from unexpected overruns by terminating the entire process group.
- Restricted `Environment=PATH` to a minimal reviewed list (`/usr/local/bin:/usr/bin:/bin`), so that npm-based launchers using `#!/usr/bin/env node` resolve to a trusted Node binary rather than a user-writable PATH entry.
- Updated the README to document the new PATH requirement and reflect the split timeouts.

**Loopback hostname validation**
- Replaced the manual IPv4 octet-parsing check in `isLoopbackHostname` with a call to Node's `isIP`, eliminating the previous ad-hoc validation that could misclassify hostnames like `127.0.0.999` if numeric coercion were ever relaxed.

**Dry-run output**
- Removed the full payload (`JSON.stringify(payload, null, 2)`) from dry-run output. Session metadata may contain sensitive data, so dry-run now only reports the endpoint URL and the session count.

**Tests**
- Removed brittle assertions that required timeouts to fire below the budget (under 500ms / under 1s); these were timing-sensitive and unrelated to the actual contract being verified. The HTTP watchdog was extended to 2 seconds for the same reason.
- Added a test asserting that dry-run output does not include session metadata.
- Added tests asserting the systemd unit contains `TimeoutStartSec=25s`, `TimeoutStopSec=5s`, `KillMode=control-group`, `SendSIGKILL=yes`, and the minimal `Environment=PATH`, and does not reference untrusted `.npm-global` paths.

### Outcome

The collector now:
1. Fails fast and predictably when either the CLI capture or the HTTP POST hangs (10s each).
2. Reliably recovers via systemd within a bounded 30-second outer envelope if those internal timeouts ever fail.
3. Routes the launcher through a minimal, reviewed `PATH`, closing the gap where a user-writable `PATH` entry could shadow the intended Node binary.
4. No longer leaks session contents into dry-run logs.

---

This pull request addresses multiple security vulnerabilities in the collector component related to issue #99, focusing on **bounding execution** and **requiring secure transport**.

## Key Changes

### 1. Stricter Redirect Handling (`redirect: "error"`)
The HTTP `fetch` call in `postSnapshot` now uses `redirect: "error"` to reject redirects instead of silently following them. This prevents a malicious or misconfigured server from redirecting the collector to a different host that would receive the snapshot data, including sensitive session metadata and the ingest token.

The README has been updated to clarify that ingest redirects are rejected and that the final server URL should be configured directly.

### 2. Ingest Token Isolation
The `fetchOpenClawSessions` function now accepts an `env` parameter and strips `PIXEL_INGEST_TOKEN` before passing the environment to the `openclaw` child process. This prevents the ingest token from leaking into the OpenClaw CLI process (and potentially its logs, error messages, or subprocesses).

### 3. Validated Session JSON
The collector now explicitly validates that the OpenClaw CLI's JSON output contains a `sessions` array before proceeding. Previously, malformed or unexpected output (e.g., a top-level array, missing `sessions` key) would silently be treated as zero sessions, causing the collector to clear its current snapshot. Now such cases throw an explicit error.

### 4. Robust Entry Point Detection
The CLI entry point check was changed from `import.meta.url === pathToFileURL(process.argv[1]).href` to `import.meta.main`. The previous comparison failed when the script was invoked through a symlink (e.g., from a package bin), causing the collector to exit silently as a no-op instead of running. The new approach correctly handles symlinked invocations.

### 5. Tighter systemd PATH
The systemd service file's `PATH` was reduced from `/usr/local/bin:/usr/bin:/bin` to `/usr/bin:/bin`. The README comment has been clarified: the first `PATH` entry must contain the Node binary selected for `ExecStart`, so the directory is now derived from `ExecStart` (`/usr/bin`) to keep the `#!/usr/bin/env node` shebang working without granting the collector access to unvetted `/usr/local/bin` paths.

### 6. Response Body Error Handling
The response parsing in `postSnapshot` now only suppresses JSON parse errors when the HTTP status indicates failure. If a 2xx response returns malformed JSON, the `SyntaxError` now propagates, preventing silent acceptance of garbage payloads.

## New Tests
- **Redirect rejection**: Verifies that a 307 redirect is not followed and no data is replayed to the target.
- **Body read timeout**: Confirms `AbortSignal.timeout` propagates through response body reads (not just headers).
- **Malformed JSON on 2xx**: Ensures `SyntaxError` is thrown when a successful response has invalid JSON.
- **Env isolation**: Asserts `PIXEL_INGEST_TOKEN` is removed from the child process environment.
- **Symlinked entrypoint**: Runs the collector through a symlink to confirm `import.meta.main` works.
- **Session shape validation**: Covers non-object payloads, top-level arrays, and explicitly empty arrays.
- **PATH alignment**: The systemd test now verifies that the first `PATH` directory equals the directory of the `ExecStart` Node binary.

## Impact
This is a hardening release that closes several ways the collector could leak data, bypass policy, or silently degrade behavior. The changes are conservative (no new dependencies, no protocol changes) and are covered by new regression tests.
<!-- kody-pr-summary:end -->