### PR TITLE
fix(ingest): add pre-auth rate limiting to ingest endpoint

### DIFF
--- a/server/auth.test.ts
+++ b/server/auth.test.ts
@@ -5,7 +5,7 @@ import { join } from "node:path";
 import type { Express, Request, Response } from "express";
 import type { Server as SocketIOServer } from "socket.io";
 import request from "supertest";
-import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 describe("API auth boundaries", () => {
   let app: Express;
@@ -16,6 +16,7 @@ describe("API auth boundaries", () => {
   let defaultIngestTokenCrypto: typeof import("./index").defaultIngestTokenCrypto;
   let ingestTokenDigestContext: typeof import("./index").INGEST_TOKEN_DIGEST_CONTEXT;
   let tailTranscript: typeof import("./index").tailTranscript;
+  let resetIngestRateBuckets: typeof import("./index")._resetIngestRateBuckets;
   let outsideTranscriptPath: string;
   const appOrigin = "https://pixel.test";
 
@@ -48,6 +49,13 @@ describe("API auth boundaries", () => {
     defaultIngestTokenCrypto = serverModule.defaultIngestTokenCrypto;
     ingestTokenDigestContext = serverModule.INGEST_TOKEN_DIGEST_CONTEXT;
     tailTranscript = serverModule.tailTranscript;
+    resetIngestRateBuckets = serverModule._resetIngestRateBuckets;
+  });
+
+  beforeEach(() => {
+    // Reset rate-limit buckets between tests so the pre-auth limiter
+    // doesn't throttle sequential test requests from 127.0.0.1.
+    resetIngestRateBuckets();
   });
 
   afterAll(() => {

--- a/server/index.ts
+++ b/server/index.ts
@@ -1356,3 +1356,4 @@ if (require.main === module) {
 }
 
 export { app, server, io, startServer };
+

--- a/server/index.ts
+++ b/server/index.ts
@@ -705,6 +705,15 @@ export function createIngestAuthenticator(
 export const authenticateIngest = createIngestAuthenticator(INGEST_TOKEN);
 
 /**
+ * Reset ingest rate-limit buckets. Exported for test isolation only —
+ * production code should never call this.
+ */
+export function _resetIngestRateBuckets(): void {
+  ingestRateBuckets.clear();
+  ingestPreAuthBuckets.clear();
+}
+
+/**
  * POST /api/ingest/agents
  *
  * Accepts agent session data pushed from the OpenClaw host via the collector script.
@@ -713,12 +722,16 @@ export const authenticateIngest = createIngestAuthenticator(INGEST_TOKEN);
  * When valid ingest data arrives, it replaces the CLI-poll result and broadcasts.
  */
 
-// In-process rate limiter: max RATE_LIMIT_MAX requests per RATE_LIMIT_WINDOW_MS per token
+// In-process rate limiters:
+// - PRE_AUTH: throttles unauthenticated/failed-token attempts per IP (CWE-770)
+// - POST_AUTH: caps authenticated push frequency per token digest
 const RATE_LIMIT_WINDOW_MS = 60_000;
-const RATE_LIMIT_MAX = 10;
+const RATE_LIMIT_MAX = 10;          // post-auth: 10 pushes/min per token
+const PRE_AUTH_RATE_LIMIT_MAX = 5;   // pre-auth: 5 attempts/min per IP
 const ingestRateBuckets = new Map<string, number[]>();
+const ingestPreAuthBuckets = new Map<string, number[]>();
 
-// Periodically prune expired rate-limit entries to prevent memory leak
+// Prune both bucket maps on the same interval to prevent memory leaks
 const ingestPruneTimer = setInterval(() => {
   const cutoff = Date.now() - RATE_LIMIT_WINDOW_MS;
   for (const [key, timestamps] of ingestRateBuckets) {
@@ -726,14 +739,45 @@ const ingestPruneTimer = setInterval(() => {
     if (pruned.length === 0) ingestRateBuckets.delete(key);
     else ingestRateBuckets.set(key, pruned);
   }
+  for (const [key, timestamps] of ingestPreAuthBuckets) {
+    const pruned = timestamps.filter(t => t > cutoff);
+    if (pruned.length === 0) ingestPreAuthBuckets.delete(key);
+    else ingestPreAuthBuckets.set(key, pruned);
+  }
 }, RATE_LIMIT_WINDOW_MS);
 ingestPruneTimer.unref?.();
+
+/**
+ * Check pre-auth rate limit for a request. Returns true if the request should
+ * be allowed through, false if it exceeded the threshold (caller sends 429).
+ * Keyed on req.ip — trusts X-Forwarded-For only behind an explicit proxy.
+ */
+function checkPreAuthRateLimit(req: express.Request): boolean {
+  const ip = req.ip || "unknown";
+  const key = `preauth:${ip}`;
+  const now = Date.now();
+  const bucket = ingestPreAuthBuckets.get(key) || [];
+  const windowStart = now - RATE_LIMIT_WINDOW_MS;
+  const recent = bucket.filter(t => t > windowStart);
+  if (recent.length >= PRE_AUTH_RATE_LIMIT_MAX) return false;
+  recent.push(now);
+  ingestPreAuthBuckets.set(key, recent);
+  return true;
+}
 
 app.post("/api/ingest/agents", (req, res) => {
   if (!INGEST_TOKEN) {
     res.status(501).json({ error: "Ingest not configured (no INGEST_API_TOKEN)" });
     return;
   }
+
+  // Pre-auth rate limit: throttle unauthenticated requests per IP before
+  // the token check to prevent brute-force and resource-exhaustion attacks.
+  if (!checkPreAuthRateLimit(req)) {
+    res.status(429).json({ error: "Too many requests" });
+    return;
+  }
+
   if (!authenticateIngest(req, res)) {
     res.status(401).json({ error: "Unauthorized" });
     return;


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
## Summary

Adds a pre-authentication rate limit to `POST /api/ingest/agents` to protect the ingest endpoint from repeated invalid-token attempts and unauthenticated request flooding.

## Changes

- Introduces a separate per-IP pre-auth bucket that allows **5 requests per 60-second window**.
- Runs the pre-auth check before token validation, so requests that fail authentication also consume the IP limit.
- Keeps the existing post-authentication limit unchanged at **10 requests per minute per token digest**, with a separate bucket.
- Extends periodic pruning to both bucket maps, preventing stale rate-limit entries from accumulating.
- Adds a shared `60_000` ms window for both limiter types.
- Exposes `_resetIngestRateBuckets()` to clear limiter state for tests.
- Resets ingest rate-limit buckets before each authentication boundary test to prevent requests from `127.0.0.1` from affecting subsequent tests.
- Preserves existing responses for rate-limited requests (`429 Too many requests`) and invalid authentication (`401 Unauthorized`).

The change limits all ingest attempts before authentication, while allowing authenticated traffic to continue operating under the existing per-token limit.

---

# Pull Request Summary

## Description
Add pre-authentication rate limiting to the ingest endpoint to prevent abuse and protect server resources from unauthenticated requests.

## Changes
- **server/index.ts**: Modified the server entry point to add pre-auth rate limiting middleware for the ingest endpoint

## Purpose
This change addresses the need to protect the ingest endpoint from potential abuse, spam, or denial-of-service attempts by limiting the rate of requests that can be made before authentication is performed. Rate limiting at the pre-authentication stage helps ensure server stability and fair resource usage for all users.

---

## Summary

Adds a pre-authentication rate limiter to the `/api/ingest/agents` endpoint to mitigate brute-force and resource-exhaustion attacks (CWE-770) before the request token is evaluated.

## Changes

**`server/index.ts`**
- Introduces a second in-memory rate-limit bucket (`ingestPreAuthBuckets`) keyed on client IP, in addition to the existing post-auth per-token bucket.
- Adds `checkPreAuthRateLimit(req)`, a per-IP sliding-window check (5 attempts/min) that runs **before** `authenticateIngest`. Requests over the threshold are rejected with HTTP 429 before any token verification work occurs.
- Extends the existing periodic pruning interval to also expire entries from the new pre-auth bucket, preventing unbounded memory growth.
- Exports `_resetIngestRateBuckets()` for test isolation — clears both bucket maps and is marked as test-only.

**`server/auth.test.ts`**
- Imports `_resetIngestRateBuckets` and adds a `beforeEach` hook that clears both rate-limit buckets, so sequential auth-boundary tests from `127.0.0.1` are not throttled by the new pre-auth limiter.
<!-- kody-pr-summary:end -->