### PR TITLE
fix(game): guard zero-size sprite canvases and make the render loop fault-tolerant (#172)

### DIFF
--- a/src/game/GameEngine.integration.test.ts
+++ b/src/game/GameEngine.integration.test.ts
@@ -568,7 +568,7 @@ describe('GameEngine integration: render fault tolerance (issue #172)', () => {
     engine.addCharacter({ id: 'cybera', name: 'Cybera', x: 2, y: 2, state: 'idle' });
 
     engine.start();
-    expect(frameErrorSpy).toHaveBeenCalledWith('[GameEngine] frame error', frameFailure);
+    expect(frameErrorSpy).toHaveBeenCalledWith('[GameEngine] render error', frameFailure);
     expect(pendingFrames).toHaveLength(1);
 
     engine.setCharacterSprite('cybera', makeCharacterSprite(goodCanvas));

--- a/src/game/GameEngine.integration.test.ts
+++ b/src/game/GameEngine.integration.test.ts
@@ -579,4 +579,34 @@ describe('GameEngine integration: render fault tolerance (issue #172)', () => {
     expect(drawnSources).toContain(goodCanvas);
     expect(pendingFrames).toHaveLength(1);
   });
+
+  it('skips the render but keeps the loop alive when update throws, then recovers', () => {
+    const made = makeCanvasWithStubbedContext();
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(made.recorded.ctx);
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    engine = new GameEngine(made.canvas, GRID) as unknown as TestGameEngine;
+    engine.addCharacter({ id: 'cybera', name: 'Cybera', x: 2, y: 2, state: 'idle' });
+
+    const updateFailure = new Error('bad state');
+    const realUpdate = engine.update.bind(engine);
+    let shouldThrow = true;
+    engine.update = ((dt: number) => {
+      if (shouldThrow) { throw updateFailure; }
+      realUpdate(dt);
+    }) as typeof engine.update;
+
+    engine.start();
+    expect(errorSpy).toHaveBeenCalledWith('[GameEngine] update error', updateFailure);
+    expect(pendingFrames).toHaveLength(1); // loop rescheduled despite the update failure
+    // Render skipped for the failed frame: partial update state never drawn.
+    expect(made.recorded.fills.length).toBe(0);
+
+    // Recovery: state fixed, next frame updates and renders normally.
+    shouldThrow = false;
+    const nextFrame = pendingFrames.shift();
+    expect(nextFrame).toBeDefined();
+    nextFrame!(performance.now());
+    expect(made.recorded.fills.length).toBeGreaterThan(0);
+    expect(pendingFrames).toHaveLength(1);
+  });
 });

--- a/src/game/GameEngine.integration.test.ts
+++ b/src/game/GameEngine.integration.test.ts
@@ -28,6 +28,7 @@ import type { EditorCallbacks } from './EditorController';
 import type { PlacedFurniture } from '../../shared/types';
 import { SUBAGENT_FADE_DURATION } from './SubAgentFSM';
 import { getDayPhase } from './Schedule';
+import type { ReadonlyLoadedCharacter } from './SpriteLoader';
 import { sfx } from '../audio/SoundFX';
 
 // Web Audio is unavailable in jsdom; replace the singleton with no-op spies
@@ -69,6 +70,7 @@ type SubAgentCharacter = {
 };
 
 type TestGameEngine = {
+  characters_sprites: readonly ReadonlyLoadedCharacter[];
   characters: Map<string, SubAgentCharacter>;
   nowMs: number;
   dayPhase: number;
@@ -94,12 +96,14 @@ type TestGameEngine = {
   killSubAgent(subId: string): void;
   reviveSubAgent(subId: string): void;
   isCharacterDying(id: string): boolean;
+  setCharacterSprite(agentId: string, sprite: ReadonlyLoadedCharacter): void;
+  start(): void;
   stop(): void;
 };
 
 // ── Recording 2D context + canvas harness ────────────────────────────────────
 
-function makeRecordingContext(): RecordingContext {
+function makeRecordingContext(onDrawImage: (...args: unknown[]) => void = () => {}): RecordingContext {
   const fills: RecordingContext['fills'] = [];
   const texts: RecordingContext['texts'] = [];
   const stub = {
@@ -110,7 +114,7 @@ function makeRecordingContext(): RecordingContext {
       texts.push({ text, x, y });
     },
     clearRect() {},
-    drawImage() {},
+    drawImage(...args: unknown[]) { onDrawImage(...args); },
     save() {},
     restore() {},
     beginPath() {},
@@ -124,6 +128,7 @@ function makeRecordingContext(): RecordingContext {
     scale() {},
     setLineDash() {},
     stroke() {},
+    fill() {},
     strokeRect() {},
     measureText(text: string) {
       return { width: text.length * 6 };
@@ -154,12 +159,14 @@ function makeRecordingContext(): RecordingContext {
 
 const GRID = { tileSize: 16, gridWidth: 24, gridHeight: 16 };
 
-function makeCanvasWithStubbedContext(): {
+function makeCanvasWithStubbedContext(
+  onDrawImage?: (...args: unknown[]) => void,
+): {
   canvas: HTMLCanvasElement;
   recorded: RecordingContext;
 } {
   const canvas = document.createElement('canvas');
-  const recorded = makeRecordingContext();
+  const recorded = makeRecordingContext(onDrawImage);
 
   // The engine constructor calls `canvas.getContext('2d')!` immediately, so
   // install the recording 2D context BEFORE constructing it.
@@ -182,6 +189,11 @@ function makeCanvasWithStubbedContext(): {
   } as DOMRect);
 
   return { canvas, recorded };
+}
+
+function makeCharacterSprite(canvas: HTMLCanvasElement): ReadonlyLoadedCharacter {
+  const frames = Array.from({ length: 7 }, () => ({ canvas, width: 16, height: 32 }));
+  return { down: frames, up: frames, right: frames, left: frames };
 }
 
 function clientCenterOf(gridX: number, gridY: number): { x: number; y: number } {
@@ -483,5 +495,88 @@ describe('GameEngine integration: schedule progression and overlay render', () =
     );
     expect(fullOverlayFill?.style).toBe(expected.overlay);
     expect(fullOverlayFill?.style).not.toBe(phaseBefore);
+  });
+});
+
+describe('GameEngine integration: render fault tolerance (issue #172)', () => {
+  let engine: TestGameEngine | null;
+  let pendingFrames: FrameRequestCallback[];
+
+  beforeEach(() => {
+    engine = null;
+    pendingFrames = [];
+    vi.stubGlobal('requestAnimationFrame', vi.fn((callback: FrameRequestCallback) => {
+      pendingFrames.push(callback);
+      return pendingFrames.length;
+    }));
+    vi.stubGlobal('cancelAnimationFrame', vi.fn());
+  });
+
+  afterEach(() => {
+    engine?.stop();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it('renders the placeholder instead of drawing a zero-size override canvas', () => {
+    const drawnSources: unknown[] = [];
+    const made = makeCanvasWithStubbedContext((source) => {
+      if (source instanceof HTMLCanvasElement && (source.width === 0 || source.height === 0)) {
+        throw new DOMException('Canvas has no image data', 'InvalidStateError');
+      }
+      drawnSources.push(source);
+    });
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(made.recorded.ctx);
+    const frameErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    engine = new GameEngine(made.canvas, GRID) as unknown as TestGameEngine;
+
+    const baseCanvas = document.createElement('canvas');
+    baseCanvas.width = 16;
+    baseCanvas.height = 32;
+    const zeroSizeCanvas = document.createElement('canvas');
+    zeroSizeCanvas.width = 0;
+    zeroSizeCanvas.height = 0;
+    engine.characters_sprites = [makeCharacterSprite(baseCanvas)];
+    engine.setCharacterSprite('cybera', makeCharacterSprite(zeroSizeCanvas));
+    engine.addCharacter({ id: 'cybera', name: 'Cybera', x: 2, y: 2, state: 'idle' });
+
+    expect(() => engine!.start()).not.toThrow();
+    expect(drawnSources).not.toContain(zeroSizeCanvas);
+    expect(made.recorded.fills.some(fill => fill.style === '#e94560')).toBe(true);
+    expect(frameErrorSpy).not.toHaveBeenCalled();
+  });
+
+  it('reschedules before a render error so a subsequent good frame still renders', () => {
+    const badCanvas = document.createElement('canvas');
+    badCanvas.width = 16;
+    badCanvas.height = 32;
+    const goodCanvas = document.createElement('canvas');
+    goodCanvas.width = 16;
+    goodCanvas.height = 32;
+    const frameFailure = new DOMException('Bad sprite frame', 'InvalidStateError');
+    const drawnSources: unknown[] = [];
+    const made = makeCanvasWithStubbedContext((source) => {
+      drawnSources.push(source);
+      if (source === badCanvas) throw frameFailure;
+    });
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(made.recorded.ctx);
+    const frameErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    engine = new GameEngine(made.canvas, GRID) as unknown as TestGameEngine;
+    engine.characters_sprites = [makeCharacterSprite(goodCanvas)];
+    engine.setCharacterSprite('cybera', makeCharacterSprite(badCanvas));
+    engine.addCharacter({ id: 'cybera', name: 'Cybera', x: 2, y: 2, state: 'idle' });
+
+    engine.start();
+    expect(frameErrorSpy).toHaveBeenCalledWith('[GameEngine] frame error', frameFailure);
+    expect(pendingFrames).toHaveLength(1);
+
+    engine.setCharacterSprite('cybera', makeCharacterSprite(goodCanvas));
+    const nextFrame = pendingFrames.shift();
+    expect(nextFrame).toBeDefined();
+    nextFrame!(performance.now());
+
+    expect(drawnSources).toContain(goodCanvas);
+    expect(pendingFrames).toHaveLength(1);
   });
 });

--- a/src/game/GameEngine.ts
+++ b/src/game/GameEngine.ts
@@ -325,16 +325,24 @@ export class GameEngine {
   private loop = () => {
     if (!this.running) return;
     // Reschedule first so no frame error can kill the loop (issue #172).
-    // update() errors are game-state logic bugs: let them propagate uncaught
-    // so they surface loudly instead of drifting silently. Only render faults
-    // are contained — that is where bad canvases/sprites can throw.
+    // update() faults (game-state logic bugs) skip the render for that frame
+    // so partially-committed state never reaches the canvas, and are logged
+    // with a distinct tag; the loop stays alive so it recovers as soon as
+    // good state arrives. render() faults (bad canvases/sprites) are
+    // contained separately (Kody review on PR #173).
     this.animFrameId = requestAnimationFrame(this.loop);
     this.nowMs = performance.now();
     const rawDt = (this.nowMs - this.lastTime) / 1000;
     // Clamp delta time to prevent teleportation when tab is backgrounded
     const dt = Math.min(rawDt, 0.1); // cap at 100ms (~10 frames)
     this.lastTime = this.nowMs;
-    this.update(dt);
+    try {
+      this.update(dt);
+    } catch (err) {
+      console.error('[GameEngine] update error', err);
+      // Skip render this frame: partial update state must not be drawn.
+      return;
+    }
     try {
       this.render();
     } catch (err) {

--- a/src/game/GameEngine.ts
+++ b/src/game/GameEngine.ts
@@ -324,14 +324,18 @@ export class GameEngine {
 
   private loop = () => {
     if (!this.running) return;
-    this.nowMs = performance.now();
-    const rawDt = (this.nowMs - this.lastTime) / 1000;
-    // Clamp delta time to prevent teleportation when tab is backgrounded
-    const dt = Math.min(rawDt, 0.1); // cap at 100ms (~10 frames)
-    this.lastTime = this.nowMs;
-    this.update(dt);
-    this.render();
     this.animFrameId = requestAnimationFrame(this.loop);
+    try {
+      this.nowMs = performance.now();
+      const rawDt = (this.nowMs - this.lastTime) / 1000;
+      // Clamp delta time to prevent teleportation when tab is backgrounded
+      const dt = Math.min(rawDt, 0.1); // cap at 100ms (~10 frames)
+      this.lastTime = this.nowMs;
+      this.update(dt);
+      this.render();
+    } catch (err) {
+      console.error('[GameEngine] frame error', err);
+    }
   };
 
   // ── Obstacle map ─────────────────────────────────────
@@ -906,7 +910,7 @@ export class GameEngine {
         }
 
         const spriteItem = furniture.get(item.type);
-        if (assetsLoaded && spriteItem) {
+        if (assetsLoaded && spriteItem && spriteItem.canvas.width > 0 && spriteItem.canvas.height > 0) {
           ctx.imageSmoothingEnabled = false;
           ctx.drawImage(spriteItem.canvas, px, py, spriteItem.width * zoom, spriteItem.height * zoom);
         } else {
@@ -950,10 +954,12 @@ export class GameEngine {
       const deskItem = furniture.get('DESK');
       const pcItem = furniture.get('PC');
       const chairItem = furniture.get('CUSHIONED_CHAIR') || furniture.get('WOODEN_CHAIR');
-      if (assetsLoaded && (deskItem || pcItem)) {
-        if (deskItem) { ctx.imageSmoothingEnabled = false; ctx.drawImage(deskItem.canvas, px, py - deskItem.height * zoom, deskItem.width * zoom, deskItem.height * zoom); }
-        if (pcItem) { ctx.imageSmoothingEnabled = false; ctx.drawImage(pcItem.canvas, px + tileSize * 0.3, py - pcItem.height * zoom - (deskItem?.height ?? 0) * zoom * 0.5, pcItem.width * zoom, pcItem.height * zoom); }
-        if (chairItem) { ctx.imageSmoothingEnabled = false; ctx.drawImage(chairItem.canvas, px + tileSize * 0.2, py + tileSize * 0.1, chairItem.width * zoom, chairItem.height * zoom); }
+      const hasDesk = deskItem && deskItem.canvas.width > 0 && deskItem.canvas.height > 0;
+      const hasPc = pcItem && pcItem.canvas.width > 0 && pcItem.canvas.height > 0;
+      if (assetsLoaded && (hasDesk || hasPc)) {
+        if (hasDesk) { ctx.imageSmoothingEnabled = false; ctx.drawImage(deskItem.canvas, px, py - deskItem.height * zoom, deskItem.width * zoom, deskItem.height * zoom); }
+        if (hasPc) { ctx.imageSmoothingEnabled = false; ctx.drawImage(pcItem.canvas, px + tileSize * 0.3, py - pcItem.height * zoom - (deskItem?.height ?? 0) * zoom * 0.5, pcItem.width * zoom, pcItem.height * zoom); }
+        if (chairItem && chairItem.canvas.width > 0 && chairItem.canvas.height > 0) { ctx.imageSmoothingEnabled = false; ctx.drawImage(chairItem.canvas, px + tileSize * 0.2, py + tileSize * 0.1, chairItem.width * zoom, chairItem.height * zoom); }
       } else {
         this.renderFallbackDesk(agentId, px, py, tileSize);
       }
@@ -963,7 +969,7 @@ export class GameEngine {
   private drawFurnitureItem(type: string, px: number, py: number, tileSize: number, zoom: number) {
     const { ctx, furniture, assetsLoaded } = this;
     const item = furniture.get(type);
-    if (assetsLoaded && item) {
+    if (assetsLoaded && item && item.canvas.width > 0 && item.canvas.height > 0) {
       ctx.imageSmoothingEnabled = false;
       ctx.drawImage(item.canvas, px, py, item.width * zoom, item.height * zoom);
     } else {
@@ -1045,7 +1051,7 @@ export class GameEngine {
       if (!sprite) { this.renderPlaceholderCharacter(char, px, py, tileSize); }
       else {
         const frameCanvas = getSpriteFrame(sprite, animState, char.direction, char.animFrame);
-        if (!frameCanvas) { this.renderPlaceholderCharacter(char, px, py, tileSize); }
+        if (!frameCanvas || frameCanvas.width === 0 || frameCanvas.height === 0) { this.renderPlaceholderCharacter(char, px, py, tileSize); }
         else {
           const scale = char.isSubAgent ? 1.5 : 2;
           const spriteW = 16 * scale, spriteH = 32 * scale;

--- a/src/game/GameEngine.ts
+++ b/src/game/GameEngine.ts
@@ -958,7 +958,7 @@ export class GameEngine {
       const hasPc = pcItem && pcItem.canvas.width > 0 && pcItem.canvas.height > 0;
       if (assetsLoaded && (hasDesk || hasPc)) {
         if (hasDesk) { ctx.imageSmoothingEnabled = false; ctx.drawImage(deskItem.canvas, px, py - deskItem.height * zoom, deskItem.width * zoom, deskItem.height * zoom); }
-        if (hasPc) { ctx.imageSmoothingEnabled = false; ctx.drawImage(pcItem.canvas, px + tileSize * 0.3, py - pcItem.height * zoom - (deskItem?.height ?? 0) * zoom * 0.5, pcItem.width * zoom, pcItem.height * zoom); }
+        if (hasPc) { ctx.imageSmoothingEnabled = false; ctx.drawImage(pcItem.canvas, px + tileSize * 0.3, py - pcItem.height * zoom - (hasDesk ? deskItem.height : 0) * zoom * 0.5, pcItem.width * zoom, pcItem.height * zoom); }
         if (chairItem && chairItem.canvas.width > 0 && chairItem.canvas.height > 0) { ctx.imageSmoothingEnabled = false; ctx.drawImage(chairItem.canvas, px + tileSize * 0.2, py + tileSize * 0.1, chairItem.width * zoom, chairItem.height * zoom); }
       } else {
         this.renderFallbackDesk(agentId, px, py, tileSize);

--- a/src/game/GameEngine.ts
+++ b/src/game/GameEngine.ts
@@ -324,17 +324,21 @@ export class GameEngine {
 
   private loop = () => {
     if (!this.running) return;
+    // Reschedule first so no frame error can kill the loop (issue #172).
+    // update() errors are game-state logic bugs: let them propagate uncaught
+    // so they surface loudly instead of drifting silently. Only render faults
+    // are contained — that is where bad canvases/sprites can throw.
     this.animFrameId = requestAnimationFrame(this.loop);
+    this.nowMs = performance.now();
+    const rawDt = (this.nowMs - this.lastTime) / 1000;
+    // Clamp delta time to prevent teleportation when tab is backgrounded
+    const dt = Math.min(rawDt, 0.1); // cap at 100ms (~10 frames)
+    this.lastTime = this.nowMs;
+    this.update(dt);
     try {
-      this.nowMs = performance.now();
-      const rawDt = (this.nowMs - this.lastTime) / 1000;
-      // Clamp delta time to prevent teleportation when tab is backgrounded
-      const dt = Math.min(rawDt, 0.1); // cap at 100ms (~10 frames)
-      this.lastTime = this.nowMs;
-      this.update(dt);
       this.render();
     } catch (err) {
-      console.error('[GameEngine] frame error', err);
+      console.error('[GameEngine] render error', err);
     }
   };
 
@@ -1051,7 +1055,8 @@ export class GameEngine {
       if (!sprite) { this.renderPlaceholderCharacter(char, px, py, tileSize); }
       else {
         const frameCanvas = getSpriteFrame(sprite, animState, char.direction, char.animFrame);
-        if (!frameCanvas || frameCanvas.width === 0 || frameCanvas.height === 0) { this.renderPlaceholderCharacter(char, px, py, tileSize); }
+        // getSpriteFrame nulls zero-size canvases centrally — trust that contract here.
+        if (!frameCanvas) { this.renderPlaceholderCharacter(char, px, py, tileSize); }
         else {
           const scale = char.isSubAgent ? 1.5 : 2;
           const spriteW = 16 * scale, spriteH = 32 * scale;

--- a/src/game/SpriteLoader.test.ts
+++ b/src/game/SpriteLoader.test.ts
@@ -1,7 +1,8 @@
-import { describe, expectTypeOf, it } from 'vitest';
+import { describe, expect, expectTypeOf, it } from 'vitest';
 
 import {
   getComposedCharacter,
+  getSpriteFrame,
   loadAllAssets,
   loadCharacters,
   loadFloors,
@@ -225,5 +226,20 @@ describe('SpriteLoader public API contracts (issue #132)', () => {
       readonly floors: readonly ReadonlyLoadedFloor[];
       readonly furniture: ReadonlyMap<string, ReadonlyLoadedFurnitureItem>;
     }>();
+  });
+
+  it('getSpriteFrame rejects a zero-size source canvas (issue #172)', () => {
+    const canvas = document.createElement('canvas');
+    canvas.width = 0;
+    canvas.height = 0;
+    const frame: ReadonlySpriteFrame = { canvas, width: 16, height: 32 };
+    const character: ReadonlyLoadedCharacter = {
+      down: [frame],
+      up: [frame],
+      right: [frame],
+      left: [frame],
+    };
+
+    expect(getSpriteFrame(character, 'idle', 'down', 0)).toBeNull();
   });
 });

--- a/src/game/SpriteLoader.ts
+++ b/src/game/SpriteLoader.ts
@@ -535,7 +535,9 @@ export function getSpriteFrame(
 
   // All directions now have pre-cached frames
   const frame = character[dir]?.[frameIdx];
-  return frame?.canvas ?? null;
+  const canvas = frame?.canvas;
+  if (!canvas || canvas.width === 0 || canvas.height === 0) return null;
+  return canvas;
 }
 
 /** Access cached characters. Returns a compile-time readonly view —
@@ -596,6 +598,16 @@ export function recomposeAgent(
 ): ReadonlyLoadedCharacter | null {
   try {
     const composed = composeCharacter(recipe);
+    const canvases = [
+      ...composed.down,
+      ...composed.up,
+      ...composed.right,
+      composed.portrait,
+    ];
+    if (canvases.some(canvas => canvas.width === 0 || canvas.height === 0)) {
+      disposeComposed(composed);
+      return null;
+    }
     const old = cachedComposed.get(agentId);
     cachedComposed.set(agentId, composed);
     if (old) disposeComposed(old);


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
## Summary

Fixes a render-loop crash (#172) where zero-dimension sprite canvases caused an `InvalidStateError` in `drawImage`, permanently freezing the office canvas because `requestAnimationFrame` was rescheduled **after** `render()` with no error handling.

## Changes

### Sink guards (`src/game/GameEngine.ts`)

- **`renderCharacter`**: zero-dimension frame canvases now fall through to `renderPlaceholderCharacter` — the previous `if (!frameCanvas)` truthy check was insufficient because `0×0` canvases are truthy.
- **`drawFurnitureItem`**: guards against `0×0` canvases before drawing.
- **Desk/PC/chair composite draw site**: individual `hasDesk` / `hasPc` / `chairItem` checks validate non-zero dimensions before each `drawImage` call.

### Source fix (`src/game/SpriteLoader.ts`)

- **`getSpriteFrame`**: returns `null` for `0×0` source canvases.
- **`recomposeAgent`**: validates composed output by checking all direction canvases (down, up, right) plus the portrait; if any is `0×0`, the composed result is disposed and `null` is returned, preventing bad canvases from entering the cache or override pipeline.

### Loop fault tolerance (`src/game/GameEngine.ts`)

The render loop now:

1. Reschedules `requestAnimationFrame` **before** `update()`/`render()`.
2. Wraps frame execution in `try`/`catch`, logging failures as `console.error('[GameEngine] frame error', err)`.

A single bad frame can no longer become a permanent outage — the loop continues to the next frame.

### Tests

**`src/game/GameEngine.integration.test.ts`** (new `describe` block: `render fault tolerance (issue #172)`)

- Zero-size override sprite → placeholder renders (pink `#e94560` fill recorded), no `drawImage` against the zero canvas, no throw, no `frame error` logged.
- Loop recovery: an injected `InvalidStateError` from `drawImage` is caught and logged, the next `requestAnimationFrame` is queued before the failure, and after swapping to a valid sprite the next frame renders successfully.
- Test harness additions: `setCharacterSprite` / `start` / `characters_sprites` exposure, `drawImage` recording via callback, `fill()` stub completion (required by the placeholder path; gap surfaced by the new try/catch during verification), and a `makeCharacterSprite` helper.

**`src/game/SpriteLoader.test.ts`**

- `getSpriteFrame` with a `0×0` source canvas returns `null`.

## Impact

- No behavior change for valid sprites.
- A corrupt or unloaded sprite now renders the placeholder for that frame instead of freezing the entire office canvas.
- The render loop is now self-healing — any per-frame rendering error is contained and reported rather than halting the loop indefinitely.

Closes #172

---

Fix rendering bug for PC sprites when no desk is present

The change addresses a potential issue in the render loop where the PC sprite's vertical position was calculated using `deskItem?.height ?? 0`. The new code uses the `hasDesk` boolean flag (which is already validated earlier in the same conditional) to determine whether to apply the desk-height offset, ensuring consistency with the sprite rendering logic above it.

---

**Summary**

This PR hardens the game's render loop so that sprite rendering failures — particularly those from zero-size canvases — can no longer crash the loop or silently corrupt frames.

**What changed**

1. **Render loop is now fault-tolerant** (`GameEngine.ts` – `loop`):
   - The `requestAnimationFrame` call is moved to the top of the loop, before any work runs. This guarantees the next frame is scheduled even if the current frame throws.
   - The timing computation (`nowMs`, `rawDt`, `dt`, `lastTime`) and `update(dt)` are now performed **outside** the `try/catch`, before rendering.
   - Only `render()` is wrapped in `try/catch`. Render errors are logged as `[GameEngine] render error` and the loop continues.
   - `update()` errors intentionally propagate uncaught, so game-state bugs surface visibly rather than drifting silently.

2. **Zero-size canvas guard centralized** (`GameEngine.ts` – `renderCharacter`):
   - The local `frameCanvas.width === 0 || frameCanvas.height === 0` check was removed.
   - A comment notes that `getSpriteFrame` is responsible for nulling zero-size canvases centrally, and the render code now simply trusts that contract.

3. **Test updated** (`GameEngine.integration.test.ts`):
   - The render fault-tolerance test now expects the new log message `[GameEngine] render error` instead of the old `[GameEngine] frame error`.

**Why**

Previously, a render exception (e.g. from a malformed or zero-size sprite canvas) could either kill the animation loop or be misclassified, hiding the real cause. The new structure makes the loop resilient to render-only failures while still keeping the loop alive frame-to-frame, and centralizes the zero-size canvas handling so it is handled consistently in one place.

---

# Summary

This PR makes the game's render loop fault-tolerant by guarding against errors during the `update()` phase, in addition to the existing `render()` error containment.

## Changes

**`src/game/GameEngine.ts`**
- Wrapped the `update(dt)` call in a `try/catch` block inside the animation loop.
- When `update()` throws, the error is now logged with the distinct tag `[GameEngine] update error`, the render step is skipped for that frame (so any partially-committed state never reaches the canvas), and the loop keeps running.
- Updated the inline comment to reflect the new behavior: `update()` faults skip the render and log, while `render()` faults remain separately contained.
- Note: `requestAnimationFrame(this.loop)` was already rescheduled first, so the loop continues regardless.

**`src/game/GameEngine.integration.test.ts`**
- Added a new integration test that verifies when `update()` throws:
  - The error is logged via `console.error` with the `[GameEngine] update error` tag.
  - The animation loop reschedules itself (pending frames continue).
  - No drawing occurs for the failed frame.
  - Once the underlying issue is resolved, the next frame both updates and renders normally.

## Behavior

Previously, an error in `update()` would propagate uncaught and kill the render loop. Now, such errors are caught, logged, and the render for that frame is skipped — preventing corrupted intermediate state from being drawn — while the engine continues running and recovers automatically on the next frame.
<!-- kody-pr-summary:end -->