### PR TITLE
fix(game): isolate engine layout state

### DIFF
--- a/src/game/GameEngine.integration.test.ts
+++ b/src/game/GameEngine.integration.test.ts
@@ -264,8 +264,13 @@ describe('GameEngine integration: editor adapters', () => {
     expect(gameCallbacks.onCharacterClick).toHaveBeenCalledWith('test-agent');
   });
 
-  it('drags, places, and rotates furniture through the full host adapter closure', () => {
-    engine.setLayout([{ id: 'desk-1', type: 'DESK', x: 3, y: 4, rotation: 0 }]);
+  it('keeps caller layout immutable while dragging and rotating through the host closure', () => {
+    const callerFurniture: PlacedFurniture[] = [
+      { id: 'desk-1', type: 'DESK', x: 3, y: 4, rotation: 0 },
+    ];
+    Object.freeze(callerFurniture[0]);
+    Object.freeze(callerFurniture);
+    engine.setLayout(callerFurniture);
     engine.setEditorMode(true);
 
     const start = clientCenterOf(3, 4);
@@ -285,6 +290,13 @@ describe('GameEngine integration: editor adapters', () => {
       x: 8,
       y: 9,
     });
+    expect(callerFurniture[0]).toEqual({
+      id: 'desk-1',
+      type: 'DESK',
+      x: 3,
+      y: 4,
+      rotation: 0,
+    });
     expect(editorCallbacks.onMoveFurniture).not.toHaveBeenCalled();
 
     canvas.dispatchEvent(
@@ -301,6 +313,7 @@ describe('GameEngine integration: editor adapters', () => {
       }),
     );
     expect(engine.getPlacedFurniture()[0].rotation).toBe(90);
+    expect(callerFurniture[0].rotation).toBe(0);
     expect(editorCallbacks.onRotateFurniture).toHaveBeenCalledWith('desk-1', 90);
   });
 });

--- a/src/game/GameEngine.ts
+++ b/src/game/GameEngine.ts
@@ -1757,7 +1757,7 @@ export class GameEngine {
   setSelectedFurnitureId(id: string | null) { this.editor.setSelectedFurnitureId(id); }
 
   setLayout(furniture: PlacedFurniture[], seats?: Record<string, { x: number; y: number }>) {
-    this.placedFurniture = furniture;
+    this.placedFurniture = furniture.map(item => ({ ...item }));
     this.obstacleDirty = true;
     // Schedule deferred rebuild to avoid blocking during rapid updates
     this.scheduleObstacleRebuild();


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
## Summary

Establishes a clear ownership boundary between the game engine and its host adapter for furniture layout state.

## Changes

### Engine Boundary (`src/game/GameEngine.ts`)

- `setLayout()` now deep-copies each furniture record on entry via `furniture.map(item => ({ ...item }))`, assigning the engine-owned clone array to `this.placedFurniture`.
- Preserves the engine's existing private in-place mutation model for drag previews and rotation.
- Preserves the existing `onMoveFurniture` / `onRotateFurniture` callback contract and deferred obstacle rebuild behavior.

### Test Coverage (`src/game/GameEngine.integration.test.ts`)

- Renames and refactors the editor-adapter integration test to explicitly verify immutability of caller-provided layouts.
- Freezes both the array and the individual furniture record before passing them into `setLayout()`.
- After dragging furniture to a new position, asserts the caller's frozen record still reports its original `{ x: 3, y: 4, rotation: 0 }`.
- After rotating through the host closure, asserts `callerFurniture[0].rotation` remains `0` while the engine's internal state reflects the rotation (`90`).

## Functional Impact

- **Crash prevention**: Caller layouts that are frozen (e.g., React state objects) no longer trigger `TypeError: Cannot assign to read only property 'x'` during drag previews or rotation.
- **State ownership clarity**: The engine now treats incoming furniture data as untrusted input, establishing it as the sole owner of mutable layout state.
- **React compatibility**: React-owned furniture data remains untouched until the host's existing callback path applies edits through the standard state-update flow.
- **No behavioral regression**: Visible engine behavior, previews, and the move/rotation callback contract remain identical.
<!-- kody-pr-summary:end -->