### PR TITLE
fix(a11y): restore keyboard access and modal focus containment

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
       "devDependencies": {
         "@testing-library/jest-dom": "^7.0.0",
         "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
         "@types/express": "^5.0.0",
         "@types/node": "^26.1.2",
         "@types/react": "^19.0.0",
@@ -1309,6 +1310,20 @@
         "@types/react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
       }
     },
     "node_modules/@tybys/wasm-util": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "devDependencies": {
     "@testing-library/jest-dom": "^7.0.0",
     "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/express": "^5.0.0",
     "@types/node": "^26.1.2",
     "@types/react": "^19.0.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,6 +29,9 @@ export const App: React.FC = () => {
   const [sidebarOpen, setSidebarOpen] = useState(false);
 
   const enabledAgentCount = agents.filter(a => a.pixelEnabled).length;
+  const selectedAgent = selectedAgentId
+    ? agents.find(agent => agent.id === selectedAgentId) ?? null
+    : null;
 
   // Escape closes the agents drawer.
   useEffect(() => {
@@ -244,10 +247,12 @@ export const App: React.FC = () => {
         open={sidebarOpen}
         onClose={() => setSidebarOpen(false)}
       />
-      <AgentDetailPanel
-        agent={selectedAgentId ? agents.find(a => a.id === selectedAgentId) ?? null : null}
-        onClose={() => setSelectedAgentId(null)}
-      />
+      {selectedAgent && (
+        <AgentDetailPanel
+          agent={selectedAgent}
+          onClose={() => setSelectedAgentId(null)}
+        />
+      )}
       <MessageTicker />
     </div>
   );

--- a/src/components/AgentDetailPanel.tsx
+++ b/src/components/AgentDetailPanel.tsx
@@ -1,9 +1,11 @@
-import React from 'react';
+import React, { useId, useRef } from 'react';
+import { createPortal } from 'react-dom';
 import type { AgentState, AgentActivity, SubAgentInfo } from '../../shared/types';
+import { useModalFocus } from '../hooks/useModalFocus';
 import './AgentDetailPanel.css';
 
 interface Props {
-  agent: AgentState | null;
+  agent: AgentState;
   onClose: () => void;
 }
 
@@ -30,7 +32,11 @@ const activityColors: Record<AgentActivity, string> = {
 };
 
 export const AgentDetailPanel: React.FC<Props> = ({ agent, onClose }) => {
-  if (!agent) return null;
+  const overlayRef = useRef<HTMLDivElement>(null);
+  const closeRef = useRef<HTMLButtonElement>(null);
+  const headingId = useId();
+
+  useModalFocus({ overlayRef, initialFocusRef: closeRef, onClose });
 
   const lastActivityDate = agent.lastActivity
     ? new Date(agent.lastActivity).toLocaleTimeString()
@@ -40,10 +46,24 @@ export const AgentDetailPanel: React.FC<Props> = ({ agent, onClose }) => {
     ? Math.round((agent.tokens.used / agent.tokens.limit) * 100)
     : null;
 
-  return (
-    <div className="detail-overlay" onClick={onClose}>
-      <div className="detail-panel" onClick={e => e.stopPropagation()}>
-        <button className="detail-close" onClick={onClose}>✕</button>
+  return createPortal(
+    <div className="detail-overlay" onClick={onClose} ref={overlayRef} tabIndex={-1}>
+      <div
+        className="detail-panel"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={headingId}
+        onClick={e => e.stopPropagation()}
+      >
+        <button
+          ref={closeRef}
+          type="button"
+          className="detail-close"
+          aria-label={`Close details for ${agent.name}`}
+          onClick={onClose}
+        >
+          ✕
+        </button>
 
         {/* Header */}
         <div className="detail-header">
@@ -54,7 +74,7 @@ export const AgentDetailPanel: React.FC<Props> = ({ agent, onClose }) => {
             {agent.name.charAt(0)}
           </div>
           <div className="detail-title">
-            <h2>{agent.name}</h2>
+            <h2 id={headingId}>{agent.name}</h2>
             <span className="detail-id">{agent.id}</span>
           </div>
         </div>
@@ -150,7 +170,8 @@ export const AgentDetailPanel: React.FC<Props> = ({ agent, onClose }) => {
           </div>
         </div>
       </div>
-    </div>
+    </div>,
+    document.body,
   );
 };
 

--- a/src/components/AgentSidebar.css
+++ b/src/components/AgentSidebar.css
@@ -81,6 +81,25 @@
   flex-shrink: 0;
 }
 
+.agent-card.has-details { cursor: pointer; }
+
+/* Native button owns the card's primary action while the visible controls
+ * remain sibling buttons above it. This preserves valid HTML and gives Enter /
+ * Space behavior without duplicating browser keyboard semantics (issue #105). */
+.agent-details-button {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  width: 100%;
+  border: 0;
+  background: transparent;
+  cursor: pointer;
+}
+.agent-details-button:focus-visible {
+  outline: 2px solid var(--acc-cyan);
+  outline-offset: -3px;
+}
+
 /* Glow effect underneath active cards */
 .agent-card.active {
   border-color: var(--acc-green);
@@ -95,10 +114,15 @@
 }
 
 .agent-card-inner {
+  position: relative;
+  z-index: 1;
+  pointer-events: none;
   display: flex;
   gap: 12px;
   align-items: flex-start;
 }
+
+.agent-card-inner button { pointer-events: auto; }
 
 .agent-portrait-wrapper {
   flex-shrink: 0;

--- a/src/components/AgentSidebar.tsx
+++ b/src/components/AgentSidebar.tsx
@@ -135,6 +135,7 @@ const AgentCard = React.memo<AgentCardProps>(({ agent, onToggle, onSelectAgent, 
                 </button>
                 <button
                   className="tag-edit-btn"
+                  data-focus-return={`customizer-${agent.id}`}
                   onClick={() => onOpenCustomizer(agent)}
                   title="Customize appearance"
                   aria-label={`Customize appearance for ${agent.name}`}
@@ -158,6 +159,7 @@ const AgentCard = React.memo<AgentCardProps>(({ agent, onToggle, onSelectAgent, 
               <div className="card-actions">
                 <button
                   className="tag-edit-btn"
+                  data-focus-return={`customizer-${agent.id}`}
                   onClick={() => onOpenCustomizer(agent)}
                   title="Customize appearance"
                   aria-label={`Customize appearance for ${agent.name}`}

--- a/src/components/AgentSidebar.tsx
+++ b/src/components/AgentSidebar.tsx
@@ -57,7 +57,15 @@ const AgentCard = React.memo<AgentCardProps>(({ agent, onToggle, onSelectAgent, 
       : 'agent-card inactive';
 
   return (
-    <div className={cardClass} onClick={() => onSelectAgent?.(agent.id)} style={{ cursor: onSelectAgent ? 'pointer' : 'default' }}>
+    <div className={`${cardClass}${onSelectAgent ? ' has-details' : ''}`}>
+      {onSelectAgent && (
+        <button
+          type="button"
+          className="agent-details-button"
+          aria-label={`Open details for ${agent.name}`}
+          onClick={() => onSelectAgent(agent.id)}
+        />
+      )}
       <div className="agent-card-inner">
         <div className="agent-portrait-wrapper">
           <AgentPortrait recipe={agent.recipe} size={44} />
@@ -67,7 +75,7 @@ const AgentCard = React.memo<AgentCardProps>(({ agent, onToggle, onSelectAgent, 
             <span className="agent-name">{agent.name}</span>
             <button
               className={`toggle-btn ${agent.pixelEnabled ? 'on' : 'off'}`}
-              onClick={(e) => { e.stopPropagation(); onToggle(agent.id, !agent.pixelEnabled); }}
+              onClick={() => onToggle(agent.id, !agent.pixelEnabled)}
               title={agent.pixelEnabled ? 'Hide from office' : 'Show in office'}
               aria-label={agent.pixelEnabled ? `Hide ${agent.name} from office` : `Show ${agent.name} in office`}
               aria-pressed={agent.pixelEnabled}
@@ -118,7 +126,8 @@ const AgentCard = React.memo<AgentCardProps>(({ agent, onToggle, onSelectAgent, 
               <div className="card-actions">
                 <button
                   className="tag-edit-btn"
-                  onClick={(e) => { e.stopPropagation(); onOpenTagEditor(agent); }}
+                  data-focus-return={`tags-${agent.id}`}
+                  onClick={() => onOpenTagEditor(agent)}
                   title="Edit tags"
                   aria-label={`Edit tags for ${agent.name}`}
                 >
@@ -126,7 +135,7 @@ const AgentCard = React.memo<AgentCardProps>(({ agent, onToggle, onSelectAgent, 
                 </button>
                 <button
                   className="tag-edit-btn"
-                  onClick={(e) => { e.stopPropagation(); onOpenCustomizer(agent); }}
+                  onClick={() => onOpenCustomizer(agent)}
                   title="Customize appearance"
                   aria-label={`Customize appearance for ${agent.name}`}
                 >
@@ -139,7 +148,8 @@ const AgentCard = React.memo<AgentCardProps>(({ agent, onToggle, onSelectAgent, 
             <div className="agent-tags">
               <button
                 className="tag-add-btn"
-                onClick={(e) => { e.stopPropagation(); onOpenTagEditor(agent); }}
+                data-focus-return={`tags-${agent.id}`}
+                onClick={() => onOpenTagEditor(agent)}
                 title="Add tags"
                 aria-label={`Add tags for ${agent.name}`}
               >
@@ -148,7 +158,7 @@ const AgentCard = React.memo<AgentCardProps>(({ agent, onToggle, onSelectAgent, 
               <div className="card-actions">
                 <button
                   className="tag-edit-btn"
-                  onClick={(e) => { e.stopPropagation(); onOpenCustomizer(agent); }}
+                  onClick={() => onOpenCustomizer(agent)}
                   title="Customize appearance"
                   aria-label={`Customize appearance for ${agent.name}`}
                 >

--- a/src/components/AgentSidebar.tsx
+++ b/src/components/AgentSidebar.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo } from 'react';
+import React, { useState, useMemo, useCallback } from 'react';
 import type { AgentState, AgentActivity, AgentTag, CharacterRecipe } from '../../shared/types';
 import { TAG_COLORS } from '../../shared/types';
 import { TagEditor } from './TagEditor';
@@ -177,6 +177,14 @@ export const AgentSidebar: React.FC<Props> = React.memo(({ agents, onToggle, onT
   const enabledCount = agents.filter(a => a.pixelEnabled).length;
   const [tagEditorAgent, setTagEditorAgent] = useState<AgentState | null>(null);
   const [customizerAgent, setCustomizerAgent] = useState<AgentState | null>(null);
+  const openTagEditor = useCallback((agent: AgentState) => {
+    setCustomizerAgent(null);
+    setTagEditorAgent(agent);
+  }, []);
+  const openCustomizer = useCallback((agent: AgentState) => {
+    setTagEditorAgent(null);
+    setCustomizerAgent(agent);
+  }, []);
 
   const agentCards = useMemo(() => agents.map(agent => (
     <AgentCard
@@ -184,10 +192,10 @@ export const AgentSidebar: React.FC<Props> = React.memo(({ agents, onToggle, onT
       agent={agent}
       onToggle={onToggle}
       onSelectAgent={onSelectAgent}
-      onOpenTagEditor={setTagEditorAgent}
-      onOpenCustomizer={setCustomizerAgent}
+      onOpenTagEditor={openTagEditor}
+      onOpenCustomizer={openCustomizer}
     />
-  )), [agents, onToggle, onSelectAgent]);
+  )), [agents, onToggle, onSelectAgent, openTagEditor, openCustomizer]);
 
   return (
     <aside className={`agent-sidebar ${open ? 'open' : ''}`} aria-label="Agents">

--- a/src/components/CharacterCustomizer.tsx
+++ b/src/components/CharacterCustomizer.tsx
@@ -40,9 +40,9 @@ export const CharacterCustomizer: React.FC<Props> = ({
   const [error, setError] = useState<string | null>(null);
   const previewRef = useRef<HTMLCanvasElement>(null);
   const overlayRef = useRef<HTMLDivElement>(null);
-  const cancelRef = useRef<HTMLButtonElement>(null);
+  const headingRef = useRef<HTMLHeadingElement>(null);
 
-  useModalFocus({ overlayRef, initialFocusRef: cancelRef, onClose });
+  useModalFocus({ overlayRef, initialFocusRef: headingRef, onClose });
 
   // Live preview: render the composed character on a canvas
   useEffect(() => {
@@ -145,7 +145,7 @@ export const CharacterCustomizer: React.FC<Props> = ({
         aria-labelledby={headingId}
         onClick={e => e.stopPropagation()}
       >
-        <h3 id={headingId}> Customize {agentName}</h3>
+        <h3 ref={headingRef} id={headingId} tabIndex={-1}>Customize {agentName}</h3>
 
         {/* Live preview */}
         <div className="customizer-preview">
@@ -235,7 +235,7 @@ export const CharacterCustomizer: React.FC<Props> = ({
           <button className="customizer-save" onClick={handleSave} disabled={saving}>
             {saving ? 'Saving...' : 'Apply'}
           </button>
-          <button ref={cancelRef} className="customizer-cancel" onClick={onClose} disabled={saving}>
+          <button className="customizer-cancel" onClick={onClose} disabled={saving}>
             Cancel
           </button>
         </div>

--- a/src/components/CharacterCustomizer.tsx
+++ b/src/components/CharacterCustomizer.tsx
@@ -6,7 +6,9 @@
  */
 
 import React, { useState, useEffect, useRef, useCallback } from 'react';
+import { createPortal } from 'react-dom';
 import type { CharacterRecipe } from '../../shared/types';
+import { useModalFocus } from '../hooks/useModalFocus';
 import './CharacterCustomizer.css';
 
 interface Props {
@@ -37,6 +39,10 @@ export const CharacterCustomizer: React.FC<Props> = ({
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const previewRef = useRef<HTMLCanvasElement>(null);
+  const overlayRef = useRef<HTMLDivElement>(null);
+  const cancelRef = useRef<HTMLButtonElement>(null);
+
+  useModalFocus({ overlayRef, initialFocusRef: cancelRef, onClose });
 
   // Live preview: render the composed character on a canvas
   useEffect(() => {
@@ -128,17 +134,10 @@ export const CharacterCustomizer: React.FC<Props> = ({
     }
   }, [agentId, recipe, onUpdateRecipe, onClose]);
 
-  // Escape key
-  useEffect(() => {
-    const handleKey = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose(); };
-    window.addEventListener('keydown', handleKey);
-    return () => window.removeEventListener('keydown', handleKey);
-  }, [onClose]);
-
   const headingId = `customizer-heading-${agentId}`;
 
-  return (
-    <div className="customizer-overlay" onClick={onClose}>
+  return createPortal(
+    <div className="customizer-overlay" onClick={onClose} ref={overlayRef} tabIndex={-1}>
       <div
         className="customizer"
         role="dialog"
@@ -236,12 +235,13 @@ export const CharacterCustomizer: React.FC<Props> = ({
           <button className="customizer-save" onClick={handleSave} disabled={saving}>
             {saving ? 'Saving...' : 'Apply'}
           </button>
-          <button className="customizer-cancel" onClick={onClose} disabled={saving}>
+          <button ref={cancelRef} className="customizer-cancel" onClick={onClose} disabled={saving}>
             Cancel
           </button>
         </div>
       </div>
-    </div>
+    </div>,
+    document.body,
   );
 };
 

--- a/src/components/SoundControls.tsx
+++ b/src/components/SoundControls.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useId } from 'react';
 import { sfx } from '../audio/SoundFX';
 import './SoundControls.css';
 
@@ -7,6 +7,7 @@ export const SoundControls: React.FC = () => {
   const [volume, setVolume] = useState(sfx.volume);
   const [ambience, setAmbience] = useState(sfx.ambienceOn);
   const [expanded, setExpanded] = useState(false);
+  const panelId = useId();
   // Unlock AudioContext on first user interaction
   useEffect(() => {
     const unlock = () => {
@@ -57,13 +58,13 @@ export const SoundControls: React.FC = () => {
         title="Sound settings"
         aria-label="Sound settings"
         aria-expanded={expanded}
-        aria-controls="sound-settings-panel"
+        aria-controls={panelId}
       >
         ⚙️
       </button>
 
       {expanded && (
-        <div className="sound-panel" id="sound-settings-panel">
+        <div className="sound-panel" id={panelId}>
           <label className="sound-slider-row">
             <span>Volume</span>
             <input

--- a/src/components/SoundControls.tsx
+++ b/src/components/SoundControls.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect } from 'react';
 import { sfx } from '../audio/SoundFX';
 import './SoundControls.css';
 
@@ -7,13 +7,8 @@ export const SoundControls: React.FC = () => {
   const [volume, setVolume] = useState(sfx.volume);
   const [ambience, setAmbience] = useState(sfx.ambienceOn);
   const [expanded, setExpanded] = useState(false);
-  const initRef = useRef(false);
-
   // Unlock AudioContext on first user interaction
   useEffect(() => {
-    if (initRef.current) return;
-    initRef.current = true;
-
     const unlock = () => {
       sfx.click(); // triggers ensureCtx → resume
       document.removeEventListener('click', unlock);
@@ -21,6 +16,10 @@ export const SoundControls: React.FC = () => {
     };
     document.addEventListener('click', unlock, { once: true });
     document.addEventListener('keydown', unlock, { once: true });
+    return () => {
+      document.removeEventListener('click', unlock);
+      document.removeEventListener('keydown', unlock);
+    };
   }, []);
 
   const toggleMute = () => {
@@ -58,12 +57,13 @@ export const SoundControls: React.FC = () => {
         title="Sound settings"
         aria-label="Sound settings"
         aria-expanded={expanded}
+        aria-controls="sound-settings-panel"
       >
         ⚙️
       </button>
 
       {expanded && (
-        <div className="sound-panel">
+        <div className="sound-panel" id="sound-settings-panel">
           <label className="sound-slider-row">
             <span>Volume</span>
             <input

--- a/src/components/TagEditor.tsx
+++ b/src/components/TagEditor.tsx
@@ -1,5 +1,7 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useCallback, useRef } from 'react';
+import { createPortal } from 'react-dom';
 import { ALL_TAGS, TAG_COLORS, type AgentTag } from '../../shared/types';
+import { useModalFocus } from '../hooks/useModalFocus';
 import './TagEditor.css';
 
 interface Props {
@@ -14,6 +16,10 @@ export const TagEditor: React.FC<Props> = ({ agentId, agentName, currentTags, on
   const [selectedTags, setSelectedTags] = useState<AgentTag[]>([...currentTags]);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const overlayRef = useRef<HTMLDivElement>(null);
+  const cancelRef = useRef<HTMLButtonElement>(null);
+
+  useModalFocus({ overlayRef, initialFocusRef: cancelRef, onClose });
 
   const handleSave = useCallback(async () => {
     setSaving(true);
@@ -28,15 +34,6 @@ export const TagEditor: React.FC<Props> = ({ agentId, agentName, currentTags, on
     }
   }, [agentId, selectedTags, onUpdateTags, onClose]);
 
-  // Escape key handling
-  useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') onClose();
-    };
-    window.addEventListener('keydown', handleKeyDown);
-    return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [onClose]);
-
   const toggleTag = (tag: AgentTag) => {
     setSelectedTags(prev => {
       if (prev.includes(tag)) {
@@ -50,8 +47,8 @@ export const TagEditor: React.FC<Props> = ({ agentId, agentName, currentTags, on
 
   const headingId = `tag-editor-heading-${agentId}`;
 
-  return (
-    <div className="tag-editor-overlay" onClick={onClose}>
+  return createPortal(
+    <div className="tag-editor-overlay" onClick={onClose} ref={overlayRef} tabIndex={-1}>
       <div
         className="tag-editor"
         role="dialog"
@@ -99,9 +96,10 @@ export const TagEditor: React.FC<Props> = ({ agentId, agentName, currentTags, on
           <button className="tag-save-btn" onClick={handleSave} disabled={saving}>
             {saving ? 'Saving...' : 'Save'}
           </button>
-          <button className="tag-cancel-btn" onClick={onClose} disabled={saving}>Cancel</button>
+          <button ref={cancelRef} className="tag-cancel-btn" onClick={onClose} disabled={saving}>Cancel</button>
         </div>
       </div>
-    </div>
+    </div>,
+    document.body,
   );
 };

--- a/src/components/accessibility.test.tsx
+++ b/src/components/accessibility.test.tsx
@@ -73,11 +73,12 @@ describe('SoundControls disclosure relationship (issue #105)', () => {
     render(<SoundControls />);
     const settings = screen.getByRole('button', { name: 'Sound settings' });
     expect(settings).toHaveAttribute('aria-expanded', 'false');
-    expect(settings).toHaveAttribute('aria-controls', 'sound-settings-panel');
+    const panelId = settings.getAttribute('aria-controls');
+    expect(panelId).toBeTruthy();
 
     fireEvent.click(settings);
     expect(settings).toHaveAttribute('aria-expanded', 'true');
-    expect(document.getElementById('sound-settings-panel')).toBeTruthy();
+    expect(document.getElementById(panelId!)).toBeTruthy();
   });
 
   it('reinstalls the one-shot unlock listener during a StrictMode effect replay', () => {
@@ -229,6 +230,29 @@ function expectModalContract(
 }
 
 describe('shared modal focus contract (issue #105)', () => {
+  it('serializes the sidebar-owned tag and character dialogs', () => {
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(null);
+    render(
+      <AgentSidebar
+        agents={[agent]}
+        onToggle={vi.fn()}
+        onToggleAll={vi.fn()}
+        onUpdateTags={async () => {}}
+        onUpdateRecipe={async () => {}}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Add tags for Cybera' }));
+    expect(screen.getByRole('dialog', { name: 'Tags for Cybera' })).toBeTruthy();
+
+    const customizer = document.querySelector<HTMLButtonElement>(
+      '[aria-label="Customize appearance for Cybera"]',
+    )!;
+    fireEvent.click(customizer);
+    expect(screen.queryByRole('dialog', { name: 'Tags for Cybera' })).toBeNull();
+    expect(screen.getByRole('dialog', { name: 'Customize Cybera' })).toBeTruthy();
+    expect(document.querySelectorAll('[role="dialog"]')).toHaveLength(1);
+  });
+
   it('contains TagEditor focus, makes the background inert, and restores its trigger', () => {
     render(<TagEditorHarness />);
     expectModalContract('Open tag editor', 'Tags for Cybera', 'Cancel');

--- a/src/components/accessibility.test.tsx
+++ b/src/components/accessibility.test.tsx
@@ -99,6 +99,7 @@ function TagEditorHarness() {
   return (
     <>
       <button onClick={() => setOpen(true)}>Open tag editor</button>
+      <button>Secondary target</button>
       {open && (
         <TagEditor
           agentId="cybera"
@@ -231,6 +232,17 @@ describe('shared modal focus contract (issue #105)', () => {
   it('contains TagEditor focus, makes the background inert, and restores its trigger', () => {
     render(<TagEditorHarness />);
     expectModalContract('Open tag editor', 'Tags for Cybera', 'Cancel');
+  });
+
+  it('falls back to an enabled background control when the invoking control becomes disabled', () => {
+    render(<TagEditorHarness />);
+    const trigger = screen.getByRole<HTMLButtonElement>('button', { name: 'Open tag editor' });
+    trigger.focus();
+    fireEvent.click(trigger);
+    trigger.disabled = true;
+    fireEvent.keyDown(document, { key: 'Escape', bubbles: true });
+    expect(trigger).not.toHaveFocus();
+    expect(screen.getByRole('button', { name: 'Secondary target' })).toHaveFocus();
   });
 
   it('contains CharacterCustomizer focus, makes the background inert, and restores its trigger', () => {

--- a/src/components/accessibility.test.tsx
+++ b/src/components/accessibility.test.tsx
@@ -1,0 +1,291 @@
+import React, { StrictMode, useState } from 'react';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { AgentState, AgentTag, CharacterRecipe } from '../../shared/types';
+import { AgentSidebar } from './AgentSidebar';
+import { CharacterCustomizer } from './CharacterCustomizer';
+import { SoundControls } from './SoundControls';
+import { TagEditor } from './TagEditor';
+import { sfx } from '../audio/SoundFX';
+
+vi.mock('./AgentPortrait', () => ({ AgentPortrait: () => null }));
+vi.mock('../audio/SoundFX', () => ({
+  sfx: {
+    muted: false,
+    volume: 0.5,
+    ambienceOn: false,
+    click: vi.fn(),
+    setMuted: vi.fn(),
+    setVolume: vi.fn(),
+    toggleAmbience: vi.fn(),
+  },
+}));
+
+const agent: AgentState = {
+  id: 'cybera',
+  name: 'Cybera',
+  activity: 'typing',
+  model: 'openai/codex',
+  sessionKey: 'agent:cybera',
+  active: true,
+  lastActivity: 1,
+  pixelEnabled: true,
+  tags: [],
+  recipe: { bodyIndex: 0, hairIndex: 0, outfitIndex: 0 },
+};
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+  vi.restoreAllMocks();
+});
+
+describe('AgentSidebar primary keyboard action (issue #105)', () => {
+  it('uses a named native button for agent details without swallowing sibling actions', () => {
+    const onSelectAgent = vi.fn();
+    const onToggle = vi.fn();
+    render(
+      <AgentSidebar
+        agents={[agent]}
+        onToggle={onToggle}
+        onToggleAll={vi.fn()}
+        onSelectAgent={onSelectAgent}
+      />,
+    );
+
+    const details = screen.getByRole('button', { name: 'Open details for Cybera' });
+    expect(details.tagName).toBe('BUTTON');
+    expect(details).toHaveAttribute('type', 'button');
+    details.focus();
+    expect(details).toHaveFocus();
+    fireEvent.click(details);
+    expect(onSelectAgent).toHaveBeenCalledWith('cybera');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Hide Cybera from office' }));
+    expect(onToggle).toHaveBeenCalledWith('cybera', false);
+    expect(onSelectAgent).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('SoundControls disclosure relationship (issue #105)', () => {
+  it('names the settings button and connects it to the expanded panel', () => {
+    render(<SoundControls />);
+    const settings = screen.getByRole('button', { name: 'Sound settings' });
+    expect(settings).toHaveAttribute('aria-expanded', 'false');
+    expect(settings).toHaveAttribute('aria-controls', 'sound-settings-panel');
+
+    fireEvent.click(settings);
+    expect(settings).toHaveAttribute('aria-expanded', 'true');
+    expect(document.getElementById('sound-settings-panel')).toBeTruthy();
+  });
+
+  it('reinstalls the one-shot unlock listener during a StrictMode effect replay', () => {
+    render(<StrictMode><SoundControls /></StrictMode>);
+    fireEvent.keyDown(document, { key: 'Tab' });
+    expect(sfx.click).toHaveBeenCalledOnce();
+  });
+
+  it('removes pending unlock listeners on unmount', () => {
+    const { unmount } = render(<SoundControls />);
+    unmount();
+    fireEvent.keyDown(document, { key: 'Tab' });
+    expect(sfx.click).not.toHaveBeenCalled();
+  });
+});
+
+function TagEditorHarness() {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <button onClick={() => setOpen(true)}>Open tag editor</button>
+      {open && (
+        <TagEditor
+          agentId="cybera"
+          agentName="Cybera"
+          currentTags={[]}
+          onUpdateTags={async (_agentId: string, _tags: AgentTag[]) => {}}
+          onClose={() => setOpen(false)}
+        />
+      )}
+    </>
+  );
+}
+
+function CharacterCustomizerHarness() {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <button onClick={() => setOpen(true)}>Open character customizer</button>
+      {open && (
+        <CharacterCustomizer
+          agentId="cybera"
+          agentName="Cybera"
+          currentRecipe={{ bodyIndex: 0, hairIndex: 0, outfitIndex: 0 }}
+          onUpdateRecipe={async (_agentId: string, _recipe: CharacterRecipe) => {}}
+          onClose={() => setOpen(false)}
+        />
+      )}
+    </>
+  );
+}
+
+function PendingTagEditorHarness() {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <button onClick={() => setOpen(true)}>Open pending tag editor</button>
+      {open && (
+        <TagEditor
+          agentId="cybera"
+          agentName="Cybera"
+          currentTags={[]}
+          onUpdateTags={() => new Promise(() => {})}
+          onClose={() => setOpen(false)}
+        />
+      )}
+    </>
+  );
+}
+
+function PendingCharacterCustomizerHarness() {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <button onClick={() => setOpen(true)}>Open pending character customizer</button>
+      {open && (
+        <CharacterCustomizer
+          agentId="cybera"
+          agentName="Cybera"
+          currentRecipe={{ bodyIndex: 0, hairIndex: 0, outfitIndex: 0 }}
+          onUpdateRecipe={() => new Promise(() => {})}
+          onClose={() => setOpen(false)}
+        />
+      )}
+    </>
+  );
+}
+
+function SidebarTagBoundaryHarness() {
+  const [agents, setAgents] = useState([agent]);
+  return (
+    <AgentSidebar
+      agents={agents}
+      onToggle={vi.fn()}
+      onToggleAll={vi.fn()}
+      onUpdateTags={async (agentId, tags) => {
+        setAgents(current => current.map(item => (
+          item.id === agentId ? { ...item, tags } : item
+        )));
+      }}
+    />
+  );
+}
+
+function expectModalContract(
+  triggerName: string,
+  dialogName: string,
+  cancelName: string,
+) {
+  const trigger = screen.getByRole('button', { name: triggerName });
+  // Testing Library's low-level fireEvent.click does not perform the browser's
+  // pointer-focus step. Focus explicitly so the harness models a real invoking
+  // control and the modal can capture the correct restore target.
+  trigger.focus();
+  fireEvent.click(trigger);
+
+  const dialog = screen.getByRole('dialog', { name: dialogName });
+  const cancel = screen.getByRole('button', { name: cancelName });
+  expect(cancel).toHaveFocus();
+
+  const appRoot = trigger.closest('div')!;
+  expect(appRoot).toHaveAttribute('inert');
+  expect(document.body.contains(dialog)).toBe(true);
+  expect(appRoot.contains(dialog)).toBe(false);
+
+  trigger.focus();
+  expect(cancel).toHaveFocus();
+
+  const controls = Array.from(dialog.querySelectorAll<HTMLButtonElement>('button:not(:disabled)'));
+  const first = controls[0];
+  const last = controls[controls.length - 1];
+  last.focus();
+  fireEvent.keyDown(document, { key: 'Tab', bubbles: true });
+  expect(first).toHaveFocus();
+
+  first.focus();
+  fireEvent.keyDown(document, { key: 'Tab', shiftKey: true, bubbles: true });
+  expect(last).toHaveFocus();
+
+  const escaped = vi.fn();
+  window.addEventListener('keydown', escaped);
+  fireEvent.keyDown(document, { key: 'Escape', bubbles: true });
+  window.removeEventListener('keydown', escaped);
+  expect(escaped).not.toHaveBeenCalled();
+  expect(screen.queryByRole('dialog', { name: dialogName })).toBeNull();
+  expect(trigger).toHaveFocus();
+  expect(appRoot).not.toHaveAttribute('inert');
+}
+
+describe('shared modal focus contract (issue #105)', () => {
+  it('contains TagEditor focus, makes the background inert, and restores its trigger', () => {
+    render(<TagEditorHarness />);
+    expectModalContract('Open tag editor', 'Tags for Cybera', 'Cancel');
+  });
+
+  it('contains CharacterCustomizer focus, makes the background inert, and restores its trigger', () => {
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(null);
+    render(<CharacterCustomizerHarness />);
+    expectModalContract('Open character customizer', 'Customize Cybera', 'Cancel');
+  });
+
+  it('re-anchors TagEditor focus when the focused Save button becomes disabled', async () => {
+    render(<PendingTagEditorHarness />);
+    fireEvent.click(screen.getByRole('button', { name: 'Open pending tag editor' }));
+    const dialog = screen.getByRole('dialog', { name: 'Tags for Cybera' });
+    const save = screen.getByRole('button', { name: 'Save' });
+    save.focus();
+    fireEvent.click(save);
+    await waitFor(() => {
+      expect(dialog).toContainElement(document.activeElement as HTMLElement);
+      expect(document.activeElement).not.toBe(save);
+    });
+  });
+
+  it('re-anchors CharacterCustomizer focus when the focused Apply button becomes disabled', async () => {
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(null);
+    render(<PendingCharacterCustomizerHarness />);
+    fireEvent.click(screen.getByRole('button', { name: 'Open pending character customizer' }));
+    const dialog = screen.getByRole('dialog', { name: 'Customize Cybera' });
+    const apply = screen.getByRole('button', { name: 'Apply' });
+    apply.focus();
+    fireEvent.click(apply);
+    await waitFor(() => {
+      expect(dialog).toContainElement(document.activeElement as HTMLElement);
+      expect(document.activeElement).not.toBe(apply);
+    });
+  });
+
+  it('restores the replacement tag trigger across zero/nonzero tag saves', async () => {
+    render(<SidebarTagBoundaryHarness />);
+
+    const addTags = screen.getByRole('button', { name: 'Add tags for Cybera' });
+    addTags.focus();
+    fireEvent.click(addTags);
+    fireEvent.click(screen.getByRole('button', { name: /^★?\s*coding$/ }));
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog', { name: 'Tags for Cybera' })).toBeNull();
+      expect(screen.getByRole('button', { name: 'Edit tags for Cybera' })).toHaveFocus();
+    });
+
+    const editTags = screen.getByRole('button', { name: 'Edit tags for Cybera' });
+    fireEvent.click(editTags);
+    fireEvent.click(screen.getByRole('button', { name: /^★?\s*coding$/ }));
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog', { name: 'Tags for Cybera' })).toBeNull();
+      expect(screen.getByRole('button', { name: 'Add tags for Cybera' })).toHaveFocus();
+    });
+  });
+});

--- a/src/components/accessibility.test.tsx
+++ b/src/components/accessibility.test.tsx
@@ -1,8 +1,10 @@
 import React, { StrictMode, useState } from 'react';
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import type { AgentState, AgentTag, CharacterRecipe } from '../../shared/types';
+import { AgentDetailPanel } from './AgentDetailPanel';
 import { AgentSidebar } from './AgentSidebar';
 import { CharacterCustomizer } from './CharacterCustomizer';
 import { SoundControls } from './SoundControls';
@@ -184,10 +186,53 @@ function SidebarTagBoundaryHarness() {
   );
 }
 
+function AgentDetailsHarness() {
+  const [selectedAgent, setSelectedAgent] = useState<AgentState | null>(null);
+  return (
+    <>
+      <AgentSidebar
+        agents={[agent]}
+        onToggle={vi.fn()}
+        onToggleAll={vi.fn()}
+        onSelectAgent={agentId => setSelectedAgent(agentId === agent.id ? agent : null)}
+      />
+      {selectedAgent && (
+        <AgentDetailPanel
+          agent={selectedAgent}
+          onClose={() => setSelectedAgent(null)}
+        />
+      )}
+    </>
+  );
+}
+
+function SidebarCustomizerBoundaryHarness() {
+  const [agents, setAgents] = useState([agent]);
+  return (
+    <>
+      <button
+        onClick={() => setAgents(current => current.map(item => ({
+          ...item,
+          tags: item.tags?.length ? [] : ['coding'],
+        })))}
+      >
+        Toggle live tags
+      </button>
+      <AgentSidebar
+        agents={agents}
+        onToggle={vi.fn()}
+        onToggleAll={vi.fn()}
+        onUpdateRecipe={async () => {}}
+      />
+    </>
+  );
+}
+
 function expectModalContract(
   triggerName: string,
   dialogName: string,
-  cancelName: string,
+  getInitialFocus: () => HTMLElement,
+  initialFocusOutsideTabOrder = false,
 ) {
   const trigger = screen.getByRole('button', { name: triggerName });
   // Testing Library's low-level fireEvent.click does not perform the browser's
@@ -197,20 +242,26 @@ function expectModalContract(
   fireEvent.click(trigger);
 
   const dialog = screen.getByRole('dialog', { name: dialogName });
-  const cancel = screen.getByRole('button', { name: cancelName });
-  expect(cancel).toHaveFocus();
+  const initialFocus = getInitialFocus();
+  expect(initialFocus).toHaveFocus();
 
   const appRoot = trigger.closest('div')!;
   expect(appRoot).toHaveAttribute('inert');
   expect(document.body.contains(dialog)).toBe(true);
   expect(appRoot.contains(dialog)).toBe(false);
 
-  trigger.focus();
-  expect(cancel).toHaveFocus();
-
   const controls = Array.from(dialog.querySelectorAll<HTMLButtonElement>('button:not(:disabled)'));
   const first = controls[0];
   const last = controls[controls.length - 1];
+  if (initialFocusOutsideTabOrder) {
+    fireEvent.keyDown(document, { key: 'Tab', shiftKey: true, bubbles: true });
+    expect(last).toHaveFocus();
+    initialFocus.focus();
+  }
+
+  trigger.focus();
+  expect(initialFocus).toHaveFocus();
+
   last.focus();
   fireEvent.keyDown(document, { key: 'Tab', bubbles: true });
   expect(first).toHaveFocus();
@@ -230,6 +281,37 @@ function expectModalContract(
 }
 
 describe('shared modal focus contract (issue #105)', () => {
+  it('opens agent details from Enter and Space, contains focus, and restores the trigger', async () => {
+    const user = userEvent.setup();
+    render(<AgentDetailsHarness />);
+
+    const trigger = screen.getByRole('button', { name: 'Open details for Cybera' });
+    const appRoot = trigger.closest('.agent-sidebar')!.parentElement!;
+    trigger.focus();
+    await user.keyboard('[Enter]');
+
+    const dialog = screen.getByRole('dialog', { name: 'Cybera' });
+    const close = screen.getByRole('button', { name: 'Close details for Cybera' });
+    expect(close).toHaveFocus();
+    expect(appRoot).toHaveAttribute('inert');
+    expect(document.body.contains(dialog)).toBe(true);
+    expect(appRoot.contains(dialog)).toBe(false);
+
+    trigger.focus();
+    expect(close).toHaveFocus();
+    await user.keyboard('[Tab]');
+    expect(close).toHaveFocus();
+    await user.keyboard('[Escape]');
+    expect(screen.queryByRole('dialog', { name: 'Cybera' })).toBeNull();
+    expect(trigger).toHaveFocus();
+    expect(appRoot).not.toHaveAttribute('inert');
+
+    await user.keyboard('[Space]');
+    expect(screen.getByRole('dialog', { name: 'Cybera' })).toBeTruthy();
+    await user.click(screen.getByRole('button', { name: 'Close details for Cybera' }));
+    expect(trigger).toHaveFocus();
+  });
+
   it('serializes the sidebar-owned tag and character dialogs', () => {
     vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(null);
     render(
@@ -255,7 +337,11 @@ describe('shared modal focus contract (issue #105)', () => {
 
   it('contains TagEditor focus, makes the background inert, and restores its trigger', () => {
     render(<TagEditorHarness />);
-    expectModalContract('Open tag editor', 'Tags for Cybera', 'Cancel');
+    expectModalContract(
+      'Open tag editor',
+      'Tags for Cybera',
+      () => screen.getByRole('button', { name: 'Cancel' }),
+    );
   });
 
   it('falls back to an enabled background control when the invoking control becomes disabled', () => {
@@ -272,7 +358,12 @@ describe('shared modal focus contract (issue #105)', () => {
   it('contains CharacterCustomizer focus, makes the background inert, and restores its trigger', () => {
     vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(null);
     render(<CharacterCustomizerHarness />);
-    expectModalContract('Open character customizer', 'Customize Cybera', 'Cancel');
+    expectModalContract(
+      'Open character customizer',
+      'Customize Cybera',
+      () => screen.getByRole('heading', { name: 'Customize Cybera' }),
+      true,
+    );
   });
 
   it('re-anchors TagEditor focus when the focused Save button becomes disabled', async () => {
@@ -323,5 +414,21 @@ describe('shared modal focus contract (issue #105)', () => {
       expect(screen.queryByRole('dialog', { name: 'Tags for Cybera' })).toBeNull();
       expect(screen.getByRole('button', { name: 'Add tags for Cybera' })).toHaveFocus();
     });
+  });
+
+  it('restores the replacement customizer trigger after live tags swap its branch', () => {
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(null);
+    render(<SidebarCustomizerBoundaryHarness />);
+
+    const customizer = screen.getByRole('button', { name: 'Customize appearance for Cybera' });
+    customizer.focus();
+    fireEvent.click(customizer);
+    expect(screen.getByRole('dialog', { name: 'Customize Cybera' })).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Toggle live tags' }));
+    fireEvent.keyDown(document, { key: 'Escape', bubbles: true });
+
+    expect(screen.queryByRole('dialog', { name: 'Customize Cybera' })).toBeNull();
+    expect(screen.getByRole('button', { name: 'Customize appearance for Cybera' })).toHaveFocus();
   });
 });

--- a/src/hooks/useModalFocus.ts
+++ b/src/hooks/useModalFocus.ts
@@ -19,6 +19,15 @@ function getFocusableElements(overlay: HTMLElement): HTMLElement[] {
   return Array.from(overlay.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR));
 }
 
+function isDisabledFormControl(element: Element | null): boolean {
+  return (
+    element instanceof HTMLButtonElement
+    || element instanceof HTMLInputElement
+    || element instanceof HTMLSelectElement
+    || element instanceof HTMLTextAreaElement
+  ) && element.disabled;
+}
+
 /**
  * Enforces the shared keyboard contract for simple modal dialogs.
  *
@@ -91,13 +100,7 @@ export function useModalFocus({ overlayRef, initialFocusRef, onClose }: ModalFoc
     document.addEventListener('focusin', onFocusIn);
     const focusabilityObserver = new MutationObserver(() => {
       const active = document.activeElement;
-      const activeIsDisabled = (
-        active instanceof HTMLButtonElement
-        || active instanceof HTMLInputElement
-        || active instanceof HTMLSelectElement
-        || active instanceof HTMLTextAreaElement
-      ) && active.disabled;
-      if (!active || !overlay.contains(active) || activeIsDisabled) focusInside();
+      if (!active || !overlay.contains(active) || isDisabledFormControl(active)) focusInside();
     });
     focusabilityObserver.observe(overlay, {
       subtree: true,
@@ -113,14 +116,20 @@ export function useModalFocus({ overlayRef, initialFocusRef, onClose }: ModalFoc
       for (const { element, wasInert } of background) {
         if (!wasInert) element.removeAttribute('inert');
       }
-      if (previousFocus?.isConnected) {
-        previousFocus.focus();
-      } else if (focusReturnId) {
-        const replacement = Array.from(
+      const replacement = focusReturnId
+        ? Array.from(
           document.querySelectorAll<HTMLElement>('[data-focus-return]'),
-        ).find(element => element.dataset.focusReturn === focusReturnId);
-        replacement?.focus();
-      }
+        ).find(element => (
+          element.dataset.focusReturn === focusReturnId && !isDisabledFormControl(element)
+        ))
+        : null;
+      const fallback = Array.from(
+        document.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR),
+      ).find(element => !overlay.contains(element));
+      const restoreTarget = previousFocus?.isConnected && !isDisabledFormControl(previousFocus)
+        ? previousFocus
+        : replacement ?? fallback;
+      restoreTarget?.focus();
     };
   }, [initialFocusRef, overlayRef]);
 }

--- a/src/hooks/useModalFocus.ts
+++ b/src/hooks/useModalFocus.ts
@@ -1,0 +1,126 @@
+import { useLayoutEffect, useRef, type RefObject } from 'react';
+
+const FOCUSABLE_SELECTOR = [
+  'button:not([disabled])',
+  '[href]',
+  'input:not([disabled])',
+  'select:not([disabled])',
+  'textarea:not([disabled])',
+  '[tabindex]:not([tabindex="-1"])',
+].join(',');
+
+interface ModalFocusOptions {
+  overlayRef: RefObject<HTMLElement | null>;
+  initialFocusRef: RefObject<HTMLElement | null>;
+  onClose: () => void;
+}
+
+function getFocusableElements(overlay: HTMLElement): HTMLElement[] {
+  return Array.from(overlay.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR));
+}
+
+/**
+ * Enforces the shared keyboard contract for simple modal dialogs.
+ *
+ * The overlay must be portaled as a direct child of document.body. This lets
+ * the hook make every background body child inert without hiding or disabling
+ * the dialog itself. Focus enters the dialog on mount, wraps on Tab, is pulled
+ * back after an unexpected escape, and returns to the invoking control when
+ * the dialog unmounts (issue #105).
+ */
+export function useModalFocus({ overlayRef, initialFocusRef, onClose }: ModalFocusOptions) {
+  const onCloseRef = useRef(onClose);
+  onCloseRef.current = onClose;
+
+  useLayoutEffect(() => {
+    const overlay = overlayRef.current;
+    if (!overlay) return;
+
+    const previousFocus = document.activeElement instanceof HTMLElement
+      ? document.activeElement
+      : null;
+    const focusReturnId = previousFocus?.dataset.focusReturn;
+    const background = Array.from(document.body.children)
+      .filter((element): element is HTMLElement => element instanceof HTMLElement && element !== overlay)
+      .map(element => ({ element, wasInert: element.hasAttribute('inert') }));
+
+    for (const { element } of background) element.setAttribute('inert', '');
+
+    const focusInside = () => {
+      const preferred = initialFocusRef.current;
+      if (preferred && !preferred.hasAttribute('disabled')) {
+        preferred.focus();
+        return;
+      }
+      (getFocusableElements(overlay)[0] ?? overlay).focus();
+    };
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        event.stopPropagation();
+        onCloseRef.current();
+        return;
+      }
+      if (event.key !== 'Tab') return;
+
+      const focusable = getFocusableElements(overlay);
+      if (focusable.length === 0) {
+        event.preventDefault();
+        overlay.focus();
+        return;
+      }
+
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      const active = document.activeElement;
+      if (event.shiftKey && (active === first || !overlay.contains(active))) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && (active === last || !overlay.contains(active))) {
+        event.preventDefault();
+        first.focus();
+      }
+    };
+
+    const onFocusIn = (event: FocusEvent) => {
+      if (event.target instanceof Node && !overlay.contains(event.target)) focusInside();
+    };
+
+    document.addEventListener('keydown', onKeyDown);
+    document.addEventListener('focusin', onFocusIn);
+    const focusabilityObserver = new MutationObserver(() => {
+      const active = document.activeElement;
+      const activeIsDisabled = (
+        active instanceof HTMLButtonElement
+        || active instanceof HTMLInputElement
+        || active instanceof HTMLSelectElement
+        || active instanceof HTMLTextAreaElement
+      ) && active.disabled;
+      if (!active || !overlay.contains(active) || activeIsDisabled) focusInside();
+    });
+    focusabilityObserver.observe(overlay, {
+      subtree: true,
+      attributes: true,
+      attributeFilter: ['disabled'],
+    });
+    focusInside();
+
+    return () => {
+      document.removeEventListener('keydown', onKeyDown);
+      document.removeEventListener('focusin', onFocusIn);
+      focusabilityObserver.disconnect();
+      for (const { element, wasInert } of background) {
+        if (!wasInert) element.removeAttribute('inert');
+      }
+      if (previousFocus?.isConnected) {
+        previousFocus.focus();
+      } else if (focusReturnId) {
+        const replacement = Array.from(
+          document.querySelectorAll<HTMLElement>('[data-focus-return]'),
+        ).find(element => element.dataset.focusReturn === focusReturnId);
+        replacement?.focus();
+      }
+    };
+  }, [initialFocusRef, overlayRef]);
+}

--- a/src/hooks/useModalFocus.ts
+++ b/src/hooks/useModalFocus.ts
@@ -35,7 +35,9 @@ function isDisabledFormControl(element: Element | null): boolean {
  * the hook make every background body child inert without hiding or disabling
  * the dialog itself. Focus enters the dialog on mount, wraps on Tab, is pulled
  * back after an unexpected escape, and returns to the invoking control when
- * the dialog unmounts (issue #105).
+ * the dialog unmounts. Callers must serialize modal entry; this hook does not
+ * manage a modal stack. A trigger's `data-focus-return` identity is sampled at
+ * mount and must remain stable for that open lifecycle (issue #105).
  */
 export function useModalFocus({ overlayRef, initialFocusRef, onClose }: ModalFocusOptions) {
   const onCloseRef = useRef(onClose);

--- a/src/hooks/useModalFocus.ts
+++ b/src/hooks/useModalFocus.ts
@@ -85,10 +85,19 @@ export function useModalFocus({ overlayRef, initialFocusRef, onClose }: ModalFoc
       const first = focusable[0];
       const last = focusable[focusable.length - 1];
       const active = document.activeElement;
-      if (event.shiftKey && (active === first || !overlay.contains(active))) {
+      const activeIsTabbable = active instanceof HTMLElement && focusable.includes(active);
+      if (event.shiftKey && (
+        active === first
+        || !overlay.contains(active)
+        || !activeIsTabbable
+      )) {
         event.preventDefault();
         last.focus();
-      } else if (!event.shiftKey && (active === last || !overlay.contains(active))) {
+      } else if (!event.shiftKey && (
+        active === last
+        || !overlay.contains(active)
+        || !activeIsTabbable
+      )) {
         event.preventDefault();
         first.focus();
       }


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
## Pull Request Description

### `AgentSidebar` — primary action as a real button

Replaces the `onClick` on the card container with a dedicated `<button class="agent-details-button" type="button">` overlay that carries the agent's "open details" action. The native button preserves Enter/Space keyboard semantics without duplicating them and is positioned absolutely behind the inner controls; the inner element is raised above it with `position: relative; z-index: 1`, and the sibling visibility/toggle/tag/customize buttons explicitly re-enable `pointer-events: auto` so they remain individually clickable. The redundant `e.stopPropagation()` calls on every sibling handler are removed since the native button no longer competes with them.

### `TagEditor` / `CharacterCustomizer` — portaled, focus-contained modals

Both dialogs are now rendered through `createPortal(..., document.body)` and delegate their keyboard behavior to a new `useModalFocus` hook. The overlay is `tabIndex={-1}`, the Cancel button becomes the initial focus target, and the local `Escape` listener plus the inline `onClick={onClose}` overlay are replaced by the hook's document-level Escape handling with `stopPropagation`, preventing nested cancellations.

### `useModalFocus` — shared modal contract

A new hook that:
- Captures the previously focused element (`previousFocus`) on mount and restores focus to it on unmount, including when that element has since been disconnected.
- Marks every other direct child of `document.body` `inert` so background content (including the sidebar) becomes non-interactive while the dialog is open, and removes `inert` only from elements that did not have it before.
- Wraps Tab focus inside the overlay, pulls focus back into the overlay when focus leaves it via `focusin`, and observes `disabled` mutations so a focus stuck on Save/Apply is redirected to the first remaining focusable element when those buttons become disabled.
- Stops Escape propagation and treats Escape as a hard cancel.

### Sidebar trigger replacement across close paths

Tag-editor triggers carry `data-focus-return={`tags-${agent.id}`}` (on both "Add tags" and "Edit tags" buttons). If the original invoking control is unmounted or becomes disabled between open and close, `useModalFocus` falls back to any other element whose `data-focus-return` matches the captured id, restoring focus to the replacement "Edit tags" / "Add tags" button when a tag save flips between zero and nonzero tags.

### `SoundControls` — disclosure relationship + StrictMode-safe unlock

The settings button now exposes `aria-controls="sound-settings-panel"` and the expanded panel renders with `id="sound-settings-panel"`. The one-shot AudioContext unlock listeners are re-installed and torn down purely through the `useEffect` cleanup function (the previous `initRef` guard is removed), so React StrictMode's effect replay correctly registers a fresh pair of `click` / `keydown` listeners and the cleanup on unmount prevents late firings.

### Accessibility test coverage

A new `src/components/accessibility.test.tsx` file exercises:
- the named native button for agent details and that sibling toggle actions do not trigger it,
- the sound disclosure `aria-controls` linkage plus StrictMode replay and unmount cleanup of the unlock listeners,
- the shared modal focus contract (initial focus on Cancel, body siblings `inert`, dialog portaled out of the app root, Tab wrap forward/backward, Escape `stopPropagation`, and trigger focus restoration on close) for both `TagEditor` and `CharacterCustomizer`,
- focus re-anchoring when a pending Save/Apply disables the focused button,
- focus restoration to the replacement sidebar trigger across the `Add tags` → `Edit tags` and `Edit tags` → `Add tags` transitions.

---

### Summary

Restored keyboard accessibility and proper modal focus behavior for issue #105 by treating modals as a contract enforced by `useModalFocus` rather than ad-hoc per-component implementations. The change ensures that every modal dialog traps focus, makes the rest of the app inert, returns focus to its invoking control on close, and degrades gracefully when that control is disabled or replaced.

### Changes

**`useModalFocus` (`src/hooks/useModalFocus.ts`)**
- Extracted a shared `isDisabledFormControl` helper used by both the focus-pull-back observer and the focus-restoration logic.
- Shifted initial focus routing in the Tab wrap handler so that focus on a non-tabbable element inside the overlay (e.g., the customizer heading, which lives outside the tab order) is treated as "outside the cycle" and pulled back to the first/last focusable element.
- Reworked cleanup to deterministically pick a restore target in priority order: the original trigger if still enabled, otherwise an enabled element matching the sampled `data-focus-return` identity, otherwise the first enabled background control. This prevents focus from being lost when the trigger becomes disabled or is unmounted (for example, when toggling tags causes the customizer button to swap DOM branches).

**`AgentDetailPanel` (`src/components/AgentDetailPanel.tsx`)**
- Removed the internal null-guard since the parent now only renders the panel when an agent exists; the `agent` prop is now non-nullable.
- Added a `useModalFocus` integration so the dialog now follows the shared keyboard contract: focus enters on open, wraps on Tab, is pulled back on escape, and returns to the trigger on close.
- Added ARIA semantics: the inner panel now has `role="dialog"`, `aria-modal="true"`, and `aria-labelledby` wired to the agent name heading via `useId`.
- Rendered through `createPortal(..., document.body)` so the overlay is a direct child of `<body>`, enabling the `inert` background strategy used by the hook.
- Added an explicit `aria-label` to the close button that names the agent being closed.

**`CharacterCustomizer` (`src/components/CharacterCustomizer.tsx`)**
- Changed the initial focus target from the Cancel button to the dialog heading, matching how screen-reader users expect focus to land on a modal's title.
- The heading is made programmatically focusable (`tabIndex={-1}`) so the hook can focus it without making it part of the natural tab order.
- The Cancel button is no longer the initial focus owner, so its ref was removed.

**`AgentSidebar` (`src/components/AgentSidebar.tsx`)**
- Wrapped `setTagEditorAgent` and `setCustomizerAgent` in `useCallback` helpers (`openTagEditor`, `openCustomizer`) that explicitly close the other dialog first. This guarantees only one sidebar-owned modal is open at a time and prevents stale state from leaving both dialogs mounted.
- Both "Customize appearance" buttons (in the expanded customizer branch and the header action row) now carry a stable `data-focus-return={`customizer-${agent.id}`}` identity so the hook can locate the correct replacement button if the original trigger is unmounted (for example, by a tags-driven re-render).

**`SoundControls` (`src/components/SoundControls.tsx`)**
- Replaced the hard-coded `sound-settings-panel` id with one generated by `useId()`, used for both the `aria-controls` attribute on the disclosure button and the `id` of the revealed panel. This avoids id collisions when multiple instances mount and removes a brittle global string.

**`App` (`src/App.tsx`)**
- Hoisted the `selectedAgent` lookup out of JSX into a derived value computed once per render.
- Now only mounts `AgentDetailPanel` when an agent is selected, instead of mounting it with a `null` agent. This aligns with the panel's new non-null contract and removes a redundant null check.

**`accessibility.test.tsx` (`src/components/accessibility.test.tsx`)**
- Added `@testing-library/user-event` to drive real keyboard interactions.
- Refactored the shared `expectModalContract` helper to take a focus-target getter (and an optional flag for initial focus that lives outside the tab order) rather than a literal cancel-button name, so it can be reused for headings and other initial focus targets.
- New coverage:
  - Agent details: opening via Enter and Space, focus containment via Tab, close via Escape, focus restoration to the trigger, and close-button focus after Space open.
  - Sidebar serialization: opening the tag editor and then the customizer replaces the tag dialog, leaving exactly one dialog in the DOM.
  - Disabled-trigger fallback: closing a dialog whose invoking button became disabled returns focus to the next enabled background control rather than dropping it.
  - Customizer heading initial focus is enforced even though the heading is not part of the natural tab order.
  - `data-focus-return` recovery: closing a dialog after a live re-render swaps the trigger button still restores focus to the equivalent control.
- Adjusted the existing `SoundControls` test to look up the panel id from the trigger rather than asserting a hard-coded string.

### Impact

All modal dialogs (agent details, tag editor, character customizer) now share a consistent, tested keyboard contract: focus enters, is trapped, and returns correctly under normal conditions and when the trigger is disabled, unmounted, or replaced. Screen readers receive proper `dialog`/`aria-modal`/`aria-labelledby` semantics, and the rest of the UI is properly inert while a modal is open.
<!-- kody-pr-summary:end -->