### PR TITLE
fix(ui): bound room-switcher at tablet width to stop covering header controls

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -874,6 +874,8 @@ app.post("/api/agents/:id/sprite", (req, res) => {
     const state = agentStates.get(id);
     if (state) state.characterSpriteId = spriteId;
     savePersistedPrefs();
+    // Broadcast sprite change so other connected clients see the new sprite
+    io.emit("agents:update", Array.from(agentStates.values()));
     res.json({ success: true });
   } else {
     res.status(404).json({ error: "Agent not found" });
@@ -1160,6 +1162,8 @@ app.delete("/api/layouts/:id", (req, res) => {
   if (!ok) {
     return res.status(404).json({ error: "Layout not found" });
   }
+  // Broadcast layout removal so connected clients drop the layout
+  io.emit("layout:update", { id, deleted: true });
   res.json({ success: true });
 });
 

--- a/src/components/RoomSwitcher.css
+++ b/src/components/RoomSwitcher.css
@@ -7,7 +7,7 @@
   transform: none;
   flex: 1 1 auto;
   min-width: 0;
-  max-width: fit-content;
+  max-width: 100%;
   margin: 0 auto;
 
   display: flex;
@@ -21,6 +21,11 @@
   border-radius: 20px;
   overflow-x: auto;
   scrollbar-width: none;
+  /* Prevent the room tabs from bleeding over the header-controls at
+   * intermediate widths between the wrap breakpoint and full desktop.
+   * The scrollable inner region is bounded by the container's own box. */
+  isolation: isolate;
+  contain: layout paint;
 }
 
 .room-switcher::-webkit-scrollbar {
@@ -75,6 +80,22 @@
   font-size: 10px;
   opacity: 0.6;
   margin-left: 2px;
+}
+
+/* Tablet/medium: top bar stays single row but room tabs scroll within
+ * their own bounded container so they can't bleed over header-controls. */
+@media (max-width: 1024px) {
+  .room-switcher {
+    max-width: 50%;
+  }
+  .room-tab {
+    padding: 6px 10px;
+    font-size: 11px;
+  }
+  .room-name {
+    display: none;
+    /* show only icon + count at tablet width to keep bar single-row */
+  }
 }
 
 @media (max-width: 768px) {


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
## Summary

Fixes room switcher layout overflow that was occluding header controls at intermediate viewport widths, and addresses two socket event broadcast gaps on the server side.

## Changes

### UI: Room Switcher Containment (`src/components/RoomSwitcher.css`)

- Replaced `max-width: fit-content` on the `.room-switcher` container with `max-width: 100%`, so the scrollable tab strip is bounded by its allocated flex space and can never grow past it.
- Added `isolation: isolate` and `contain: layout paint` to scope the scroll container's paint and layout, preventing the tabs from visually bleeding over sibling header children (sidebar toggle, editor, connection status, sound, settings).
- Introduced a new tablet breakpoint at `max-width: 1024px` that:
  - Caps the switcher at 50% of the available header width.
  - Hides `.room-name` text so each tab shows only its icon plus the agent count badge.
  - Tights tab padding to `6px 10px` and font-size to `11px`.
  
  This keeps the top bar on a single row at tablet sizes without the tabs colliding with the right-side controls.

The existing ≤768px mobile wrap behavior (full-width scrollable strip on a second row) is preserved unchanged.

### Server: Missing Socket Broadcasts (`server/index.ts`)

- **`POST /api/agents/:id/sprite`** — After updating `state.characterSpriteId` and persisting preferences, the server now emits `agents:update` with the full list of `agentStates`. Without this, a client that changes an agent's sprite would see the update locally but other connected clients would keep the old sprite until they refreshed.
- **`DELETE /api/layouts/:id`** — After successfully removing a layout, the server now emits `layout:update` with `{ id, deleted: true }` so other connected clients drop the layout from their UI in real time rather than only the originating client seeing the deletion.

Both are fire-and-forget `io.emit(...)` calls placed after the persistence/mutation step and before the HTTP response, matching the broadcast pattern already used elsewhere in these handlers.

## Verification

- Visual check at 1024×768: room tabs contained, header-controls cluster (sidebar toggle, editor, status, sound, settings) clearly visible with no overlap.
- 324/324 tests pass.
<!-- kody-pr-summary:end -->