### PR TITLE
feat(server): add global GET rate limiting for SPA fallback and static assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ Set `TRUST_PROXY` to restore per-client limiting:
 Two hard requirements:
 
 1. **The trusted proxy must overwrite client-supplied forwarding headers.** If clients can reach the server directly (or an intermediate hop forwards a spoofable `X-Forwarded-For`), do not configure trust — each forged header value would get its own rate bucket and defeat the limiter.
-2. **Unrestricted trust is deliberately rejected.** `TRUST_PROXY="true"` (and any other malformed value) aborts startup with a descriptive error rather than silently degrading security. Express's blanket `"true"` would trust every peer, which is exactly the spoofing scenario above.
+2. **Unrestricted trust is deliberately rejected.** `TRUST_PROXY="true"`, any `/0` CIDR (`0.0.0.0/0`, `::/0` — a zero prefix length matches every address of the family, i.e. the same blanket trust), and any other malformed value abort startup with a descriptive error rather than silently degrading security. Express's blanket `"true"` would trust every peer, which is exactly the spoofing scenario above.
 
 Malformed values (bad CIDRs, hostnames, empty entries, `"true"`) fail fast at startup with an error naming the accepted forms — never as an opaque crash from inside Express, and never by silently falling back to no trust, which would reintroduce the shared-bucket collapse.
 

--- a/README.md
+++ b/README.md
@@ -216,6 +216,7 @@ Furniture uses per-type directories with `manifest.json` for dimensions and rota
 | `POLL_INTERVAL` | `3000` | Agent state poll interval in ms (cli mode only) |
 | `ACTIVE_MINUTES` | `30` | Session staleness threshold |
 | `INGEST_API_TOKEN` | *(none)* | Shared secret for ingest API auth (required for ingest mode) |
+| `TRUST_PROXY` | *(unset)* | Reverse-proxy trust for client-IP rate limiting: `"false"`/`"0"`/unset = no trust (default), a positive integer = trusted proxy hop count (e.g. `"1"`), or a comma-separated list of proxy IPs/CIDRs or the presets `loopback`/`linklocal`/`uniquelocal` (e.g. `"10.0.0.0/8,127.0.0.1"`). Required for per-client limiting behind a reverse proxy; invalid values fail startup with a descriptive error. See [Reverse-proxy deployments](#reverse-proxy-deployments). |
 | `OPENCLAW_AGENTS_DIR` | `~/.openclaw/agents` | Path to agent session transcripts |
 | `DATA_DIR` | `./data` | Persistence directory for preferences and layouts |
 
@@ -232,6 +233,26 @@ The legacy `dataSource` field remains a compatibility alias for **effective owne
 ### Reverse-proxy deployments
 
 If you terminate TLS or rewrite requests in a reverse proxy in front of the Node server, make sure the `Origin` header from the browser is forwarded unchanged. State-mutating REST routes (`POST/PUT/PATCH/DELETE /api/*`) require an allowed `Origin` in production; stripping or rewriting it will cause legitimate browser mutations to fail with `403 Forbidden origin`.
+
+#### Client identity and rate limiting (`TRUST_PROXY`)
+
+By default the server does not trust any proxy: every request's client IP is the direct socket peer. Behind a reverse proxy that means **all users share the proxy's address** — and with it a single public GET/HEAD rate bucket (120 req/min). One noisy client can then exhaust the budget for everyone behind that proxy.
+
+Set `TRUST_PROXY` to restore per-client limiting:
+
+| Value | Meaning |
+|-------|---------|
+| *(unset)* / `"false"` / `"0"` | No proxy trust; `req.ip` is the direct peer (default, correct for direct exposure) |
+| `"1"`, `"2"`, … | Trust exactly that many proxy hops (Express `trust proxy N`). Use the exact hop count of your chain so the client IP is read from the correct `X-Forwarded-For` position |
+| `"loopback"`, `"linklocal"`, `"uniquelocal"` | Express IP presets for the respective address ranges |
+| `"10.0.0.0/8,127.0.0.1"` | Explicit proxy IPs/CIDRs — only those addresses are treated as trusted proxies |
+
+Two hard requirements:
+
+1. **The trusted proxy must overwrite client-supplied forwarding headers.** If clients can reach the server directly (or an intermediate hop forwards a spoofable `X-Forwarded-For`), do not configure trust — each forged header value would get its own rate bucket and defeat the limiter.
+2. **Unrestricted trust is deliberately rejected.** `TRUST_PROXY="true"` (and any other malformed value) aborts startup with a descriptive error rather than silently degrading security. Express's blanket `"true"` would trust every peer, which is exactly the spoofing scenario above.
+
+Malformed values (bad CIDRs, hostnames, empty entries, `"true"`) fail fast at startup with an error naming the accepted forms — never as an opaque crash from inside Express, and never by silently falling back to no trust, which would reintroduce the shared-bucket collapse.
 
 ## Scripts
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -7,6 +7,7 @@
  */
 
 import { execFile } from "node:child_process";
+import { isIP } from "node:net";
 import express from "express";
 import { createServer } from "http";
 import { Server as SocketIOServer } from "socket.io";
@@ -51,28 +52,62 @@ const corsConfig = createCorsConfig();
  * noisy client deny the dashboard to all others.
  *
  * `TRUST_PROXY` opts in explicitly for documented reverse-proxy deployments
- * (see README):
+ * (see README "Reverse-proxy deployments"):
  *   - unset / "false" / "0"   -> trust nobody (default)
  *   - integer string ("1", …) -> trust that many proxy hops (Express
  *     `trust proxy <n>` semantics); use the exact hop count of the deployed
  *     proxy chain so the client IP is read from the correct
  *     X-Forwarded-For position
- *   - comma-separated IPs/CIDRs ("10.0.0.0/8,127.0.0.1") -> trust those
- *     proxy addresses only
+ *   - comma-separated IPs/CIDRs or presets ("10.0.0.0/8,127.0.0.1",
+ *     "loopback", "linklocal", "uniquelocal") -> trust those proxy
+ *     addresses only
  *
  * "true"/unrestricted trust is deliberately NOT accepted: with no proxy in
  * front, clients could spoof X-Forwarded-For and each forged value would
  * get its own rate bucket, defeating the limiter entirely. Only enable
  * this when the front proxy overwrites client-supplied forwarding headers.
+ *
+ * Malformed values fail fast at startup with a descriptive error naming
+ * the accepted forms — never as an opaque TypeError from deep inside
+ * Express, and never by silently falling back to no trust (which would
+ * reintroduce the all-users-share-one-bucket collapse).
  */
-function parseTrustProxy(raw: string | undefined): number | string[] | undefined {
+const TRUST_PROXY_PRESETS = new Set(["loopback", "linklocal", "uniquelocal"]);
+
+/** One TRUST_PROXY list entry: a bare IP, an IP/prefix-length CIDR, or a
+ * documented preset. Deliberately stricter than proxy-addr: no DNS
+ * hostnames, no wildcard octets — operators state exact addresses. */
+function isTrustProxyEntry(entry: string): boolean {
+  if (TRUST_PROXY_PRESETS.has(entry)) return true;
+  const slash = entry.indexOf("/");
+  if (slash === -1) return isIP(entry) !== 0;
+  const addr = entry.slice(0, slash);
+  const prefix = entry.slice(slash + 1);
+  if (!/^\d{1,3}$/.test(prefix)) return false;
+  const bits = Number(prefix);
+  const family = isIP(addr);
+  if (family === 6) return bits <= 128;
+  return family === 4 && bits <= 32;
+}
+
+export function parseTrustProxy(raw: string | undefined): number | string[] | undefined {
   if (!raw) return undefined;
   const value = raw.trim();
   if (!value || value === "false" || value === "0") return undefined;
   const hops = Number(value);
   if (Number.isInteger(hops) && hops > 0 && String(hops) === value) return hops;
-  const cidrs = value.split(",").map(s => s.trim()).filter(Boolean);
-  return cidrs.length > 0 ? cidrs : undefined;
+  const entries = value.split(",").map(s => s.trim()).filter(Boolean);
+  if (entries.length === 0 || !entries.every(isTrustProxyEntry)) {
+    throw new Error(
+      `Invalid TRUST_PROXY value: "${raw}". Accepted forms: unset/"false"/"0" (no proxy trust, default), ` +
+      `a positive integer (trusted proxy hop count, e.g. "1"), or a comma-separated list of proxy ` +
+      `IPs/CIDRs or the presets loopback/linklocal/uniquelocal (e.g. "10.0.0.0/8,127.0.0.1"). ` +
+      `Unrestricted "true" is deliberately rejected: without a controlled proxy that overwrites ` +
+      `X-Forwarded-For, clients could forge forwarding headers and defeat per-client rate limiting. ` +
+      `See README "Reverse-proxy deployments".`,
+    );
+  }
+  return entries;
 }
 const trustProxy = parseTrustProxy(process.env.TRUST_PROXY);
 if (trustProxy !== undefined) {
@@ -807,12 +842,15 @@ export function checkPublicGetRateLimit(req: express.Request): boolean {
  * non-API paths are counted. HEAD is included because express.static and
  * the SPA sendFile fallback perform the same filesystem work for HEAD as
  * for GET — leaving it uncounted would let clients bypass the bound.
- * /api/* reads are explicitly excluded so dashboard polling and other API
- * traffic never consume the static/SPA budget.
+ * /api reads are exempt via an exact namespace boundary — "/api" itself and
+ * "/api/*" only — so dashboard polling and other API traffic never consume
+ * the static/SPA budget, while sibling public paths that merely share the
+ * prefix ("/apiary", "/api-v2") stay rate-limited instead of leaking past
+ * the limiter to the SPA filesystem path (review finding).
  */
 function publicGetRateLimiter(req: express.Request, res: express.Response, next: express.NextFunction): void {
   if (req.method !== "GET" && req.method !== "HEAD") { next(); return; }
-  if (req.path.startsWith("/api")) { next(); return; }
+  if (req.path === "/api" || req.path.startsWith("/api/")) { next(); return; }
   if (!checkPublicGetRateLimit(req)) {
     res.status(429).json({ error: "Too many requests" });
     return;

--- a/server/index.ts
+++ b/server/index.ts
@@ -42,6 +42,44 @@ const app = express();
 const server = createServer(app);
 const corsConfig = createCorsConfig();
 
+/**
+ * Reverse-proxy trust contract (issue #125 review, P1).
+ *
+ * Default: no proxy trust — `req.ip` is the direct socket peer, the safe
+ * default for direct exposure. Without trust, every browser behind one
+ * reverse proxy would share a single public-GET rate bucket, letting one
+ * noisy client deny the dashboard to all others.
+ *
+ * `TRUST_PROXY` opts in explicitly for documented reverse-proxy deployments
+ * (see README):
+ *   - unset / "false" / "0"   -> trust nobody (default)
+ *   - integer string ("1", …) -> trust that many proxy hops (Express
+ *     `trust proxy <n>` semantics); use the exact hop count of the deployed
+ *     proxy chain so the client IP is read from the correct
+ *     X-Forwarded-For position
+ *   - comma-separated IPs/CIDRs ("10.0.0.0/8,127.0.0.1") -> trust those
+ *     proxy addresses only
+ *
+ * "true"/unrestricted trust is deliberately NOT accepted: with no proxy in
+ * front, clients could spoof X-Forwarded-For and each forged value would
+ * get its own rate bucket, defeating the limiter entirely. Only enable
+ * this when the front proxy overwrites client-supplied forwarding headers.
+ */
+function parseTrustProxy(raw: string | undefined): number | string[] | undefined {
+  if (!raw) return undefined;
+  const value = raw.trim();
+  if (!value || value === "false" || value === "0") return undefined;
+  const hops = Number(value);
+  if (Number.isInteger(hops) && hops > 0 && String(hops) === value) return hops;
+  const cidrs = value.split(",").map(s => s.trim()).filter(Boolean);
+  return cidrs.length > 0 ? cidrs : undefined;
+}
+const trustProxy = parseTrustProxy(process.env.TRUST_PROXY);
+if (trustProxy !== undefined) {
+  app.set("trust proxy", trustProxy);
+  logger.info({ trustProxy, subsystem: "server" }, "Reverse-proxy trust configured");
+}
+
 const io = new SocketIOServer(server, {
   cors: {
     origin: corsConfig.socketOrigin,
@@ -97,13 +135,13 @@ app.use(correlationMiddleware);
 app.use(httpRequestLogMiddleware);
 app.use(express.json({ limit: "100kb" }));
 
-// Serve built frontend in production (Vite output is in dist/client, server is compiled to dist/server/index.js)
-const FRONTEND_DIR = resolve(__dirname, "..", "..", "client");
+// Serve built frontend in production (Vite output is in dist/client, server is compiled to dist/server/index.js).
+// FRONTEND_DIR is env-overridable for HTTP-level tests (issue #125).
+const FRONTEND_DIR = process.env.FRONTEND_DIR || resolve(__dirname, "..", "..", "client");
 if (existsSync(FRONTEND_DIR)) {
-  // Throttle unauthenticated GET traffic before the static middleware so
+  // Throttle unauthenticated GET/HEAD traffic before the static middleware so
   // express.static's filesystem access is rate-limited per IP (issue #125).
-  // Only mounted here and on the SPA fallback — NOT app.use(global) so it
-  // doesn't intercept /api or other non-frontend routes.
+  // The middleware itself skips /api paths — see publicGetRateLimiter.
   app.use(publicGetRateLimiter);
   app.use(express.static(FRONTEND_DIR));
 }
@@ -713,11 +751,14 @@ export const authenticateIngest = createIngestAuthenticator(INGEST_TOKEN);
  * Reset ingest rate-limit buckets. Exported for test isolation only —
  * production code should never call this.
  */
-export function _resetIngestRateBuckets(): void {
+export function _resetRateLimitBuckets(): void {
   ingestRateBuckets.clear();
   ingestPreAuthBuckets.clear();
   publicGetRateBuckets.clear();
 }
+
+/** @deprecated Use _resetRateLimitBuckets — alias kept for import compatibility. */
+export const _resetIngestRateBuckets = _resetRateLimitBuckets;
 
 /**
  * POST /api/ingest/agents
@@ -741,11 +782,11 @@ const ingestPreAuthBuckets = new Map<string, number[]>();
 const publicGetRateBuckets = new Map<string, number[]>();
 
 /**
- * Check whether an unauthenticated GET request from this IP is within the
+ * Check whether an unauthenticated GET/HEAD request from this IP is within the
  * public rate limit. Keyed on req.ip. Returns true if allowed, false if
- * the caller should respond 429. Express trusts X-Forwarded-For only when
- * `app.set('trust proxy', ...)` is configured upstream; we do not set it,
- * so req.ip is always the direct peer.
+ * the caller should respond 429. Client-IP identity depends on the explicit
+ * TRUST_PROXY contract configured at startup (see parseTrustProxy); with the
+ * default no-trust setting req.ip is the direct peer.
  */
 export function checkPublicGetRateLimit(req: express.Request): boolean {
   const ip = req.ip || "unknown";
@@ -761,11 +802,17 @@ export function checkPublicGetRateLimit(req: express.Request): boolean {
 }
 
 /**
- * Middleware: applies the public GET rate limit and returns 429 when exceeded.
- * Mounted before the static middleware and SPA fallback so both paths are bounded.
+ * Middleware: applies the public rate limit and returns 429 when exceeded.
+ * Scope contract (issue #125, review): only GET and HEAD requests to
+ * non-API paths are counted. HEAD is included because express.static and
+ * the SPA sendFile fallback perform the same filesystem work for HEAD as
+ * for GET — leaving it uncounted would let clients bypass the bound.
+ * /api/* reads are explicitly excluded so dashboard polling and other API
+ * traffic never consume the static/SPA budget.
  */
 function publicGetRateLimiter(req: express.Request, res: express.Response, next: express.NextFunction): void {
-  if (req.method !== "GET") { next(); return; }
+  if (req.method !== "GET" && req.method !== "HEAD") { next(); return; }
+  if (req.path.startsWith("/api")) { next(); return; }
   if (!checkPublicGetRateLimit(req)) {
     res.status(429).json({ error: "Too many requests" });
     return;
@@ -1297,8 +1344,8 @@ app.use("/api", (_req, res) => {
 // time; the named "*splat" wildcard is the documented migration form and
 // still matches every unmatched GET path, including "/".
 //
-// Rate-limited per IP so filesystem access for index.html is bounded
-// (issue #125).
+// Requests reach here only after passing publicGetRateLimiter + static
+// above, so filesystem access for index.html is already bounded (issue #125).
 app.get("*splat", (_req, res) => {
   const indexPath = join(FRONTEND_DIR, "index.html");
   if (existsSync(indexPath)) {

--- a/server/index.ts
+++ b/server/index.ts
@@ -102,6 +102,8 @@ const FRONTEND_DIR = resolve(__dirname, "..", "..", "client");
 if (existsSync(FRONTEND_DIR)) {
   // Throttle unauthenticated GET traffic before the static middleware so
   // express.static's filesystem access is rate-limited per IP (issue #125).
+  // Only mounted here and on the SPA fallback — NOT app.use(global) so it
+  // doesn't intercept /api or other non-frontend routes.
   app.use(publicGetRateLimiter);
   app.use(express.static(FRONTEND_DIR));
 }
@@ -763,6 +765,7 @@ export function checkPublicGetRateLimit(req: express.Request): boolean {
  * Mounted before the static middleware and SPA fallback so both paths are bounded.
  */
 function publicGetRateLimiter(req: express.Request, res: express.Response, next: express.NextFunction): void {
+  if (req.method !== "GET") { next(); return; }
   if (!checkPublicGetRateLimit(req)) {
     res.status(429).json({ error: "Too many requests" });
     return;
@@ -1296,7 +1299,7 @@ app.use("/api", (_req, res) => {
 //
 // Rate-limited per IP so filesystem access for index.html is bounded
 // (issue #125).
-app.get("*splat", publicGetRateLimiter, (_req, res) => {
+app.get("*splat", (_req, res) => {
   const indexPath = join(FRONTEND_DIR, "index.html");
   if (existsSync(indexPath)) {
     res.sendFile(indexPath);

--- a/server/index.ts
+++ b/server/index.ts
@@ -100,6 +100,9 @@ app.use(express.json({ limit: "100kb" }));
 // Serve built frontend in production (Vite output is in dist/client, server is compiled to dist/server/index.js)
 const FRONTEND_DIR = resolve(__dirname, "..", "..", "client");
 if (existsSync(FRONTEND_DIR)) {
+  // Throttle unauthenticated GET traffic before the static middleware so
+  // express.static's filesystem access is rate-limited per IP (issue #125).
+  app.use(publicGetRateLimiter);
   app.use(express.static(FRONTEND_DIR));
 }
 
@@ -711,6 +714,7 @@ export const authenticateIngest = createIngestAuthenticator(INGEST_TOKEN);
 export function _resetIngestRateBuckets(): void {
   ingestRateBuckets.clear();
   ingestPreAuthBuckets.clear();
+  publicGetRateBuckets.clear();
 }
 
 /**
@@ -725,13 +729,48 @@ export function _resetIngestRateBuckets(): void {
 // In-process rate limiters:
 // - PRE_AUTH: throttles unauthenticated/failed-token attempts per IP (CWE-770)
 // - POST_AUTH: caps authenticated push frequency per token digest
+// - PUBLIC_GET: app-wide throttle for unauthenticated GET traffic (SPA + static)
 const RATE_LIMIT_WINDOW_MS = 60_000;
 const RATE_LIMIT_MAX = 10;          // post-auth: 10 pushes/min per token
 const PRE_AUTH_RATE_LIMIT_MAX = 5;   // pre-auth: 5 attempts/min per IP
+const PUBLIC_GET_RATE_LIMIT_MAX = 120; // public GET: 120 req/min per IP (SPA + static)
 const ingestRateBuckets = new Map<string, number[]>();
 const ingestPreAuthBuckets = new Map<string, number[]>();
+const publicGetRateBuckets = new Map<string, number[]>();
 
-// Prune both bucket maps on the same interval to prevent memory leaks
+/**
+ * Check whether an unauthenticated GET request from this IP is within the
+ * public rate limit. Keyed on req.ip. Returns true if allowed, false if
+ * the caller should respond 429. Express trusts X-Forwarded-For only when
+ * `app.set('trust proxy', ...)` is configured upstream; we do not set it,
+ * so req.ip is always the direct peer.
+ */
+export function checkPublicGetRateLimit(req: express.Request): boolean {
+  const ip = req.ip || "unknown";
+  const key = `get:${ip}`;
+  const now = Date.now();
+  const bucket = publicGetRateBuckets.get(key) || [];
+  const windowStart = now - RATE_LIMIT_WINDOW_MS;
+  const recent = bucket.filter(t => t > windowStart);
+  if (recent.length >= PUBLIC_GET_RATE_LIMIT_MAX) return false;
+  recent.push(now);
+  publicGetRateBuckets.set(key, recent);
+  return true;
+}
+
+/**
+ * Middleware: applies the public GET rate limit and returns 429 when exceeded.
+ * Mounted before the static middleware and SPA fallback so both paths are bounded.
+ */
+function publicGetRateLimiter(req: express.Request, res: express.Response, next: express.NextFunction): void {
+  if (!checkPublicGetRateLimit(req)) {
+    res.status(429).json({ error: "Too many requests" });
+    return;
+  }
+  next();
+}
+
+// Prune all three bucket maps on the same interval to prevent memory leaks
 const ingestPruneTimer = setInterval(() => {
   const cutoff = Date.now() - RATE_LIMIT_WINDOW_MS;
   for (const [key, timestamps] of ingestRateBuckets) {
@@ -743,6 +782,11 @@ const ingestPruneTimer = setInterval(() => {
     const pruned = timestamps.filter(t => t > cutoff);
     if (pruned.length === 0) ingestPreAuthBuckets.delete(key);
     else ingestPreAuthBuckets.set(key, pruned);
+  }
+  for (const [key, timestamps] of publicGetRateBuckets) {
+    const pruned = timestamps.filter(t => t > cutoff);
+    if (pruned.length === 0) publicGetRateBuckets.delete(key);
+    else publicGetRateBuckets.set(key, pruned);
   }
 }, RATE_LIMIT_WINDOW_MS);
 ingestPruneTimer.unref?.();
@@ -1249,7 +1293,10 @@ app.use("/api", (_req, res) => {
 // Express 5 (path-to-regexp v8) rejects a bare "*" wildcard at registration
 // time; the named "*splat" wildcard is the documented migration form and
 // still matches every unmatched GET path, including "/".
-app.get("*splat", (_req, res) => {
+//
+// Rate-limited per IP so filesystem access for index.html is bounded
+// (issue #125).
+app.get("*splat", publicGetRateLimiter, (_req, res) => {
   const indexPath = join(FRONTEND_DIR, "index.html");
   if (existsSync(indexPath)) {
     res.sendFile(indexPath);

--- a/server/index.ts
+++ b/server/index.ts
@@ -86,6 +86,11 @@ function isTrustProxyEntry(entry: string): boolean {
   if (!/^\d{1,3}$/.test(prefix)) return false;
   const bits = Number(prefix);
   const family = isIP(addr);
+  // Prefix length 0 ("0.0.0.0/0", "::/0") matches every address of the
+  // family — semantically unrestricted trust, which this contract rejects
+  // — and proxy-addr's compile() additionally throws an opaque
+  // "invalid range on address" TypeError on /0 CIDRs (review repro).
+  if (bits < 1) return false;
   if (family === 6) return bits <= 128;
   return family === 4 && bits <= 32;
 }
@@ -101,7 +106,8 @@ export function parseTrustProxy(raw: string | undefined): number | string[] | un
     throw new Error(
       `Invalid TRUST_PROXY value: "${raw}". Accepted forms: unset/"false"/"0" (no proxy trust, default), ` +
       `a positive integer (trusted proxy hop count, e.g. "1"), or a comma-separated list of proxy ` +
-      `IPs/CIDRs or the presets loopback/linklocal/uniquelocal (e.g. "10.0.0.0/8,127.0.0.1"). ` +
+      `IPs/CIDRs (prefix length 1-32 for IPv4, 1-128 for IPv6) or the presets loopback/linklocal/uniquelocal ` +
+      `(e.g. "10.0.0.0/8,127.0.0.1"). ` +
       `Unrestricted "true" is deliberately rejected: without a controlled proxy that overwrites ` +
       `X-Forwarded-For, clients could forge forwarding headers and defeat per-client rate limiting. ` +
       `See README "Reverse-proxy deployments".`,

--- a/server/spa.test.ts
+++ b/server/spa.test.ts
@@ -1,79 +1,129 @@
-import { mkdtempSync, rmSync } from "node:fs";
+/**
+ * HTTP-level regression tests for the public GET/HEAD rate limiter
+ * (issue #125, review findings).
+ *
+ * Pins the scope contract of publicGetRateLimiter:
+ *   1. the 120/121 threshold and 429 response on static/SPA paths;
+ *   2. GET and HEAD are both counted (HEAD performs the same filesystem
+ *      work via express.static / SPA sendFile);
+ *   3. /api/* GET reads are NOT throttled by this limiter;
+ *   4. non-GET/HEAD methods bypass this limiter entirely;
+ *   5. bucket reset restores a clean window (test isolation oracle).
+ *
+ * FRONTEND_DIR is pointed at a temp fixture so the limiter + static mount
+ * are actually registered (they are skipped entirely when the directory
+ * does not exist, which is why these paths were previously untestable).
+ */
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { Express } from "express";
-import type { Server as SocketIOServer } from "socket.io";
 import request from "supertest";
-import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
-/**
- * Regression: the SPA fallback catch-all survived the Express 4→5 migration.
- *
- * Express 5 (path-to-regexp v8) rejects a bare "*" wildcard at route
- * registration time, so the fallback was migrated to the named "*splat"
- * form. This pins that the catch-all still MATCHES unmatched GET paths:
- * the response must come from our handler (index.html served, or the
- * explicit "Not found" text when no build artifact exists) and must NOT be
- * Express's default "Cannot GET …" 404, which would indicate the wildcard
- * failed to register/match.
- */
-describe("API 404 boundary and SPA fallback catch-all (Express 5 *splat)", () => {
+const PUBLIC_GET_RATE_LIMIT_MAX = 120;
+
+describe("public GET/HEAD rate limiter (issue #125)", () => {
   let app: Express;
-  let io: SocketIOServer;
+  let frontendDir: string;
   let dataDir: string;
+  let resetRateLimitBuckets: typeof import("./index")._resetRateLimitBuckets;
 
   beforeAll(async () => {
-    dataDir = mkdtempSync(join(tmpdir(), "pixel-agents-spa-test-"));
+    dataDir = mkdtempSync(join(tmpdir(), "pixel-agents-spa-data-"));
+    frontendDir = mkdtempSync(join(tmpdir(), "pixel-agents-spa-frontend-"));
+    mkdirSync(join(frontendDir, "assets"), { recursive: true });
+    writeFileSync(join(frontendDir, "index.html"), "<!doctype html><title>spa-fixture</title>");
+    writeFileSync(join(frontendDir, "assets", "fixture.txt"), "static-fixture");
+
     vi.stubEnv("DATA_DIR", dataDir);
-    vi.stubEnv("DATA_SOURCE", "cli");
+    vi.stubEnv("DATA_SOURCE", "ingest");
+    vi.stubEnv("INGEST_API_TOKEN", "test-secret");
     vi.stubEnv("NODE_ENV", "production");
     vi.stubEnv("CORS_ORIGIN", "https://pixel.test");
+    vi.stubEnv("FRONTEND_DIR", frontendDir);
+    // Deliberately NOT setting TRUST_PROXY: default no-trust contract means
+    // all supertest requests share the loopback bucket unless reset.
 
     vi.resetModules();
     const serverModule = await import("./index");
     app = serverModule.app;
-    io = serverModule.io;
+    resetRateLimitBuckets = serverModule._resetRateLimitBuckets;
   });
 
   afterAll(() => {
-    io.close();
     rmSync(dataDir, { recursive: true, force: true });
+    rmSync(frontendDir, { recursive: true, force: true });
     vi.unstubAllEnvs();
-    vi.resetModules();
   });
 
-  it("returns JSON 404s for unknown API GET routes", async () => {
-    const response = await request(app).get("/api/definitely-missing");
-
-    expect(response.status).toBe(404);
-    expect(response.headers["content-type"]).toMatch(/application\/json/);
-    expect(response.body).toEqual({ error: "Not found" });
+  beforeEach(() => {
+    resetRateLimitBuckets();
   });
 
-  it("handles a deep non-API GET via the catch-all, not Express's default 404", async () => {
-    const response = await request(app).get("/some/deep/spa/route");
-
-    // Our handler either serves index.html (200, html) or returns the
-    // explicit "Not found" text (404) when the client build is absent.
-    expect([200, 404]).toContain(response.status);
-    if (response.status === 404) {
-      expect(response.text).toBe("Not found");
-    } else {
-      expect(response.headers["content-type"]).toMatch(/text\/html/);
+  it("allows up to 120 GETs then returns 429 on the 121st (threshold pin)", async () => {
+    for (let i = 0; i < PUBLIC_GET_RATE_LIMIT_MAX; i++) {
+      const res = await request(app).get("/assets/fixture.txt");
+      expect(res.status).toBe(200);
     }
+    const blocked = await request(app).get("/assets/fixture.txt");
+    expect(blocked.status).toBe(429);
+    expect(blocked.body).toEqual({ error: "Too many requests" });
   });
 
-  it("serves the SPA at the root path '/' (documented contract)", async () => {
-    const response = await request(app).get("/");
-
-    // Same contract as the deep route: the catch-all must match "/", serving
-    // index.html (200) or the explicit "Not found" text (404) when no build
-    // artifact exists — never Express's default "Cannot GET /" 404.
-    expect([200, 404]).toContain(response.status);
-    if (response.status === 404) {
-      expect(response.text).toBe("Not found");
-    } else {
-      expect(response.headers["content-type"]).toMatch(/text\/html/);
+  it("counts HEAD requests against the same bucket as GET", async () => {
+    for (let i = 0; i < PUBLIC_GET_RATE_LIMIT_MAX; i++) {
+      const res = await request(app).head("/");
+      expect(res.status).toBe(200);
     }
+    // Bucket now full from HEAD alone: both HEAD and GET must be rejected.
+    const blockedHead = await request(app).head("/");
+    expect(blockedHead.status).toBe(429);
+    const blockedGet = await request(app).get("/");
+    expect(blockedGet.status).toBe(429);
+  });
+
+  it("covers the SPA fallback path (unknown non-API route)", async () => {
+    for (let i = 0; i < PUBLIC_GET_RATE_LIMIT_MAX; i++) {
+      const res = await request(app).get("/some/client-side/route");
+      expect(res.status).toBe(200);
+      expect(res.text).toContain("spa-fixture");
+    }
+    const blocked = await request(app).get("/some/client-side/route");
+    expect(blocked.status).toBe(429);
+  });
+
+  it("does not throttle /api GET reads (scope contract)", async () => {
+    // Drive the public bucket to the limit via static traffic...
+    for (let i = 0; i < PUBLIC_GET_RATE_LIMIT_MAX; i++) {
+      await request(app).get("/assets/fixture.txt");
+    }
+    // ...then confirm API reads are still served (404 from the /api boundary,
+    // not 429 from the public limiter).
+    const apiRes = await request(app).get("/api/status");
+    expect(apiRes.status).not.toBe(429);
+  });
+
+  it("lets non-GET/HEAD methods bypass the public limiter", async () => {
+    for (let i = 0; i < PUBLIC_GET_RATE_LIMIT_MAX; i++) {
+      await request(app).get("/assets/fixture.txt");
+    }
+    // Bucket is full for GET/HEAD; a POST to an unknown route must not be
+    // answered 429 by THIS limiter (the /api boundary or 404 handles it).
+    const postRes = await request(app).post("/assets/fixture.txt").send({});
+    expect(postRes.status).not.toBe(429);
+  });
+
+  it("reset helper restores a clean window", async () => {
+    for (let i = 0; i < PUBLIC_GET_RATE_LIMIT_MAX; i++) {
+      await request(app).get("/assets/fixture.txt");
+    }
+    const blocked = await request(app).get("/assets/fixture.txt");
+    expect(blocked.status).toBe(429);
+
+    resetRateLimitBuckets();
+
+    const allowed = await request(app).get("/assets/fixture.txt");
+    expect(allowed.status).toBe(200);
   });
 });

--- a/server/spa.test.ts
+++ b/server/spa.test.ts
@@ -6,9 +6,17 @@
  *   1. the 120/121 threshold and 429 response on static/SPA paths;
  *   2. GET and HEAD are both counted (HEAD performs the same filesystem
  *      work via express.static / SPA sendFile);
- *   3. /api/* GET reads are NOT throttled by this limiter;
- *   4. non-GET/HEAD methods bypass this limiter entirely;
- *   5. bucket reset restores a clean window (test isolation oracle).
+ *   3. the /api exemption uses an exact namespace boundary: "/api" and
+ *      "/api/*" are exempt, sibling prefixes ("/apiary", "/api-v2", "/apis")
+ *      are NOT — they fall through to the SPA filesystem path and must
+ *      stay rate-limited;
+ *   4. non-GET/HEAD methods bypass this limiter entirely (explicit 404);
+ *   5. unknown /api routes keep the JSON 404 boundary contract (issue #103);
+ *   6. bucket reset restores a clean window (test isolation oracle);
+ *   7. the TRUST_PROXY parser accepts only documented forms and fails fast
+ *      with a descriptive error on malformed/unrestricted values;
+ *   8. with TRUST_PROXY=1, distinct X-Forwarded-For clients get distinct
+ *      buckets (no proxy-collapse), while the exemption still holds.
  *
  * FRONTEND_DIR is pointed at a temp fixture so the limiter + static mount
  * are actually registered (they are skipped entirely when the directory
@@ -18,23 +26,31 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { Express } from "express";
+import type { Server as SocketIOServer } from "socket.io";
 import request from "supertest";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 const PUBLIC_GET_RATE_LIMIT_MAX = 120;
 
+function makeFrontendFixture(): string {
+  const dir = mkdtempSync(join(tmpdir(), "pixel-agents-spa-frontend-"));
+  mkdirSync(join(dir, "assets"), { recursive: true });
+  writeFileSync(join(dir, "index.html"), "<!doctype html><title>spa-fixture</title>");
+  writeFileSync(join(dir, "assets", "fixture.txt"), "static-fixture");
+  return dir;
+}
+
 describe("public GET/HEAD rate limiter (issue #125)", () => {
   let app: Express;
+  let io: SocketIOServer;
   let frontendDir: string;
   let dataDir: string;
   let resetRateLimitBuckets: typeof import("./index")._resetRateLimitBuckets;
+  let parseTrustProxy: typeof import("./index").parseTrustProxy;
 
   beforeAll(async () => {
     dataDir = mkdtempSync(join(tmpdir(), "pixel-agents-spa-data-"));
-    frontendDir = mkdtempSync(join(tmpdir(), "pixel-agents-spa-frontend-"));
-    mkdirSync(join(frontendDir, "assets"), { recursive: true });
-    writeFileSync(join(frontendDir, "index.html"), "<!doctype html><title>spa-fixture</title>");
-    writeFileSync(join(frontendDir, "assets", "fixture.txt"), "static-fixture");
+    frontendDir = makeFrontendFixture();
 
     vi.stubEnv("DATA_DIR", dataDir);
     vi.stubEnv("DATA_SOURCE", "ingest");
@@ -48,13 +64,17 @@ describe("public GET/HEAD rate limiter (issue #125)", () => {
     vi.resetModules();
     const serverModule = await import("./index");
     app = serverModule.app;
+    io = serverModule.io;
     resetRateLimitBuckets = serverModule._resetRateLimitBuckets;
+    parseTrustProxy = serverModule.parseTrustProxy;
   });
 
   afterAll(() => {
+    io.close();
     rmSync(dataDir, { recursive: true, force: true });
     rmSync(frontendDir, { recursive: true, force: true });
     vi.unstubAllEnvs();
+    vi.resetModules();
   });
 
   beforeEach(() => {
@@ -93,25 +113,45 @@ describe("public GET/HEAD rate limiter (issue #125)", () => {
     expect(blocked.status).toBe(429);
   });
 
-  it("does not throttle /api GET reads (scope contract)", async () => {
-    // Drive the public bucket to the limit via static traffic...
+  it("rate-limits /api-prefixed siblings while exempting the /api namespace exactly", async () => {
+    // Fill the bucket for this IP with ordinary static traffic.
     for (let i = 0; i < PUBLIC_GET_RATE_LIMIT_MAX; i++) {
       await request(app).get("/assets/fixture.txt");
     }
-    // ...then confirm API reads are still served (404 from the /api boundary,
-    // not 429 from the public limiter).
-    const apiRes = await request(app).get("/api/status");
-    expect(apiRes.status).not.toBe(429);
+
+    // Sibling prefixes merely sharing the characters "api" are NOT part of
+    // the API namespace: they fall through to the SPA sendFile path and
+    // must remain rate-limited (review finding: /apiary, /api-v2 bypass).
+    for (const sibling of ["/apiary", "/api-v2", "/apis"]) {
+      const blocked = await request(app).get(sibling);
+      expect(blocked.status).toBe(429);
+    }
+
+    // The exact namespace boundary stays exempt: /api itself hits the API
+    // JSON 404 boundary (not the limiter), and /api/status keeps serving.
+    const apiRoot = await request(app).get("/api");
+    expect(apiRoot.status).toBe(404);
+    expect(apiRoot.body).toEqual({ error: "Not found" });
+
+    const apiStatus = await request(app).get("/api/status");
+    expect(apiStatus.status).toBe(200);
   });
 
-  it("lets non-GET/HEAD methods bypass the public limiter", async () => {
+  it("returns JSON 404s for unknown API GET routes (issue #103 boundary pin)", async () => {
+    const response = await request(app).get("/api/definitely-missing");
+    expect(response.status).toBe(404);
+    expect(response.headers["content-type"]).toMatch(/application\/json/);
+    expect(response.body).toEqual({ error: "Not found" });
+  });
+
+  it("lets non-GET/HEAD methods bypass the public limiter (explicit 404)", async () => {
     for (let i = 0; i < PUBLIC_GET_RATE_LIMIT_MAX; i++) {
       await request(app).get("/assets/fixture.txt");
     }
-    // Bucket is full for GET/HEAD; a POST to an unknown route must not be
-    // answered 429 by THIS limiter (the /api boundary or 404 handles it).
+    // Bucket is full for GET/HEAD; a POST to a static path is outside this
+    // limiter's scope and lands in Express's ordinary 404 path.
     const postRes = await request(app).post("/assets/fixture.txt").send({});
-    expect(postRes.status).not.toBe(429);
+    expect(postRes.status).toBe(404);
   });
 
   it("reset helper restores a clean window", async () => {
@@ -125,5 +165,121 @@ describe("public GET/HEAD rate limiter (issue #125)", () => {
 
     const allowed = await request(app).get("/assets/fixture.txt");
     expect(allowed.status).toBe(200);
+  });
+
+  describe("parseTrustProxy contract (unit)", () => {
+    it.each([
+      [undefined, undefined],
+      ["", undefined],
+      ["false", undefined],
+      ["0", undefined],
+      ["1", 1],
+      ["2", 2],
+      ["loopback", ["loopback"]],
+      ["uniquelocal", ["uniquelocal"]],
+      ["10.0.0.0/8,127.0.0.1", ["10.0.0.0/8", "127.0.0.1"]],
+      ["::1", ["::1"]],
+      ["2001:db8::/32", ["2001:db8::/32"]],
+    ])("accepts %j -> %j", (raw, expected) => {
+      expect(parseTrustProxy(raw as string | undefined)).toEqual(expected);
+    });
+
+    it.each([
+      ["true"],
+      ["yes"],
+      ["-1"],
+      ["01"],
+      ["1e2"],
+      ["10.0.0.0/33"],
+      ["::1/129"],
+      ["300.300.300.300"],
+      ["example.com"],
+      ["10.0.0.0/8,not-an-ip"],
+      [",,"],
+    ])("rejects malformed value %j with a descriptive error", (raw) => {
+      expect(() => parseTrustProxy(raw)).toThrow(/Invalid TRUST_PROXY value/);
+      expect(() => parseTrustProxy(raw)).toThrow(/Accepted forms/);
+    });
+  });
+});
+
+describe("TRUST_PROXY malformed startup (fail fast)", () => {
+  it("rejects unrestricted 'true' at module load with a descriptive error", async () => {
+    vi.stubEnv("TRUST_PROXY", "true");
+    vi.resetModules();
+    await expect(import("./index")).rejects.toThrow(/Invalid TRUST_PROXY value/);
+    vi.unstubAllEnvs();
+  });
+
+  it("rejects a malformed CIDR at module load with a descriptive error", async () => {
+    vi.stubEnv("TRUST_PROXY", "10.0.0.0/33");
+    vi.resetModules();
+    await expect(import("./index")).rejects.toThrow(/Invalid TRUST_PROXY value/);
+    vi.unstubAllEnvs();
+  });
+});
+
+describe("TRUST_PROXY=1 per-client buckets (proxy separation)", () => {
+  let app: Express;
+  let io: SocketIOServer;
+  let frontendDir: string;
+  let dataDir: string;
+  let resetRateLimitBuckets: typeof import("./index")._resetRateLimitBuckets;
+
+  beforeAll(async () => {
+    dataDir = mkdtempSync(join(tmpdir(), "pixel-agents-spa-trust-data-"));
+    frontendDir = makeFrontendFixture();
+
+    vi.stubEnv("DATA_DIR", dataDir);
+    vi.stubEnv("DATA_SOURCE", "ingest");
+    vi.stubEnv("INGEST_API_TOKEN", "test-secret");
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("CORS_ORIGIN", "https://pixel.test");
+    vi.stubEnv("FRONTEND_DIR", frontendDir);
+    vi.stubEnv("TRUST_PROXY", "1");
+
+    vi.resetModules();
+    const serverModule = await import("./index");
+    app = serverModule.app;
+    io = serverModule.io;
+    resetRateLimitBuckets = serverModule._resetRateLimitBuckets;
+  });
+
+  afterAll(() => {
+    io.close();
+    rmSync(dataDir, { recursive: true, force: true });
+    rmSync(frontendDir, { recursive: true, force: true });
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+
+  beforeEach(() => {
+    resetRateLimitBuckets();
+  });
+
+  it("gives distinct X-Forwarded-For clients distinct buckets", async () => {
+    // Client A exhausts its own bucket.
+    for (let i = 0; i < PUBLIC_GET_RATE_LIMIT_MAX; i++) {
+      const res = await request(app)
+        .get("/assets/fixture.txt")
+        .set("X-Forwarded-For", "203.0.113.1");
+      expect(res.status).toBe(200);
+    }
+    const blockedA = await request(app)
+      .get("/assets/fixture.txt")
+      .set("X-Forwarded-For", "203.0.113.1");
+    expect(blockedA.status).toBe(429);
+
+    // Client B still has a full bucket of its own — no shared-bucket collapse.
+    const servedB = await request(app)
+      .get("/assets/fixture.txt")
+      .set("X-Forwarded-For", "203.0.113.2");
+    expect(servedB.status).toBe(200);
+
+    // The /api namespace exemption keeps working under trusted proxy mode.
+    const apiStatus = await request(app)
+      .get("/api/status")
+      .set("X-Forwarded-For", "203.0.113.1");
+    expect(apiStatus.status).toBe(200);
   });
 });

--- a/server/spa.test.ts
+++ b/server/spa.test.ts
@@ -192,6 +192,9 @@ describe("public GET/HEAD rate limiter (issue #125)", () => {
       ["1e2"],
       ["10.0.0.0/33"],
       ["::1/129"],
+      ["0.0.0.0/0"],
+      ["::/0"],
+      ["10.0.0.0/0"],
       ["300.300.300.300"],
       ["example.com"],
       ["10.0.0.0/8,not-an-ip"],
@@ -213,6 +216,16 @@ describe("TRUST_PROXY malformed startup (fail fast)", () => {
 
   it("rejects a malformed CIDR at module load with a descriptive error", async () => {
     vi.stubEnv("TRUST_PROXY", "10.0.0.0/33");
+    vi.resetModules();
+    await expect(import("./index")).rejects.toThrow(/Invalid TRUST_PROXY value/);
+    vi.unstubAllEnvs();
+  });
+
+  it("rejects /0 CIDRs (unrestricted range) at module load with a descriptive error", async () => {
+    // proxy-addr's compile() would throw an opaque "invalid range on
+    // address" TypeError; the project validator must fail first with a
+    // TRUST_PROXY-named error (review repro on 98504fc).
+    vi.stubEnv("TRUST_PROXY", "0.0.0.0/0");
     vi.resetModules();
     await expect(import("./index")).rejects.toThrow(/Invalid TRUST_PROXY value/);
     vi.unstubAllEnvs();


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
## Summary

This PR implements per-IP rate limiting for unauthenticated GET traffic on the SPA fallback route and `express.static` middleware, addressing issue #125.

## Changes

**New rate limiter implementation in `server/index.ts`:**
- Added `publicGetRateBuckets` Map alongside the existing `ingestRateBuckets` and `ingestPreAuthBuckets`, keyed by `req.ip` with a namespace prefix (`get:<ip>`) to avoid collision with other bucket keys
- Introduced `PUBLIC_GET_RATE_LIMIT_MAX = 120` constant (120 requests/min per IP) — significantly higher than the auth-related limits since this gates normal browser asset loading
- Exported `checkPublicGetRateLimit()` for test isolation and unit testing
- Created `publicGetRateLimiter` middleware that only processes GET methods and returns 429 `{ error: "Too many requests" }` when the limit is exceeded

**Middleware placement (scoped, not global):**
- Mounted `publicGetRateLimiter` via `app.use()` *only* when `FRONTEND_DIR` exists, positioned before `express.static(FRONTEND_DIR)` to throttle filesystem access
- Applied per-route to the SPA fallback (`app.get("*splat", ...)`) since that handler also reads `index.html` from disk
- Deliberately scoped to the static-serving section rather than `app.use(publicGetRateLimiter)` globally, preserving full speed on `/api` and other non-frontend routes

**Memory hygiene:**
- Extended the existing 60s prune interval loop to also clean up `publicGetRateBuckets`, deleting empty entries to prevent map growth
- Updated `_resetIngestRateBuckets()` to clear the new map alongside the existing two, keeping test teardown comprehensive

## Security boundary clarification

The limiter trusts `req.ip` directly without `app.set('trust proxy', ...)`, so it reflects the direct TCP peer rather than spoofable `X-Forwarded-For` headers. This is the correct posture for an unauthenticated public-facing endpoint where proxy headers could be forged.

## What was preserved

The ingest authentication and post-auth rate-limiting pipeline (token digest keyed, `RATE_LIMIT_MAX = 10`, `PRE_AUTH_RATE_LIMIT_MAX = 5`) is completely untouched. This change only adds an outer protective layer for public asset traffic and does not alter the auth boundary semantics.

---

### PR Summary: Global GET Rate Limiting for SPA Fallback & Static Assets (issue #125 review)

This change hardens the existing public GET rate limiter based on the P1 review findings from issue #125. The previous implementation only covered plain `GET`, leaving the limiter exploitable and unconfigurable for real deployments. The PR addresses three concrete review gaps:

**1. Reverse-proxy trust contract (server/index.ts)**
- Adds a `parseTrustProxy` helper that reads `TRUST_PROXY` and supports integer hop counts (`"1"`, `"2"`, …) and comma-separated IPs/CIDRs (`"10.0.0.0/8,127.0.0.1"`).
- Default is **no proxy trust** (`req.ip` = direct socket peer), preventing both cross-client bucket collisions behind a shared proxy and `X-Forwarded-For` spoofing when no proxy exists.
- Unrestricted `"true"` trust is deliberately rejected — spoofable clients would each mint their own bucket.
- Applies the setting via `app.set("trust proxy", …)` at startup and logs the resolved value.

**2. Limiter scope expansion: HEAD + `/api` exclusion**
- `publicGetRateLimiter` now counts both `GET` and `HEAD`, since `express.static` and the SPA `sendFile` fallback do the same filesystem work for HEAD.
- Requests with paths starting with `/api` bypass the limiter, so dashboard polling and other API traffic never consume the static/SPA budget.

**3. Test coverage (server/spa.test.ts)**
The test file was rebuilt around a temp frontend fixture (made possible by the new `FRONTEND_DIR` env override) so the limiter+static mount can actually be exercised end-to-end. Six regression tests pin the contract:
- 120-allow / 121-block threshold returns `429 {error: "Too many requests"}` for static paths.
- HEAD requests share the same bucket as GET.
- SPA fallback path (`/some/client-side/route`) is covered by the same limiter.
- `/api/*` GET reads are NOT throttled.
- Non-GET/HEAD methods bypass the limiter.
- `_resetRateLimitBuckets` (renamed from `_resetIngestRateBuckets`, with a deprecated alias) restores a clean window.

**Supporting changes**
- `FRONTEND_DIR` is now env-overridable to enable the HTTP-level tests.
- `_resetIngestRateBuckets` was renamed to `_resetRateLimitBuckets` to reflect its broadened scope; the old name is kept as a deprecated alias for import compatibility.
- Inline comments were updated to point at the new scope contract and proxy-trust helper instead of the old "we do not set trust proxy" wording.

---

## Summary

This change hardens the global GET/HEAD rate limiter that protects SPA fallback and static-asset routes, and adds a `TRUST_PROXY` environment variable so that per-client rate limiting works correctly behind a reverse proxy.

### Highlights

- **Exact `/api` exemption boundary.** The limiter now skips only `/api` itself and `/api/*`, instead of any path whose prefix string starts with `api`. Sibling paths like `/apiary`, `/api-v2`, and `/apis` fall through to the SPA `sendFile` path and are correctly rate-limited, while the `/api` JSON 404 boundary contract is preserved.
- **New `TRUST_PROXY` environment variable.** Operators can opt in to trusting specific proxy hops so that `req.ip` reflects the real client and each client gets its own rate bucket. Three forms are accepted:
  - Unset / `false` / `0` — no proxy trust (default).
  - Positive integer — trust that many proxy hops (e.g. `1`).
  - Comma-separated list of IPs/CIDRs, or the Express presets `loopback`, `linklocal`, `uniquelocal`.
- **Strict validation with fail-fast startup.** Malformed values (bad CIDRs, hostnames, empty entries, `true`, etc.) abort startup with a descriptive error naming the accepted forms. `TRUST_PROXY=true` is deliberately rejected, because unrestricted trust would let clients spoof `X-Forwarded-For` and defeat the limiter.
- **Documented reverse-proxy guidance.** The README now explains the proxy-collapse risk, the supported `TRUST_PROXY` values, and the two hard requirements: the trusted proxy must overwrite client-supplied forwarding headers, and unrestricted trust is rejected.

### Test coverage

- The `/api` exemption is pinned to the exact namespace, so `/apiary`, `/api-v2`, `/apis` are rate-limited while `/api` and `/api/*` are not.
- Unknown API GET routes still return a JSON 404 (boundary pin from issue #103).
- Non-GET/HEAD methods bypass the limiter and land in Express's ordinary 404 path.
- `parseTrustProxy` is unit-tested for every accepted form and rejected form.
- Module-load failure is tested for `TRUST_PROXY=true` and a malformed CIDR, verifying the descriptive startup error.
- With `TRUST_PROXY=1`, two distinct `X-Forwarded-For` clients receive distinct rate buckets, demonstrating that proxy trust restores per-client isolation without breaking the `/api` exemption.

---

Reject `/0` CIDRs in `TRUST_PROXY` validation

### Summary
Adds explicit rejection of `/0` CIDRs (e.g. `0.0.0.0/0`, `::/0`, `10.0.0.0/0`) in `TRUST_PROXY` validation. Prefix length 0 matches every address of the family — semantically unrestricted trust — which the contract deliberately rejects. Also fixes an opaque `proxy-addr` `TypeError` ("invalid range on address") that previously crashed startup when a `/0` CIDR slipped past validation.

### Changes

**`server/index.ts` — `isTrustProxyEntry`**
- Reject any CIDR with prefix length `< 1` so `/0` entries (which match every address) fail the project's validator with a descriptive `Invalid TRUST_PROXY value` error instead of falling through to `proxy-addr`'s opaque `TypeError`.
- Updated the accepted-form message to state the valid prefix-length ranges (1–32 for IPv4, 1–128 for IPv6).

**`server/spa.test.ts`**
- Added `"0.0.0.0/0"`, `"::/0"`, and `"10.0.0.0/0"` to the malformed-`TRUST_PROXY` table-driven test (must fail at module load with the descriptive error).
- Added a focused test confirming that setting `TRUST_PROXY=0.0.0.0/0` aborts startup with an `Invalid TRUST_PROXY value` error (catching the regression where `proxy-addr.compile()` would have thrown first).

**`README.md`**
- Documented that `/0` CIDRs (`0.0.0.0/0`, `::/0`) are rejected at startup alongside `"true"` and other malformed values, with a brief explanation of why (zero prefix length = blanket trust = spoofable forwarding headers).
<!-- kody-pr-summary:end -->