### PR TITLE
fix(store): protect live agent state from stale updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ See [collector/README.md](collector/README.md) for full setup instructions.
 | `LayoutEditor` | Toolbar, furniture palette, layout manager UI |
 | `PixelOffice` | Canvas wrapper, wires agent/layout data to GameEngine |
 | `AgentSidebar` | Agent list with toggles and activity badges |
-| `useAgentStore` | Fetches agent state from backend API |
+| `useAgentStore` | Fetches agent state via REST fallback and switches to Socket.IO only after the first live snapshot |
 | `useLayoutStore` | CRUD operations for layouts with auto-save |
 
 ### Sprite Format

--- a/src/hooks/useAgentStore.test.tsx
+++ b/src/hooks/useAgentStore.test.tsx
@@ -521,6 +521,7 @@ describe('useAgentStore mutation failures', () => {
 
     expect(latest(snapshots).agents[0]?.name).toBe('Socket fixture');
     expect(latest(snapshots).agents[0]?.pixelEnabled).toBe(false);
+    expect(latest(snapshots).error).toBe('Toggle failed');
 
     unmount();
   });

--- a/src/hooks/useAgentStore.test.tsx
+++ b/src/hooks/useAgentStore.test.tsx
@@ -268,11 +268,16 @@ describe('useAgentStore mutation failures', () => {
 
   it('does not let an older failed toggle roll back a newer optimistic toggle', async () => {
     const toggleResolvers: Array<(response: Response) => void> = [];
+    const reconciledAgent = { ...agent, pixelEnabled: false };
+    let getCount = 0;
     vi.stubGlobal('fetch', vi.fn((_: RequestInfo | URL, init?: RequestInit) => {
       if (init?.method === 'POST') {
         return new Promise<Response>((resolve) => toggleResolvers.push(resolve));
       }
-      return Promise.resolve(new Response(JSON.stringify({ agents: [agent] }), {
+      getCount += 1;
+      return Promise.resolve(new Response(JSON.stringify({
+        agents: getCount === 1 ? [agent] : [reconciledAgent],
+      }), {
         status: 200,
         headers: { 'Content-Type': 'application/json' },
       }));
@@ -304,7 +309,7 @@ describe('useAgentStore mutation failures', () => {
     });
 
     expect(latest(snapshots).agents[0]?.pixelEnabled).toBe(false);
-    expect(latest(snapshots).error).toBe('Older toggle failed');
+    expect(latest(snapshots).error).toBeNull();
 
     unmount();
   });
@@ -361,6 +366,161 @@ describe('useAgentStore mutation failures', () => {
       }));
       await mutation;
     });
+
+    expect(latest(snapshots).agents[0]?.pixelEnabled).toBe(false);
+    expect(latest(snapshots).error).toBeNull();
+
+    unmount();
+  });
+
+  it('does not expose a stale failing REST poll that races with an optimistic toggle', async () => {
+    let resolvePoll: ((response: Response) => void) | undefined;
+    let resolveToggle: ((response: Response) => void) | undefined;
+    let getCount = 0;
+    vi.stubGlobal('fetch', vi.fn((_: RequestInfo | URL, init?: RequestInit) => {
+      if (init?.method === 'POST') {
+        return new Promise<Response>((resolve) => {
+          resolveToggle = resolve;
+        });
+      }
+      getCount += 1;
+      if (getCount === 1) {
+        return Promise.resolve(new Response(JSON.stringify({ agents: [agent] }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }));
+      }
+      return new Promise<Response>((resolve) => {
+        resolvePoll = resolve;
+      });
+    }));
+
+    const { snapshots, unmount } = await renderStoreProbe();
+    let poll: Promise<void> | undefined;
+    let mutation: Promise<void> | undefined;
+
+    act(() => {
+      poll = latest(snapshots).refresh();
+    });
+    await flushMicrotasks();
+    act(() => {
+      mutation = latest(snapshots).toggleAgent(agent.id, false);
+    });
+    await flushMicrotasks();
+
+    await act(async () => {
+      resolvePoll?.(new Response(JSON.stringify({ error: 'Stale REST failure' }), {
+        status: 500,
+        headers: { 'Content-Type': 'application/json' },
+      }));
+      await poll;
+    });
+    expect(latest(snapshots).error).toBeNull();
+
+    await act(async () => {
+      resolveToggle?.(new Response(JSON.stringify({ success: true }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }));
+      await mutation;
+    });
+
+    expect(latest(snapshots).agents[0]?.pixelEnabled).toBe(false);
+    expect(latest(snapshots).error).toBeNull();
+
+    unmount();
+  });
+
+  it('reconciles after two superseding single-agent toggles fail', async () => {
+    const toggleResolvers: Array<(response: Response) => void> = [];
+    const serverAgent = { ...agent, name: 'Server fixture', pixelEnabled: true };
+    let getCount = 0;
+    vi.stubGlobal('fetch', vi.fn((_: RequestInfo | URL, init?: RequestInit) => {
+      if (init?.method === 'POST') {
+        return new Promise<Response>((resolve) => toggleResolvers.push(resolve));
+      }
+      getCount += 1;
+      return Promise.resolve(new Response(JSON.stringify({
+        agents: getCount === 1 ? [agent] : [serverAgent],
+      }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }));
+    }));
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const { snapshots, unmount } = await renderStoreProbe();
+    const storeBeforeRerender = latest(snapshots);
+    let older: Promise<void> | undefined;
+    let newer: Promise<void> | undefined;
+
+    act(() => {
+      older = storeBeforeRerender.toggleAgent(agent.id, false);
+      newer = storeBeforeRerender.toggleAgent(agent.id, true);
+    });
+    await flushMicrotasks();
+
+    await act(async () => {
+      toggleResolvers[1]?.(new Response(JSON.stringify({ error: 'Newer toggle failed' }), {
+        status: 500,
+        headers: { 'Content-Type': 'application/json' },
+      }));
+      await newer;
+    });
+    expect(latest(snapshots).agents[0]?.pixelEnabled).toBe(false);
+
+    await act(async () => {
+      toggleResolvers[0]?.(new Response(JSON.stringify({ error: 'Older toggle failed' }), {
+        status: 500,
+        headers: { 'Content-Type': 'application/json' },
+      }));
+      await older;
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    expect(latest(snapshots).agents[0]?.name).toBe('Server fixture');
+    expect(latest(snapshots).agents[0]?.pixelEnabled).toBe(true);
+    expect(latest(snapshots).error).toBeNull();
+
+    unmount();
+  });
+
+  it('preserves a socket snapshot when an optimistic toggle later fails', async () => {
+    let resolveToggle: ((response: Response) => void) | undefined;
+    vi.stubGlobal('fetch', vi.fn((_: RequestInfo | URL, init?: RequestInit) => {
+      if (init?.method === 'POST') {
+        return new Promise<Response>((resolve) => {
+          resolveToggle = resolve;
+        });
+      }
+      return Promise.resolve(new Response(JSON.stringify({ agents: [agent] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }));
+    }));
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const { snapshots, unmount } = await renderStoreProbe();
+    let mutation: Promise<void> | undefined;
+
+    act(() => {
+      mutation = latest(snapshots).toggleAgent(agent.id, false);
+    });
+    await flushMicrotasks();
+
+    const socketAgent = { ...agent, name: 'Socket fixture', pixelEnabled: false };
+    await emitSocketEvent('agents:update', [socketAgent]);
+
+    await act(async () => {
+      resolveToggle?.(new Response(JSON.stringify({ error: 'Toggle failed' }), {
+        status: 500,
+        headers: { 'Content-Type': 'application/json' },
+      }));
+      await mutation;
+    });
+
+    expect(latest(snapshots).agents[0]?.name).toBe('Socket fixture');
+    expect(latest(snapshots).agents[0]?.pixelEnabled).toBe(false);
 
     unmount();
   });
@@ -556,11 +716,16 @@ describe('useAgentStore mutation failures', () => {
   it('does not let an older failed sprite request replace a newer optimistic sprite', async () => {
     const spriteResolvers: Array<(response: Response) => void> = [];
     const agentWithSprite = { ...agent, characterSpriteId: 'char_1' };
+    const reconciledAgent = { ...agent, characterSpriteId: 'char_3' };
+    let getCount = 0;
     vi.stubGlobal('fetch', vi.fn((_: RequestInfo | URL, init?: RequestInit) => {
       if (init?.method === 'POST') {
         return new Promise<Response>((resolve) => spriteResolvers.push(resolve));
       }
-      return Promise.resolve(new Response(JSON.stringify({ agents: [agentWithSprite] }), {
+      getCount += 1;
+      return Promise.resolve(new Response(JSON.stringify({
+        agents: getCount === 1 ? [agentWithSprite] : [reconciledAgent],
+      }), {
         status: 200,
         headers: { 'Content-Type': 'application/json' },
       }));
@@ -592,6 +757,61 @@ describe('useAgentStore mutation failures', () => {
     });
 
     expect(latest(snapshots).agents[0]?.characterSpriteId).toBe('char_3');
+
+    unmount();
+  });
+
+  it('reconciles after two superseding sprite changes fail', async () => {
+    const spriteResolvers: Array<(response: Response) => void> = [];
+    const initialAgent = { ...agent, characterSpriteId: 'char_1' };
+    const serverAgent = { ...agent, name: 'Server fixture', characterSpriteId: 'char_4' };
+    let getCount = 0;
+    vi.stubGlobal('fetch', vi.fn((_: RequestInfo | URL, init?: RequestInit) => {
+      if (init?.method === 'POST') {
+        return new Promise<Response>((resolve) => spriteResolvers.push(resolve));
+      }
+      getCount += 1;
+      return Promise.resolve(new Response(JSON.stringify({
+        agents: getCount === 1 ? [initialAgent] : [serverAgent],
+      }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }));
+    }));
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const { snapshots, unmount } = await renderStoreProbe();
+    const storeBeforeRerender = latest(snapshots);
+    let older: Promise<void> | undefined;
+    let newer: Promise<void> | undefined;
+
+    act(() => {
+      older = storeBeforeRerender.setCharacterSprite(agent.id, 'char_2');
+      newer = storeBeforeRerender.setCharacterSprite(agent.id, 'char_3');
+    });
+    await flushMicrotasks();
+
+    await act(async () => {
+      spriteResolvers[1]?.(new Response(JSON.stringify({ error: 'Newer sprite failed' }), {
+        status: 500,
+        headers: { 'Content-Type': 'application/json' },
+      }));
+      await newer;
+    });
+    expect(latest(snapshots).agents[0]?.characterSpriteId).toBe('char_2');
+
+    await act(async () => {
+      spriteResolvers[0]?.(new Response(JSON.stringify({ error: 'Older sprite failed' }), {
+        status: 500,
+        headers: { 'Content-Type': 'application/json' },
+      }));
+      await older;
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    expect(latest(snapshots).agents[0]?.name).toBe('Server fixture');
+    expect(latest(snapshots).agents[0]?.characterSpriteId).toBe('char_4');
+    expect(latest(snapshots).error).toBeNull();
 
     unmount();
   });

--- a/src/hooks/useAgentStore.test.tsx
+++ b/src/hooks/useAgentStore.test.tsx
@@ -54,9 +54,9 @@ async function flushMicrotasks() {
   });
 }
 
-async function emitSocketEvent(event: 'connect' | 'disconnect') {
+async function emitSocketEvent(event: 'connect' | 'disconnect' | 'agents:update', ...args: unknown[]) {
   await act(async () => {
-    socketMock.handlers.get(event)?.();
+    socketMock.handlers.get(event)?.(...args);
   });
   await flushMicrotasks();
 }
@@ -93,7 +93,7 @@ describe('useAgentStore REST polling fallback', () => {
   it('keeps connected=false when REST fallback succeeds while WebSocket is disconnected', async () => {
     const { snapshots, unmount } = await renderStoreProbe();
 
-    expect(fetch).toHaveBeenCalled();
+    expect(fetch).toHaveBeenCalledTimes(1);
     expect(latest(snapshots).connected).toBe(false);
 
     unmount();
@@ -117,7 +117,9 @@ describe('useAgentStore REST polling fallback', () => {
     const { snapshots, unmount } = await renderStoreProbe();
 
     await emitSocketEvent('connect');
+    expect(latest(snapshots).connected).toBe(false);
 
+    await emitSocketEvent('agents:update', []);
     expect(latest(snapshots).connected).toBe(true);
 
     const callsAfterReconnect = vi.mocked(fetch).mock.calls.length;
@@ -135,6 +137,7 @@ describe('useAgentStore REST polling fallback', () => {
     const { snapshots, unmount } = await renderStoreProbe();
 
     await emitSocketEvent('connect');
+    await emitSocketEvent('agents:update', []);
     expect(latest(snapshots).connected).toBe(true);
 
     const callsBeforeDisconnect = vi.mocked(fetch).mock.calls.length;
@@ -152,6 +155,445 @@ describe('useAgentStore REST polling fallback', () => {
 
     unmount();
     expect(socketMock.socket.disconnect).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not let an in-flight REST response overwrite a newer socket snapshot', async () => {
+    const restResolvers: Array<(response: Response) => void> = [];
+    vi.mocked(fetch).mockImplementation(() => new Promise<Response>((resolve) => {
+      restResolvers.push(resolve);
+    }));
+
+    const { snapshots, unmount } = await renderStoreProbe();
+    expect(restResolvers.length).toBeGreaterThan(0);
+
+    const socketAgent = {
+      id: 'agent-1',
+      name: 'Fresh socket state',
+      activity: 'typing' as const,
+      model: 'test',
+      sessionKey: 'socket',
+      active: true,
+      lastActivity: 2,
+      pixelEnabled: false,
+      tags: [],
+    };
+    await emitSocketEvent('agents:update', [socketAgent]);
+
+    await act(async () => {
+      for (const resolve of restResolvers) {
+        resolve(new Response(JSON.stringify({
+          agents: [{ ...socketAgent, name: 'Stale REST state', lastActivity: 1, pixelEnabled: true }],
+        }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }));
+      }
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    expect(latest(snapshots).agents).toEqual([socketAgent]);
+    expect(latest(snapshots).connected).toBe(true);
+
+    unmount();
+  });
+});
+
+describe('useAgentStore mutation failures', () => {
+  const agent = {
+    id: 'agent-1',
+    name: 'Test Agent',
+    activity: 'typing' as const,
+    model: 'test',
+    sessionKey: 's1',
+    active: true,
+    lastActivity: 1,
+    pixelEnabled: true,
+    tags: [],
+  };
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    socketMock.handlers.clear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('rolls back an optimistic toggle and exposes an HTTP 500 error', async () => {
+    let resolveToggle: ((response: Response) => void) | undefined;
+    vi.stubGlobal('fetch', vi.fn((_: RequestInfo | URL, init?: RequestInit) => {
+      if (init?.method === 'POST') {
+        return new Promise<Response>((resolve) => {
+          resolveToggle = resolve;
+        });
+      }
+      return Promise.resolve(new Response(JSON.stringify({ agents: [agent] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }));
+    }));
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const { snapshots, unmount } = await renderStoreProbe();
+    expect(latest(snapshots).agents[0]?.pixelEnabled).toBe(true);
+
+    let mutation: Promise<void> | undefined;
+    act(() => {
+      mutation = latest(snapshots).toggleAgent(agent.id, false);
+    });
+    await flushMicrotasks();
+    expect(latest(snapshots).agents[0]?.pixelEnabled).toBe(false);
+
+    await act(async () => {
+      resolveToggle?.(new Response(JSON.stringify({ error: 'Toggle failed' }), {
+        status: 500,
+        headers: { 'Content-Type': 'application/json' },
+      }));
+      await mutation;
+    });
+
+    expect(latest(snapshots).agents[0]?.pixelEnabled).toBe(true);
+    expect(latest(snapshots).error).toBe('Toggle failed');
+
+    await act(async () => {
+      await latest(snapshots).toggleAll(true);
+    });
+    expect(latest(snapshots).error).toBe('Toggle failed');
+
+    unmount();
+  });
+
+  it('does not let an older failed toggle roll back a newer optimistic toggle', async () => {
+    const toggleResolvers: Array<(response: Response) => void> = [];
+    vi.stubGlobal('fetch', vi.fn((_: RequestInfo | URL, init?: RequestInit) => {
+      if (init?.method === 'POST') {
+        return new Promise<Response>((resolve) => toggleResolvers.push(resolve));
+      }
+      return Promise.resolve(new Response(JSON.stringify({ agents: [agent] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }));
+    }));
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const { snapshots, unmount } = await renderStoreProbe();
+    let older: Promise<void> | undefined;
+    let newer: Promise<void> | undefined;
+    const storeBeforeRerender = latest(snapshots);
+
+    act(() => {
+      older = storeBeforeRerender.toggleAgent(agent.id, false);
+      newer = storeBeforeRerender.toggleAgent(agent.id, false);
+    });
+    await flushMicrotasks();
+
+    await act(async () => {
+      toggleResolvers[1]?.(new Response(JSON.stringify({ success: true }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }));
+      await newer;
+      toggleResolvers[0]?.(new Response(JSON.stringify({ error: 'Older toggle failed' }), {
+        status: 500,
+        headers: { 'Content-Type': 'application/json' },
+      }));
+      await older;
+    });
+
+    expect(latest(snapshots).agents[0]?.pixelEnabled).toBe(false);
+    expect(latest(snapshots).error).toBe('Older toggle failed');
+
+    unmount();
+  });
+
+  it('does not let an in-flight REST poll overwrite an optimistic toggle', async () => {
+    let resolvePoll: ((response: Response) => void) | undefined;
+    let resolveToggle: ((response: Response) => void) | undefined;
+    let getCount = 0;
+    vi.stubGlobal('fetch', vi.fn((_: RequestInfo | URL, init?: RequestInit) => {
+      if (init?.method === 'POST') {
+        return new Promise<Response>((resolve) => {
+          resolveToggle = resolve;
+        });
+      }
+      getCount += 1;
+      if (getCount === 1) {
+        return Promise.resolve(new Response(JSON.stringify({ agents: [agent] }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }));
+      }
+      return new Promise<Response>((resolve) => {
+        resolvePoll = resolve;
+      });
+    }));
+
+    const { snapshots, unmount } = await renderStoreProbe();
+    let poll: Promise<void> | undefined;
+    let mutation: Promise<void> | undefined;
+
+    act(() => {
+      poll = latest(snapshots).refresh();
+    });
+    await flushMicrotasks();
+    act(() => {
+      mutation = latest(snapshots).toggleAgent(agent.id, false);
+    });
+    await flushMicrotasks();
+    expect(latest(snapshots).agents[0]?.pixelEnabled).toBe(false);
+
+    await act(async () => {
+      resolvePoll?.(new Response(JSON.stringify({ agents: [agent] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }));
+      await poll;
+    });
+    expect(latest(snapshots).agents[0]?.pixelEnabled).toBe(false);
+
+    await act(async () => {
+      resolveToggle?.(new Response(JSON.stringify({ success: true }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }));
+      await mutation;
+    });
+
+    unmount();
+  });
+
+  it('keeps successful toggle-all changes while rolling back only failed agents', async () => {
+    const agents = [agent, { ...agent, id: 'agent-2', name: 'Second Agent' }];
+    vi.stubGlobal('fetch', vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      if (init?.method === 'POST') {
+        const failed = String(input).includes('/agent-2/');
+        return Promise.resolve(new Response(
+          failed ? JSON.stringify({ error: 'Second toggle failed' }) : JSON.stringify({ success: true }),
+          {
+            status: failed ? 500 : 200,
+            headers: { 'Content-Type': 'application/json' },
+          },
+        ));
+      }
+      return Promise.resolve(new Response(JSON.stringify({ agents }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }));
+    }));
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const { snapshots, unmount } = await renderStoreProbe();
+
+    await act(async () => {
+      await latest(snapshots).toggleAll(false);
+    });
+
+    expect(latest(snapshots).agents.map(current => [current.id, current.pixelEnabled])).toEqual([
+      ['agent-1', false],
+      ['agent-2', true],
+    ]);
+    expect(latest(snapshots).error).toBe('Failed to toggle 1 agent: agent-2 (Second toggle failed)');
+
+    unmount();
+  });
+
+  it('reports every failed agent from a bulk toggle', async () => {
+    const agents = [agent, { ...agent, id: 'agent-2', name: 'Second Agent' }];
+    vi.stubGlobal('fetch', vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      if (init?.method === 'POST') {
+        const id = String(input).includes('/agent-2/') ? 'agent-2' : 'agent-1';
+        return Promise.resolve(new Response(JSON.stringify({ error: `${id} rejected` }), {
+          status: 500,
+          headers: { 'Content-Type': 'application/json' },
+        }));
+      }
+      return Promise.resolve(new Response(JSON.stringify({ agents }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }));
+    }));
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const { snapshots, unmount } = await renderStoreProbe();
+
+    await act(async () => {
+      await latest(snapshots).toggleAll(false);
+    });
+
+    expect(latest(snapshots).error).toBe(
+      'Failed to toggle 2 agents: agent-1 (agent-1 rejected), agent-2 (agent-2 rejected)',
+    );
+
+    unmount();
+  });
+
+  it('reconciles after a superseded bulk failure and a newer failure both roll back', async () => {
+    const postResolvers: Array<(response: Response) => void> = [];
+    vi.stubGlobal('fetch', vi.fn((_: RequestInfo | URL, init?: RequestInit) => {
+      if (init?.method === 'POST') {
+        return new Promise<Response>((resolve) => postResolvers.push(resolve));
+      }
+      return Promise.resolve(new Response(JSON.stringify({ agents: [agent] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }));
+    }));
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const { snapshots, unmount } = await renderStoreProbe();
+    const storeBeforeRerender = latest(snapshots);
+    let bulk: Promise<void> | undefined;
+    let newer: Promise<void> | undefined;
+
+    act(() => {
+      bulk = storeBeforeRerender.toggleAll(false);
+      newer = storeBeforeRerender.toggleAgent(agent.id, true);
+    });
+    await flushMicrotasks();
+
+    await act(async () => {
+      postResolvers[1]?.(new Response(JSON.stringify({ error: 'Newer toggle failed' }), {
+        status: 500,
+        headers: { 'Content-Type': 'application/json' },
+      }));
+      await newer;
+    });
+    expect(latest(snapshots).agents[0]?.pixelEnabled).toBe(false);
+
+    await act(async () => {
+      postResolvers[0]?.(new Response(JSON.stringify({ error: 'Bulk toggle failed' }), {
+        status: 500,
+        headers: { 'Content-Type': 'application/json' },
+      }));
+      await bulk;
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    expect(latest(snapshots).agents[0]?.pixelEnabled).toBe(true);
+
+    unmount();
+  });
+
+  it('rolls back an optimistic sprite change and exposes an HTTP 500 error', async () => {
+    let resolveSprite: ((response: Response) => void) | undefined;
+    const agentWithSprite = { ...agent, characterSpriteId: 'char_1' };
+    vi.stubGlobal('fetch', vi.fn((_: RequestInfo | URL, init?: RequestInit) => {
+      if (init?.method === 'POST') {
+        return new Promise<Response>((resolve) => {
+          resolveSprite = resolve;
+        });
+      }
+      return Promise.resolve(new Response(JSON.stringify({ agents: [agentWithSprite] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }));
+    }));
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const { snapshots, unmount } = await renderStoreProbe();
+
+    let mutation: Promise<void> | undefined;
+    act(() => {
+      mutation = latest(snapshots).setCharacterSprite(agent.id, 'char_2');
+    });
+    await flushMicrotasks();
+    expect(latest(snapshots).agents[0]?.characterSpriteId).toBe('char_2');
+
+    await act(async () => {
+      resolveSprite?.(new Response(JSON.stringify({ error: 'Sprite failed' }), {
+        status: 500,
+        headers: { 'Content-Type': 'application/json' },
+      }));
+      await mutation;
+    });
+
+    expect(latest(snapshots).agents[0]?.characterSpriteId).toBe('char_1');
+    expect(latest(snapshots).error).toBe('Sprite failed');
+
+    unmount();
+  });
+
+  it('restores an unset sprite field when an optimistic sprite request fails', async () => {
+    let resolveSprite: ((response: Response) => void) | undefined;
+    vi.stubGlobal('fetch', vi.fn((_: RequestInfo | URL, init?: RequestInit) => {
+      if (init?.method === 'POST') {
+        return new Promise<Response>((resolve) => {
+          resolveSprite = resolve;
+        });
+      }
+      return Promise.resolve(new Response(JSON.stringify({ agents: [agent] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }));
+    }));
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const { snapshots, unmount } = await renderStoreProbe();
+    let mutation: Promise<void> | undefined;
+
+    act(() => {
+      mutation = latest(snapshots).setCharacterSprite(agent.id, 'char_2');
+    });
+    await flushMicrotasks();
+    expect(latest(snapshots).agents[0]?.characterSpriteId).toBe('char_2');
+
+    await act(async () => {
+      resolveSprite?.(new Response(JSON.stringify({ error: 'Sprite failed' }), {
+        status: 500,
+        headers: { 'Content-Type': 'application/json' },
+      }));
+      await mutation;
+    });
+
+    expect(latest(snapshots).agents[0]?.characterSpriteId).toBeUndefined();
+
+    unmount();
+  });
+
+  it('does not let an older failed sprite request replace a newer optimistic sprite', async () => {
+    const spriteResolvers: Array<(response: Response) => void> = [];
+    const agentWithSprite = { ...agent, characterSpriteId: 'char_1' };
+    vi.stubGlobal('fetch', vi.fn((_: RequestInfo | URL, init?: RequestInit) => {
+      if (init?.method === 'POST') {
+        return new Promise<Response>((resolve) => spriteResolvers.push(resolve));
+      }
+      return Promise.resolve(new Response(JSON.stringify({ agents: [agentWithSprite] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }));
+    }));
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const { snapshots, unmount } = await renderStoreProbe();
+    let older: Promise<void> | undefined;
+    let newer: Promise<void> | undefined;
+    const storeBeforeRerender = latest(snapshots);
+
+    act(() => {
+      older = storeBeforeRerender.setCharacterSprite(agent.id, 'char_2');
+      newer = storeBeforeRerender.setCharacterSprite(agent.id, 'char_3');
+    });
+    await flushMicrotasks();
+
+    await act(async () => {
+      spriteResolvers[1]?.(new Response(JSON.stringify({ success: true }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }));
+      await newer;
+      spriteResolvers[0]?.(new Response(JSON.stringify({ error: 'Older sprite failed' }), {
+        status: 500,
+        headers: { 'Content-Type': 'application/json' },
+      }));
+      await older;
+    });
+
+    expect(latest(snapshots).agents[0]?.characterSpriteId).toBe('char_3');
+
+    unmount();
   });
 });
 

--- a/src/hooks/useAgentStore.ts
+++ b/src/hooks/useAgentStore.ts
@@ -59,9 +59,12 @@ export function useAgentStore() {
       updateAgents(() => data.agents || []);
       setError(null);
     } catch (err) {
-      if (socketRevisionRef.current === socketRevisionAtRequest) {
-        setError(errorMessage(err));
-      }
+      if (
+        socketRevisionRef.current !== socketRevisionAtRequest
+        || stateRevisionRef.current !== stateRevisionAtRequest
+        || pendingMutationsRef.current > 0
+      ) return;
+      setError(errorMessage(err));
     }
   }, [updateAgents]);
 
@@ -97,6 +100,7 @@ export function useAgentStore() {
     startMutation();
     let previousEnabled: boolean | undefined;
     const socketRevisionAtMutation = socketRevisionRef.current;
+    let needsReconcile = false;
     setError(null);
     updateAgents(current => current.map(agent => {
       if (agent.id !== agentId) return agent;
@@ -113,19 +117,19 @@ export function useAgentStore() {
       await requireOk(res);
     } catch (err) {
       console.error('Failed to toggle agent:', err);
-      if (
-        previousEnabled !== undefined
-        && socketRevisionRef.current === socketRevisionAtMutation
-        && isCurrentMutation(mutationKey, mutationRevision)
-      ) {
-        const rollbackEnabled = previousEnabled;
-        updateAgents(current => current.map(agent =>
-          agent.id === agentId ? { ...agent, pixelEnabled: rollbackEnabled } : agent
-        ));
+      if (socketRevisionRef.current === socketRevisionAtMutation) {
+        const isCurrent = isCurrentMutation(mutationKey, mutationRevision);
+        needsReconcile = !isCurrent;
+        if (previousEnabled !== undefined && isCurrent) {
+          const rollbackEnabled = previousEnabled;
+          updateAgents(current => current.map(agent =>
+            agent.id === agentId ? { ...agent, pixelEnabled: rollbackEnabled } : agent
+          ));
+        }
       }
       setError(errorMessage(err));
     } finally {
-      finishMutation();
+      finishMutation(needsReconcile);
     }
   }, [beginMutation, finishMutation, isCurrentMutation, startMutation, updateAgents]);
 
@@ -194,6 +198,7 @@ export function useAgentStore() {
     let previousSpriteId: string | undefined;
     let foundAgent = false;
     const socketRevisionAtMutation = socketRevisionRef.current;
+    let needsReconcile = false;
     setError(null);
     updateAgents(current => current.map(agent => {
       if (agent.id !== agentId) return agent;
@@ -211,25 +216,25 @@ export function useAgentStore() {
       await requireOk(res);
     } catch (err) {
       console.error('Failed to set sprite:', err);
-      if (
-        foundAgent
-        && socketRevisionRef.current === socketRevisionAtMutation
-        && isCurrentMutation(mutationKey, mutationRevision)
-      ) {
-        updateAgents(current => current.map(agent => {
-          if (agent.id !== agentId) return agent;
-          const nextAgent = { ...agent };
-          if (previousSpriteId === undefined) {
-            delete nextAgent.characterSpriteId;
-          } else {
-            nextAgent.characterSpriteId = previousSpriteId;
-          }
-          return nextAgent;
-        }));
+      if (socketRevisionRef.current === socketRevisionAtMutation) {
+        const isCurrent = isCurrentMutation(mutationKey, mutationRevision);
+        needsReconcile = !isCurrent;
+        if (foundAgent && isCurrent) {
+          updateAgents(current => current.map(agent => {
+            if (agent.id !== agentId) return agent;
+            const nextAgent = { ...agent };
+            if (previousSpriteId === undefined) {
+              delete nextAgent.characterSpriteId;
+            } else {
+              nextAgent.characterSpriteId = previousSpriteId;
+            }
+            return nextAgent;
+          }));
+        }
       }
       setError(errorMessage(err));
     } finally {
-      finishMutation();
+      finishMutation(needsReconcile);
     }
   }, [beginMutation, finishMutation, isCurrentMutation, startMutation, updateAgents]);
 
@@ -241,10 +246,7 @@ export function useAgentStore() {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ tags }),
       });
-      if (!res.ok) {
-        const body = await res.json().catch(() => null);
-        throw new Error(body?.error ?? `HTTP ${res.status}`);
-      }
+      await requireOk(res);
       // Only mutate local state after server confirms success
       const body = await res.json();
       updateAgents(current => current.map(a =>
@@ -282,10 +284,7 @@ export function useAgentStore() {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(recipe),
       });
-      if (!res.ok) {
-        const body = await res.json().catch(() => null);
-        throw new Error(body?.error ?? `HTTP ${res.status}`);
-      }
+      await requireOk(res);
       // Optimistic update
       updateAgents(current => current.map(a =>
         a.id === agentId ? { ...a, recipe } : a

--- a/src/hooks/useAgentStore.ts
+++ b/src/hooks/useAgentStore.ts
@@ -1,88 +1,237 @@
-import { useState, useEffect, useCallback, useMemo } from 'react';
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { io as socketIO } from 'socket.io-client';
 import type { AgentState, CharacterRecipe } from '../../shared/types';
-import { ALL_TAGS, TAG_COLORS, DEFAULT_ROOMS, resolveRoomByTags, type AgentTag } from '../../shared/types';
+import { ALL_TAGS, TAG_COLORS, resolveRoomByTags, type AgentTag } from '../../shared/types';
 
 const API_BASE = '/api';
 
 export { ALL_TAGS, TAG_COLORS };
 export type { AgentTag };
 
+async function requireOk(response: Response): Promise<void> {
+  if (response.ok) return;
+
+  const body = await response.json().catch(() => null);
+  const message = body && typeof body === 'object' && 'error' in body && typeof body.error === 'string'
+    ? body.error
+    : `HTTP ${response.status}`;
+  throw new Error(message);
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : 'Connection failed';
+}
+
 export function useAgentStore() {
   const [agents, setAgents] = useState<AgentState[]>([]);
   const [connected, setConnected] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [activeRoomId, setActiveRoomId] = useState<string>('office');
+  const socketRevisionRef = useRef(0);
+  const stateRevisionRef = useRef(0);
+  const pendingMutationsRef = useRef(0);
+  const pendingReconcileRef = useRef(false);
+  const agentsRef = useRef<AgentState[]>([]);
+  const mutationRevisionRef = useRef(new Map<string, number>());
 
-  const fetchAgents = useCallback(async () => {
-    // `connected` is a WebSocket-liveness signal and is driven only by the
-    // Socket.IO event handlers below. A successful REST response here is NOT
-    // evidence that the WS is up — flipping `connected` from this function
-    // would create a feedback loop with the REST polling fallback that gates
-    // on `connected` (see useEffect for the fallback).
-    try {
-      const res = await fetch(`${API_BASE}/agents`);
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      const data = await res.json();
-      setAgents(data.agents || []);
-      setError(null);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Connection failed');
-    }
+  const updateAgents = useCallback((updater: (current: AgentState[]) => AgentState[]) => {
+    const next = updater(agentsRef.current);
+    agentsRef.current = next;
+    stateRevisionRef.current += 1;
+    setAgents(next);
   }, []);
 
-  const toggleAgent = useCallback(async (agentId: string, enabled: boolean) => {
+  const fetchAgents = useCallback(async () => {
+    // `connected` means a Socket.IO snapshot has arrived, not merely that the
+    // transport opened. A successful REST response here must not stop the
+    // fallback polling that remains active until that first snapshot.
+    const socketRevisionAtRequest = socketRevisionRef.current;
+    const stateRevisionAtRequest = stateRevisionRef.current;
     try {
-      await fetch(`${API_BASE}/agents/${agentId}/toggle`, {
+      const res = await fetch(`${API_BASE}/agents`);
+      await requireOk(res);
+      const data = await res.json();
+      if (
+        socketRevisionRef.current !== socketRevisionAtRequest
+        || stateRevisionRef.current !== stateRevisionAtRequest
+        || pendingMutationsRef.current > 0
+      ) return;
+      updateAgents(() => data.agents || []);
+      setError(null);
+    } catch (err) {
+      if (socketRevisionRef.current === socketRevisionAtRequest) {
+        setError(errorMessage(err));
+      }
+    }
+  }, [updateAgents]);
+
+  const beginMutation = useCallback((key: string) => {
+    const revision = (mutationRevisionRef.current.get(key) ?? 0) + 1;
+    mutationRevisionRef.current.set(key, revision);
+    return revision;
+  }, []);
+
+  const startMutation = useCallback(() => {
+    pendingMutationsRef.current += 1;
+  }, []);
+
+  const isCurrentMutation = useCallback((key: string, revision: number) => (
+    mutationRevisionRef.current.get(key) === revision
+  ), []);
+
+  const finishMutation = useCallback((needsReconcile = false) => {
+    if (needsReconcile) pendingReconcileRef.current = true;
+    pendingMutationsRef.current = Math.max(0, pendingMutationsRef.current - 1);
+    // Invalidate any REST snapshot that began while this mutation was active,
+    // including successful mutations that required no further local update.
+    stateRevisionRef.current += 1;
+    if (pendingMutationsRef.current === 0 && pendingReconcileRef.current) {
+      pendingReconcileRef.current = false;
+      void fetchAgents();
+    }
+  }, [fetchAgents]);
+
+  const toggleAgent = useCallback(async (agentId: string, enabled: boolean) => {
+    const mutationKey = `toggle:${agentId}`;
+    const mutationRevision = beginMutation(mutationKey);
+    startMutation();
+    let previousEnabled: boolean | undefined;
+    const socketRevisionAtMutation = socketRevisionRef.current;
+    setError(null);
+    updateAgents(current => current.map(agent => {
+      if (agent.id !== agentId) return agent;
+      previousEnabled = agent.pixelEnabled;
+      return { ...agent, pixelEnabled: enabled };
+    }));
+
+    try {
+      const res = await fetch(`${API_BASE}/agents/${agentId}/toggle`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ enabled }),
       });
-      // Optimistic update — don't wait for next poll
-      setAgents(prev => prev.map(a =>
-        a.id === agentId ? { ...a, pixelEnabled: enabled } : a
-      ));
+      await requireOk(res);
     } catch (err) {
       console.error('Failed to toggle agent:', err);
-      // Revert on error by re-fetching
-      fetchAgents();
+      if (
+        previousEnabled !== undefined
+        && socketRevisionRef.current === socketRevisionAtMutation
+        && isCurrentMutation(mutationKey, mutationRevision)
+      ) {
+        const rollbackEnabled = previousEnabled;
+        updateAgents(current => current.map(agent =>
+          agent.id === agentId ? { ...agent, pixelEnabled: rollbackEnabled } : agent
+        ));
+      }
+      setError(errorMessage(err));
+    } finally {
+      finishMutation();
     }
-  }, [fetchAgents]);
+  }, [beginMutation, finishMutation, isCurrentMutation, startMutation, updateAgents]);
 
   const toggleAll = useCallback(async (enabled: boolean) => {
+    const changedAgents = agentsRef.current.filter(agent => agent.pixelEnabled !== enabled);
+    if (changedAgents.length === 0) {
+      return;
+    }
+
+    startMutation();
+    const previousEnabled = new Map(changedAgents.map(agent => [agent.id, agent.pixelEnabled]));
+    const mutationRevisions = new Map(changedAgents.map(agent => {
+      const key = `toggle:${agent.id}`;
+      return [agent.id, beginMutation(key)] as const;
+    }));
+    const socketRevisionAtMutation = socketRevisionRef.current;
+    setError(null);
+    updateAgents(current => current.map(agent => (
+      previousEnabled.has(agent.id) ? { ...agent, pixelEnabled: enabled } : agent
+    )));
+
+    let needsReconcile = false;
     try {
-      // Fire all toggles in parallel
-      const promises = agents.map(agent => {
-        if (agent.pixelEnabled !== enabled) {
-          return fetch(`${API_BASE}/agents/${agent.id}/toggle`, {
+      const results = await Promise.all(changedAgents.map(async agent => {
+        try {
+          const res = await fetch(`${API_BASE}/agents/${agent.id}/toggle`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ enabled }),
           });
+          await requireOk(res);
+          return null;
+        } catch (error) {
+          return { agentId: agent.id, error };
         }
-        return Promise.resolve();
-      });
-      await Promise.all(promises);
-      // Optimistic update
-      setAgents(prev => prev.map(a => ({ ...a, pixelEnabled: enabled })));
-    } catch (err) {
-      console.error('Failed to toggle all agents:', err);
-      fetchAgents();
+      }));
+
+      const failures = results.filter((result): result is { agentId: string; error: unknown } => result !== null);
+      if (failures.length > 0) {
+        const details = failures.map(({ agentId, error }) => `${agentId} (${errorMessage(error)})`).join(', ');
+        const message = `Failed to toggle ${failures.length} agent${failures.length === 1 ? '' : 's'}: ${details}`;
+        console.error(message);
+        if (socketRevisionRef.current === socketRevisionAtMutation) {
+          const currentFailures = failures.filter(({ agentId }) => (
+            isCurrentMutation(`toggle:${agentId}`, mutationRevisions.get(agentId) ?? 0)
+          ));
+          needsReconcile = currentFailures.length !== failures.length;
+          const failedIds = new Set(currentFailures.map(failure => failure.agentId));
+          updateAgents(current => current.map(agent =>
+            failedIds.has(agent.id)
+              ? { ...agent, pixelEnabled: previousEnabled.get(agent.id) ?? agent.pixelEnabled }
+              : agent
+          ));
+        }
+        setError(message);
+      }
+    } finally {
+      finishMutation(needsReconcile);
     }
-  }, [agents, fetchAgents]);
+  }, [beginMutation, finishMutation, isCurrentMutation, startMutation, updateAgents]);
 
   const setCharacterSprite = useCallback(async (agentId: string, spriteId: string) => {
+    const mutationKey = `sprite:${agentId}`;
+    const mutationRevision = beginMutation(mutationKey);
+    startMutation();
+    let previousSpriteId: string | undefined;
+    let foundAgent = false;
+    const socketRevisionAtMutation = socketRevisionRef.current;
+    setError(null);
+    updateAgents(current => current.map(agent => {
+      if (agent.id !== agentId) return agent;
+      foundAgent = true;
+      previousSpriteId = agent.characterSpriteId;
+      return { ...agent, characterSpriteId: spriteId };
+    }));
+
     try {
-      await fetch(`${API_BASE}/agents/${agentId}/sprite`, {
+      const res = await fetch(`${API_BASE}/agents/${agentId}/sprite`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ spriteId }),
       });
-      fetchAgents();
+      await requireOk(res);
     } catch (err) {
       console.error('Failed to set sprite:', err);
+      if (
+        foundAgent
+        && socketRevisionRef.current === socketRevisionAtMutation
+        && isCurrentMutation(mutationKey, mutationRevision)
+      ) {
+        updateAgents(current => current.map(agent => {
+          if (agent.id !== agentId) return agent;
+          const nextAgent = { ...agent };
+          if (previousSpriteId === undefined) {
+            delete nextAgent.characterSpriteId;
+          } else {
+            nextAgent.characterSpriteId = previousSpriteId;
+          }
+          return nextAgent;
+        }));
+      }
+      setError(errorMessage(err));
+    } finally {
+      finishMutation();
     }
-  }, [fetchAgents]);
+  }, [beginMutation, finishMutation, isCurrentMutation, startMutation, updateAgents]);
 
   /** Update tags for an agent — only mutates local state on server success */
   const updateTags = useCallback(async (agentId: string, tags: AgentTag[]) => {
@@ -98,14 +247,14 @@ export function useAgentStore() {
       }
       // Only mutate local state after server confirms success
       const body = await res.json();
-      setAgents(prev => prev.map(a =>
+      updateAgents(current => current.map(a =>
         a.id === agentId ? { ...a, tags, roomId: body.roomId } : a
       ));
     } catch (err) {
       console.error('Failed to update tags:', err);
       throw err; // re-throw so caller (TagEditor) can display the error
     }
-  }, []);
+  }, [updateAgents]);
 
   /**
    * Resolve which room an agent belongs to.
@@ -138,25 +287,27 @@ export function useAgentStore() {
         throw new Error(body?.error ?? `HTTP ${res.status}`);
       }
       // Optimistic update
-      setAgents(prev => prev.map(a =>
+      updateAgents(current => current.map(a =>
         a.id === agentId ? { ...a, recipe } : a
       ));
     } catch (err) {
       console.error('Failed to update recipe:', err);
       throw err;
     }
-  }, []);
+  }, [updateAgents]);
 
   useEffect(() => {
-    fetchAgents(); // Initial fetch
-    
     const socket = socketIO({ transports: ['websocket', 'polling'] });
 
-    const handleConnect = () => setConnected(true);
+    // Transport connectivity alone does not mean client state is fresh. Keep
+    // the REST fallback active until this connection delivers its first snapshot.
+    const handleConnect = () => setConnected(false);
     const handleDisconnect = () => setConnected(false);
     const handleUpdate = (updatedAgents: AgentState[]) => {
-      setAgents(updatedAgents);
+      socketRevisionRef.current += 1;
+      updateAgents(() => updatedAgents);
       setError(null);
+      setConnected(true);
     };
 
     socket.on('connect', handleConnect);
@@ -169,11 +320,10 @@ export function useAgentStore() {
       socket.off('agents:update', handleUpdate);
       socket.disconnect();
     };
-  }, [fetchAgents]);
+  }, [updateAgents]);
 
-  // REST polling fallback — primary update channel is Socket.IO; this degraded-mode
-  // poll kicks in only when the WS connection is down so the UI does not freeze on
-  // stale state. Matches the contract documented in AGENTS.md ("Data Flow").
+  // REST polling fallback — keep it active while Socket.IO is down or while a
+  // newly opened connection has not delivered its first authoritative snapshot.
   useEffect(() => {
     if (connected) return;
     fetchAgents(); // immediate first fetch — don't wait the full interval on entry


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
# Pull Request Description

## Summary
Harden `useAgentStore` against stale REST updates, premature "connected" status, and silent mutation failures by tracking socket revisions, treating HTTP non-2xx responses as errors, and rolling back only the optimistic state for failed operations.

## What's Changing

### Live state protection from stale REST responses
- Introduces a `socketRevisionRef` counter that increments on every `agents:update` socket event.
- `fetchAgents()` captures the revision at request time and discards the response (including the error it might surface) if a newer socket snapshot arrived in the meantime — preventing in-flight REST responses from flickering agents back to stale activity, tags, recipe, or toggle state.

### Accurate `connected` semantics
- `handleConnect` no longer flips `connected` to `true`. The flag now means "the current socket connection has delivered its first authoritative snapshot," not merely "the transport opened."
- `handleUpdate` (the `agents:update` socket handler) is the only path that sets `connected = true`, and it does so only after incrementing the revision counter.
- The REST polling fallback comment and behavior are updated to keep polling active until the first live snapshot arrives, even when the socket transport is open.

### Mutation failure handling
- Adds a `requireOk()` helper that throws on non-2xx responses, parsing the server's `error` field when present and falling back to `HTTP <status>`.
- Adds an `errorMessage()` helper for normalizing thrown errors into strings used by the store's `error` field.
- `toggleAgent`: applies the optimistic toggle before the request, rolls back only the targeted agent on failure (and only when no newer socket snapshot has arrived), and surfaces the server error through `error`.
- `toggleAll`: skips agents whose `pixelEnabled` already matches the target, applies the optimistic change for all changed agents upfront, fires the requests in parallel, keeps the optimistic state for agents that succeeded, rolls back only the failed agents when no fresher socket snapshot exists, and reports the first failure through `error`.
- `setCharacterSprite`: applies the optimistic sprite change before the request, restores the previous `characterSpriteId` (deleting it if it didn't exist) on failure, and surfaces the server error through `error` — all guarded by the socket revision check.
- All three mutation paths now `setError(null)` at the start, so prior failures clear on a successful retry.

### Documentation and tests
- README description of `useAgentStore` now reflects the REST-as-fallback / switch-to-Socket.IO behavior.
- Test helper `emitSocketEvent` now forwards extra arguments so `agents:update` payloads can be delivered.
- Existing REST polling tests updated to emit `agents:update` after `connect` so `connected` becomes `true`.
- New tests cover:
  - `connected` staying `false` after `connect` until the first `agents:update` arrives.
  - Stale REST responses not overwriting a newer socket snapshot.
  - `toggleAgent` rolling back on HTTP 500 and exposing the server error.
  - `toggleAll` rolling back only failed agents while keeping successful optimistic changes.
  - `setCharacterSprite` rolling back on HTTP 500 and exposing the server error.

## Rationale
- Without a revision counter, REST responses that crossed in flight with a Socket.IO update could revert the UI to outdated state.
- Reporting `connected` on transport open (rather than first snapshot) caused the REST fallback to stop before any real agent data was loaded.
- Awaiting `fetch` without checking `Response.ok` meant HTTP errors were silently treated as successful mutations, leaving the optimistic change in place and providing no feedback to the user.

## Impact
- Users no longer see agent state flicker when a REST poll races with a live socket update.
- The connection indicator now reflects whether the live channel is actually serving data.
- Failed toggle/sprite operations revert their optimistic change (when not superseded by newer socket state) and surface the server-provided error through the existing store error channel.

---

# Protect live agent state from stale updates

## Summary

Hardens `useAgentStore` so that out-of-order responses (REST polling arriving after a newer Socket.IO snapshot, or a failed mutation resolving after a newer optimistic edit) cannot corrupt the live agent list. Also fixes a long-standing bug where the WebSocket's `connect` event was treated as proof of fresh state.

## Behavior changes

- **`connected` now means "first socket snapshot received," not "transport open."** Previously, a `connect` event flipped `connected` to `true` even though no `agents:update` had arrived yet, which stopped the REST fallback mid-stream. Now the socket must deliver an `agents:update` before `connected` becomes `true`. Re-connecting after a disconnect also reverts `connected` to `false` until the next snapshot lands.
- **REST responses are revision-checked.** Each fetch records the current socket revision and, if a socket snapshot arrived in the meantime, silently drops the late REST payload instead of overwriting newer state.
- **Mutation failures are revision-checked.** `toggleAgent`, `toggleAll`, and `setCharacterSprite` now track a per-agent mutation revision and the socket revision at the time of the optimistic edit. Failed rollbacks are skipped if a newer mutation or a newer socket snapshot has superseded them.
- **Optimistic mutations precede the network call.** Previously, `toggleAgent` and `setCharacterSprite` applied the optimistic update only after the fetch resolved; failures were "reverted" by re-fetching. They now apply optimistically up front, capture the previous value, and roll it back only if the server rejected the change.
- **HTTP errors surface a real message.** A new `requireOk` helper reads `body.error` from non-2xx responses, so a 500 with `{ error: "Toggle failed" }` now exposes that message in `error` instead of a generic `HTTP 500`.

## `toggleAll` (bulk toggle)

- Skips agents already in the desired state and short-circuits when there is nothing to do.
- Runs all toggles in parallel and collects failures.
- Rolls back **only** the agents that failed, leaving successful agents in their new state (previously a single failure re-fetched and could clobber all the other successful toggles).
- Reports failures with a consolidated message such as `Failed to toggle 2 agents: agent-1 (agent-1 rejected), agent-2 (agent-2 rejected)`.
- A single failed agent now reports `Failed to toggle 1 agent: agent-2 (Second toggle failed)` instead of an opaque generic error.

## Test changes (`useAgentStore.test.tsx`)

- Added a helper that emits arbitrary socket events with payload arguments, enabling `agents:update` simulation.
- Existing tests now explicitly emit an `agents:update` before asserting `connected === true`, reflecting the new contract.
- New tests cover:
  - Stale REST response does not overwrite a newer socket snapshot.
  - Optimistic toggle rolls back and surfaces the HTTP error message; the error is not cleared by a subsequent successful `toggleAll`.
  - An older failed toggle does not roll back a newer optimistic toggle.
  - `toggleAll` rolls back only the failed agents and keeps the successful ones.
  - `toggleAll` reports every failed agent in a single error.
  - Optimistic sprite change rolls back and surfaces the HTTP error message.
  - An older failed sprite request does not replace a newer optimistic sprite.

## Docs

`README.md` updated to describe `useAgentStore` as fetching via REST fallback and only switching to Socket.IO after the first live snapshot.

---

## Summary

This PR fixes a race condition in the `useAgentStore` hook where stale REST responses could overwrite newer Socket.IO snapshots, causing the UI to revert to outdated agent state. The fix introduces proper revision tracking and ordering guarantees across all data mutations.

## Changes

### `src/hooks/useAgentStore.ts`

**Connection lifecycle fix**
- `connected` now means a live Socket.IO snapshot has been received, not merely that the transport opened. Previously the `connect` handler set `connected=true` immediately, which stopped the REST polling fallback before any real data arrived — and worse, in-flight REST responses could overwrite the first live snapshot.
- Added a `socketRevisionRef` counter that's incremented on every `agents:update` event. In-flight REST responses now check this revision before applying, so any response that races behind a fresh snapshot is discarded.

**Mutation correctness**
- `toggleAgent` now does a true optimistic update before the network call and rolls back to the captured previous value on HTTP failure (previously it relied on a re-fetch, which could itself be stale). The rollback only fires if the mutation is still the most recent for that agent and no new socket snapshot has arrived in the meantime.
- `toggleAll` now snapshots the previous `pixelEnabled` for each changed agent, fires the requests in parallel, and only rolls back the agents that actually failed — successful changes are preserved. The error message reports every failed agent.
- `setCharacterSprite` applies the same optimistic-update-with-conditional-rollback pattern. When an agent had no sprite set previously and the request fails, the field is properly deleted (not left with `undefined`).
- Added an HTTP error helper (`requireOk`) that surfaces server-provided `error` messages, and a shared `errorMessage` utility.
- All state writes now go through a single `updateAgents` helper backed by an `agentsRef` mirror, avoiding stale-closure issues with `setAgents(prev => ...)`.

### `src/hooks/useAgentStore.test.tsx`

- Extended the socket mock to forward arbitrary arguments to `agents:update` handlers.
- Added a new `useAgentStore mutation failures` describe block with seven tests covering: optimistic toggle rollback on HTTP 500, ordering protection so an older failed toggle can't roll back a newer optimistic change, bulk-toggle partial-failure behavior, multi-agent failure reporting, sprite-change rollback, unset-sprite cleanup on failure, and sprite-mutation ordering protection.
- Adjusted existing fallback tests to expect REST polling to continue until the first `agents:update` arrives.

### `README.md`

- Updated the `useAgentStore` row in the components table to describe the new behavior: "Fetches agent state via REST fallback and switches to Socket.IO only after the first live snapshot."

---

## Summary

This PR hardens the `useAgentStore` hook so that concurrent REST polls, socket snapshots, and optimistic mutations never overwrite newer client state with stale data, and so that `connected` reflects the arrival of an authoritative socket snapshot rather than just a transport handshake.

### Problem
- A REST response that resolved before a newer socket snapshot could silently revert the UI to stale server data.
- An optimistic toggle could be incorrectly rolled back by the resolution of an *older* in-flight mutation, even after a newer successful mutation applied.
- Bulk-toggle failures rolled back every agent instead of only the ones that actually failed, hiding successful changes from the user.
- Optimistic sprite changes that failed did not restore the previous (possibly unset) sprite field correctly.
- The REST fallback would stop polling as soon as the socket transport connected, but before the connection had actually pushed live state, so the UI could be left on stale data.
- In-flight REST polls could clobber successful optimistic local changes.

### Changes
**`src/hooks/useAgentStore.ts`**
- Introduce revision counters (`socketRevisionRef`, `stateRevisionRef`, `mutationRevisionRef` per-agent-key) and a pending-mutation counter, plus a `mutationRevision` per request.
- Replace direct `setAgents(...)` calls with a guarded `updateAgents` helper that routes through a ref-backed current value and bumps `stateRevisionRef`.
- `fetchAgents` now snapshots `socketRevision`, `stateRevision`, and the pending-mutation count before requesting, and **discards** the response if any of them advanced before it resolved. It also passes errors through `errorMessage` so they surface uniformly.
- Add `beginMutation`, `startMutation`, `isCurrentMutation`, and `finishMutation` helpers. `finishMutation` invalidates any in-flight REST snapshot that started mid-mutation and, if a bulk failure indicated newer state exists, triggers an immediate reconcile.
- `toggleAgent` now performs the optimistic flip *before* the network request, tracks the previous `pixelEnabled`, and on failure only rolls back if the socket snapshot hasn't advanced *and* this is still the current mutation for that agent. On HTTP failure it propagates the server's `error` message into the store's `error` field.
- `toggleAll` now performs a single optimistic update for all agents that actually need changing, then runs per-agent requests in parallel. Failures are isolated: only agents whose mutation is still current get rolled back. The error message includes every failed agent id and reason (`Failed to toggle N agent(s): ...`). A `needsReconcile` flag triggers a `fetchAgents` once all mutations settle if some failures were superseded by newer activity.
- `setCharacterSprite` mirrors `toggleAgent`: optimistic update with prior value capture, guarded rollback (including correctly removing the `characterSpriteId` field when it was previously unset), and `error` propagation.
- `updateTags` and `updateRecipe` switched to the `updateAgents` helper for consistency.
- Connection lifecycle: `handleConnect` no longer flips `connected` to `true`. Only the first `agents:update` payload promotes the connection to "connected", and any socket update bumps `socketRevisionRef` to invalidate any pending REST response. The REST polling effect continues to run until `connected === true`.

**`src/hooks/useAgentStore.test.tsx`**
- Generalise `emitSocketEvent` to forward arbitrary arguments, enabling `agents:update` simulation.
- Update existing "REST polling fallback" tests to assert `connected === false` immediately after `connect`, and to emit an `agents:update` to drive `connected` to `true`.
- Add new "useAgentStore mutation failures" test block covering:
  - Optimistic `toggleAgent` rollback and HTTP 500 error surfacing; the error persists across a subsequent successful `toggleAll`.
  - Out-of-order resolutions: an older failed toggle does **not** roll back a newer successful optimistic toggle.
  - Stale in-flight REST poll does not overwrite an optimistic toggle.
  - Bulk toggle keeps successful changes and only rolls back failed agents, with a precise aggregated error message.
  - Bulk toggle aggregates every agent failure into the error message.
  - A superseded bulk failure followed by a newer failed toggle correctly leaves the agent's state at the toggle's intended value.
  - Optimistic sprite change rolls back on HTTP 500 and surfaces the server error.
  - Failed sprite request correctly restores an *unset* sprite field (not just a previously-set one).
  - Older failed sprite request does not replace a newer successful optimistic sprite.

**`README.md`**
- Update the `useAgentStore` description in the architecture table to reflect the new behavior: REST fallback is used, and Socket.IO is considered live only after the first `agents:update` snapshot arrives.

---

## Summary

This pull request hardens the agent store against stale or racing updates so that live UI state reflects the most recent user actions, server responses, and socket pushes rather than being clobbered by older in-flight requests.

### Key Changes

- **REST poll error guarding** – `refresh()` failures now also bail out when there are pending optimistic mutations or when the local state revision has moved on, preventing a slow or failing poll from overwriting a fresher optimistic state with its error message.
- **Toggle / sprite mutation safety** – When a mutation fails but has been superseded by a newer mutation (or a socket update), the store no longer rolls back local state to the stale `previousEnabled` / `previousSpriteId`. Instead, it sets a `needsReconcile` flag so the post-mutation reconciler refetches authoritative server state and merges it into the current snapshot.
- **Reconciler consistency** – The reconciler now always runs in the `finally` block (via `finishMutation(needsReconcile)`) when a failed mutation is no longer current, ensuring the store converges to the latest server truth even after chained mutations both fail.
- **Shared HTTP error helper** – The tag and recipe mutation paths now reuse the existing `requireOk(res)` helper instead of duplicating the inline `res.ok`/JSON-error parsing logic.

### Behavioral Impact

- Failed toggles or sprite changes that have been overridden by a newer action no longer leave stale error banners or stale local state behind.
- A slow REST poll that errors out while a user is mid-toggle no longer surfaces a misleading error or undoes optimistic UI.
- Socket snapshots remain authoritative even if a previously optimistic toggle subsequently fails.
- Two rapid, both-failing mutations now correctly reconcile to the latest server state instead of getting stuck on an intermediate value.

### Test Coverage

New and updated tests cover:
- Older failed toggle no longer surfaces its error after a newer toggle resolves against a reconciled server snapshot.
- Stale failing REST poll racing with an optimistic toggle leaves no error and preserves the optimistic state.
- Two superseding single-agent toggles that both fail reconcile to the latest server fixture.
- A socket snapshot survives a later failing optimistic toggle.
- Two superseding sprite changes that both fail reconcile to the latest server value.
- The existing “older failed request replaces newer optimistic update” tests now assert a reconciliation pass instead of leaving stale UI.
<!-- kody-pr-summary:end -->

## Summary by Sourcery

Harden useAgentStore state synchronization and mutation handling so newer live or optimistic updates are protected from stale responses and failures.

Bug Fixes:
- Prevent stale REST responses and failed optimistic mutations from overwriting newer Socket.IO or local agent state.
- Ensure HTTP mutation failures surface server-provided error messages and restore only the affected agent state.
- Keep REST fallback active until the socket delivers its first authoritative agent snapshot.

Enhancements:
- Define connected status by receipt of the first live socket snapshot rather than transport connection.
- Improve bulk toggles to skip unchanged agents, run concurrently, preserve successful updates, and report all failures.

Documentation:
- Update the useAgentStore documentation to describe REST fallback and Socket.IO activation after the first live snapshot.

Tests:
- Expand useAgentStore coverage for stale responses, connection semantics, optimistic rollback, mutation ordering, partial bulk failures, and sprite restoration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved agent data synchronization between REST polling and live updates.
  - Prevented stale responses from overwriting newer agent state.
  - Added reliable rollback and reconciliation for failed or concurrent updates.
  - Improved handling of bulk toggles and sprite updates.

- **Tests**
  - Expanded coverage for live agent updates, polling behavior, stale responses, failures, rollbacks, and concurrent changes.

- **Documentation**
  - Clarified when the application switches from REST fallback to live updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->