### PR TITLE
fix(server): return JSON 404s for unknown API routes

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -1189,6 +1189,14 @@ io.on("connection", (socket) => {
   });
 });
 
+// Unmatched requests that reach the end of the API route chain keep the API
+// representation/status contract. In particular, an unknown GET must not fall
+// through to the SPA and look like a successful HTML navigation response.
+// Register this boundary before the client-side fallback (issue #103).
+app.use("/api", (_req, res) => {
+  res.status(404).json({ error: "Not found" });
+});
+
 // SPA fallback: serve index.html for any non-API/non-asset route.
 // Express 5 (path-to-regexp v8) rejects a bare "*" wildcard at registration
 // time; the named "*splat" wildcard is the documented migration form and

--- a/server/spa.test.ts
+++ b/server/spa.test.ts
@@ -17,7 +17,7 @@ import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
  * Express's default "Cannot GET …" 404, which would indicate the wildcard
  * failed to register/match.
  */
-describe("SPA fallback catch-all (Express 5 *splat)", () => {
+describe("API 404 boundary and SPA fallback catch-all (Express 5 *splat)", () => {
   let app: Express;
   let io: SocketIOServer;
   let dataDir: string;
@@ -40,6 +40,14 @@ describe("SPA fallback catch-all (Express 5 *splat)", () => {
     rmSync(dataDir, { recursive: true, force: true });
     vi.unstubAllEnvs();
     vi.resetModules();
+  });
+
+  it("returns JSON 404s for unknown API GET routes", async () => {
+    const response = await request(app).get("/api/definitely-missing");
+
+    expect(response.status).toBe(404);
+    expect(response.headers["content-type"]).toMatch(/application\/json/);
+    expect(response.body).toEqual({ error: "Not found" });
   });
 
   it("handles a deep non-API GET via the catch-all, not Express's default 404", async () => {


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
## Summary

Add an explicit API 404 boundary in the Express server so that unmatched `/api/*` requests return a structured JSON 404 instead of falling through to the SPA catch-all and being served as `index.html`.

## Changes

### `server/index.ts`
- Register a terminal middleware on `/api` that responds with `404` and JSON `{ "error": "Not found" }`.
- Place this middleware **before** the SPA fallback so unknown API routes are caught first while valid API handlers and deep client-side routes are unaffected.
- The implementation is a single `app.use("/api", …)` call with a one-line response, with an inline comment explaining the rationale and referencing issue #103.

### `server/spa.test.ts`
- Rename the existing `describe` block to `"API 404 boundary and SPA fallback catch-all (Express 5 *splat)"` to reflect the new coverage.
- Add a new regression test, `returns JSON 404s for unknown API GET routes`, that:
  - Issues `GET /api/definitely-missing`.
  - Asserts status `404`, `Content-Type` matching `application/json`, and body `{ error: "Not found" }`.
- Keep the existing deep-route test (now `"handles a deep non-API GET via the catch-all, not Express's default 404"`) unchanged in behavior, preserving coverage that valid SPA routes still reach the fallback.

## Functional Impact

- API namespace gains a terminal boundary: typos and unknown `/api/*` paths produce a clear `404 application/json` rather than masquerading as a successful HTML page load.
- Representation and status semantics for `/api` are now distinct from browser navigation responses, preventing the `200 text/html` mismatch that could mask client-side API errors in production builds.
- No changes to valid API routes, the SPA fallback, dependencies, configuration, or build output.
<!-- kody-pr-summary:end -->