### PR TITLE
fix(server): cap persisted layout files

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,10 +87,11 @@ Click **📐 Layouts** to manage saved layouts:
 - Switch between layouts
 - Delete layouts (default layout is protected)
 
-The server stores at most 100 layout files. Legacy installations above that
-limit show at most 100 layouts at a time; delete unused layouts until the
-capacity warning clears. Delete an unused layout before creating another after
-the limit is reached.
+The server permits at most 100 entries in the layouts directory. Legacy
+installations above that limit show at most 100 layouts at a time; delete unused
+layouts until the capacity warning clears. Delete an unused layout before
+creating another after the limit is reached. Non-layout files also consume
+capacity; if the warning persists, remove them from that directory manually.
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -87,6 +87,9 @@ Click **📐 Layouts** to manage saved layouts:
 - Switch between layouts
 - Delete layouts (default layout is protected)
 
+The server stores at most 100 layout files. Delete an unused layout before
+creating another after that limit is reached.
+
 ## Architecture
 
 ### Data Source Modes

--- a/README.md
+++ b/README.md
@@ -87,8 +87,10 @@ Click **📐 Layouts** to manage saved layouts:
 - Switch between layouts
 - Delete layouts (default layout is protected)
 
-The server stores at most 100 layout files. Delete an unused layout before
-creating another after that limit is reached.
+The server stores at most 100 layout files. Legacy installations above that
+limit show at most 100 layouts at a time; delete unused layouts until the
+capacity warning clears. Delete an unused layout before creating another after
+the limit is reached.
 
 ## Architecture
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -8,7 +8,7 @@
 
 import { execFile } from "node:child_process";
 import { isIP } from "node:net";
-import express from "express";
+import express, { type Response } from "express";
 import helmet from "helmet";
 import { createServer } from "http";
 import { Server as SocketIOServer } from "socket.io";
@@ -1176,9 +1176,22 @@ app.get("/api/rooms", (_req, res) => {
 // ---- Layout persistence ----
 
 const LAYOUTS_DIR = join(DATA_DIR, "layouts");
+const MAX_LAYOUT_FILES = 100;
+
+function respondLayoutCapacityExceeded(res: Response) {
+  return res.status(507).json({ error: `Layout limit reached (${MAX_LAYOUT_FILES})` });
+}
 
 function ensureLayoutsDir() {
   mkdirSync(LAYOUTS_DIR, { recursive: true });
+}
+
+function countLayoutFiles(): number {
+  ensureLayoutsDir();
+  // Count every JSON entry, including malformed files. listLayouts() still
+  // pays the directory/read/validation cost for them, so excluding them here
+  // would let invalid persisted state bypass the resource bound.
+  return readdirSync(LAYOUTS_DIR).filter((file) => file.endsWith(".json")).length;
 }
 
 function listLayouts(): OfficeLayoutDoc[] {
@@ -1218,13 +1231,22 @@ function loadLayout(id: string): OfficeLayoutDoc | null {
   }
 }
 
-function saveLayout(layout: OfficeLayoutDoc): void {
+function saveLayout(layout: OfficeLayoutDoc): boolean {
   if (!isValidLayoutId(layout.id)) throw new Error(`Invalid layout ID: ${layout.id}`);
   ensureLayoutsDir();
-  layout.updatedAt = Date.now();
-  const validated = parseOfficeLayoutDoc(layout);
+  const validated = parseOfficeLayoutDoc({ ...layout, updatedAt: Date.now() });
   if (!validated) throw new Error(`Invalid layout document: ${layout.id}`);
-  writeFileSync(join(LAYOUTS_DIR, `${validated.id}.json`), JSON.stringify(validated, null, 2));
+  // Construct filesystem paths only from the schema-validated document. This
+  // keeps the path boundary explicit for both humans and static analysis.
+  const target = join(LAYOUTS_DIR, `${validated.id}.json`);
+  // The server is a single Node process and all operations below are
+  // synchronous, so the capacity decision and write run in one event-loop
+  // turn. Existing files remain replaceable, including malformed files that
+  // an operator is repairing.
+  if (!existsSync(target) && countLayoutFiles() >= MAX_LAYOUT_FILES) return false;
+  layout.updatedAt = validated.updatedAt;
+  writeFileSync(target, JSON.stringify(validated, null, 2));
+  return true;
 }
 
 function deleteLayout(id: string): boolean {
@@ -1281,7 +1303,9 @@ app.get("/api/layouts", (_req, res) => {
   // Always include default if empty
   if (layouts.length === 0) {
     const def = getDefaultLayout();
-    saveLayout(def);
+    if (!saveLayout(def)) {
+      return respondLayoutCapacityExceeded(res);
+    }
     layouts.push(def);
   }
   res.json({ layouts });
@@ -1296,7 +1320,9 @@ app.get("/api/layouts/:id", (req, res) => {
     // Auto-create default
     if (id === "default") {
       const def = getDefaultLayout();
-      saveLayout(def);
+      if (!saveLayout(def)) {
+        return respondLayoutCapacityExceeded(res);
+      }
       return res.json(def);
     }
     return res.status(404).json({ error: "Layout not found" });
@@ -1328,15 +1354,17 @@ app.put("/api/layouts/:id", (req, res) => {
     id, // prevent id overwrite
   };
   if (!parseOfficeLayoutDoc(layout)) return res.status(400).json({ error: "Invalid layout document" });
-  saveLayout(layout);
+  if (!saveLayout(layout)) {
+    return respondLayoutCapacityExceeded(res);
+  }
   io.emit("layout:update", layout);
   res.json({ success: true, layout });
 });
 
 app.post("/api/layouts", (req, res) => {
-  const id = `layout-${randomUUID()}`;
   const parsed = parseLayoutMutationBody(req.body, { width: 24, height: 16 });
   if (!parsed.ok) return res.status(400).json({ error: parsed.error });
+  const id = `layout-${randomUUID()}`;
 
   const layout: OfficeLayoutDoc = {
     id,
@@ -1348,7 +1376,9 @@ app.post("/api/layouts", (req, res) => {
     updatedAt: Date.now(),
   };
   if (!parseOfficeLayoutDoc(layout)) return res.status(400).json({ error: "Invalid layout document" });
-  saveLayout(layout);
+  if (!saveLayout(layout)) {
+    return respondLayoutCapacityExceeded(res);
+  }
   io.emit("layout:update", layout);
   res.json({ success: true, layout });
 });
@@ -1516,4 +1546,3 @@ if (require.main === module) {
 }
 
 export { app, server, io, startServer };
-

--- a/server/index.ts
+++ b/server/index.ts
@@ -12,7 +12,7 @@ import express, { type Response } from "express";
 import helmet from "helmet";
 import { createServer } from "http";
 import { Server as SocketIOServer } from "socket.io";
-import { readFileSync, writeFileSync, existsSync, mkdirSync, readdirSync, unlinkSync, createReadStream } from "node:fs";
+import { readFileSync, writeFileSync, existsSync, mkdirSync, opendirSync, unlinkSync, createReadStream } from "node:fs";
 import { stat as statAsync } from "node:fs/promises";
 import { createHmac, randomUUID, timingSafeEqual } from "node:crypto";
 import { join, resolve } from "node:path";
@@ -1186,20 +1186,36 @@ function ensureLayoutsDir() {
   mkdirSync(LAYOUTS_DIR, { recursive: true });
 }
 
-function countLayoutFiles(): number {
+function readLayoutFileNames(limit: number): string[] {
   ensureLayoutsDir();
-  // Count every JSON entry, including malformed files. listLayouts() still
-  // pays the directory/read/validation cost for them, so excluding them here
-  // would let invalid persisted state bypass the resource bound.
-  return readdirSync(LAYOUTS_DIR).filter((file) => file.endsWith(".json")).length;
+  const directory = opendirSync(LAYOUTS_DIR);
+  const files: string[] = [];
+  try {
+    for (let entry = directory.readSync(); entry; entry = directory.readSync()) {
+      // Every JSON entry consumes capacity, including malformed files and
+      // non-regular entries. This keeps both listing and capacity scans bounded.
+      if (entry.name.endsWith(".json")) {
+        files.push(entry.name);
+        if (files.length === limit) break;
+      }
+    }
+    return files;
+  } finally {
+    directory.closeSync();
+  }
 }
 
-function listLayouts(): OfficeLayoutDoc[] {
+function countLayoutFiles(): number {
+  return readLayoutFileNames(MAX_LAYOUT_FILES).length;
+}
+
+function listLayouts(): { layouts: OfficeLayoutDoc[]; overCapacity: boolean } {
   ensureLayoutsDir();
   try {
-    const files = readdirSync(LAYOUTS_DIR).filter(f => f.endsWith(".json"));
+    const files = readLayoutFileNames(MAX_LAYOUT_FILES + 1);
+    const overCapacity = files.length > MAX_LAYOUT_FILES;
     const layouts: OfficeLayoutDoc[] = [];
-    for (const file of files) {
+    for (const file of files.slice(0, MAX_LAYOUT_FILES)) {
       try {
         const raw = readFileSync(join(LAYOUTS_DIR, file), "utf-8");
         const layout = parseOfficeLayoutDoc(JSON.parse(raw));
@@ -1209,9 +1225,9 @@ function listLayouts(): OfficeLayoutDoc[] {
         logger.warn({ err, file, subsystem: "layout" }, "skipping unreadable layout file");
       }
     }
-    return layouts.sort((a, b) => b.updatedAt - a.updatedAt);
+    return { layouts: layouts.sort((a, b) => b.updatedAt - a.updatedAt), overCapacity };
   } catch {
-    return [];
+    return { layouts: [], overCapacity: false };
   }
 }
 
@@ -1299,16 +1315,18 @@ function getDefaultLayout(): OfficeLayoutDoc {
 // Layout REST API
 
 app.get("/api/layouts", (_req, res) => {
-  const layouts = listLayouts();
+  const { layouts, overCapacity } = listLayouts();
   // Always include default if empty
-  if (layouts.length === 0) {
+  if (layouts.length === 0 && !overCapacity) {
     const def = getDefaultLayout();
     if (!saveLayout(def)) {
       return respondLayoutCapacityExceeded(res);
     }
     layouts.push(def);
   }
-  res.json({ layouts });
+  res.json(overCapacity
+    ? { layouts, overCapacity: true, layoutLimit: MAX_LAYOUT_FILES }
+    : { layouts });
 });
 
 app.get("/api/layouts/:id", (req, res) => {

--- a/server/index.ts
+++ b/server/index.ts
@@ -1186,34 +1186,36 @@ function ensureLayoutsDir() {
   mkdirSync(LAYOUTS_DIR, { recursive: true });
 }
 
-function readLayoutFileNames(limit: number): string[] {
+function readLayoutDirectory(limit: number): { files: string[]; entryCount: number } {
   ensureLayoutsDir();
   const directory = opendirSync(LAYOUTS_DIR);
   const files: string[] = [];
+  let entryCount = 0;
   try {
-    for (let entry = directory.readSync(); entry; entry = directory.readSync()) {
-      // Every JSON entry consumes capacity, including malformed files and
-      // non-regular entries. This keeps both listing and capacity scans bounded.
-      if (entry.name.endsWith(".json")) {
-        files.push(entry.name);
-        if (files.length === limit) break;
-      }
+    while (entryCount < limit) {
+      const entry = directory.readSync();
+      if (!entry) break;
+      entryCount += 1;
+      // Every directory entry consumes capacity. JSON entries are collected
+      // without inspecting their type so malformed/non-regular entries retain
+      // the same resource-budget impact as persisted layout files.
+      if (entry.name.endsWith(".json")) files.push(entry.name);
     }
-    return files;
+    return { files, entryCount };
   } finally {
     directory.closeSync();
   }
 }
 
-function countLayoutFiles(): number {
-  return readLayoutFileNames(MAX_LAYOUT_FILES).length;
+function countLayoutEntries(): number {
+  return readLayoutDirectory(MAX_LAYOUT_FILES).entryCount;
 }
 
 function listLayouts(): { layouts: OfficeLayoutDoc[]; overCapacity: boolean } {
   ensureLayoutsDir();
   try {
-    const files = readLayoutFileNames(MAX_LAYOUT_FILES + 1);
-    const overCapacity = files.length > MAX_LAYOUT_FILES;
+    const { files, entryCount } = readLayoutDirectory(MAX_LAYOUT_FILES + 1);
+    const overCapacity = entryCount > MAX_LAYOUT_FILES;
     const layouts: OfficeLayoutDoc[] = [];
     for (const file of files.slice(0, MAX_LAYOUT_FILES)) {
       try {
@@ -1259,7 +1261,7 @@ function saveLayout(layout: OfficeLayoutDoc): boolean {
   // synchronous, so the capacity decision and write run in one event-loop
   // turn. Existing files remain replaceable, including malformed files that
   // an operator is repairing.
-  if (!existsSync(target) && countLayoutFiles() >= MAX_LAYOUT_FILES) return false;
+  if (!existsSync(target) && countLayoutEntries() >= MAX_LAYOUT_FILES) return false;
   layout.updatedAt = validated.updatedAt;
   writeFileSync(target, JSON.stringify(validated, null, 2));
   return true;

--- a/server/layoutCapacity.http.test.ts
+++ b/server/layoutCapacity.http.test.ts
@@ -26,6 +26,17 @@ describe("layout persistence capacity", () => {
     }
   }
 
+  function seedValidLayouts(count: number): void {
+    for (let index = 0; index < count; index += 1) {
+      const id = `legacy-${String(index).padStart(3, "0")}`;
+      writeFileSync(join(layoutsDir, `${id}.json`), JSON.stringify({
+        id,
+        ...body,
+        updatedAt: index + 1,
+      }));
+    }
+  }
+
   beforeAll(async () => {
     dataDir = mkdtempSync(join(tmpdir(), "pixel-agents-layout-capacity-"));
     layoutsDir = join(dataDir, "layouts");
@@ -123,6 +134,35 @@ describe("layout persistence capacity", () => {
       .expect({ error: "Layout limit reached (100)" });
 
     expect(readdirSync(layoutsDir).filter((file) => file.endsWith(".json"))).toHaveLength(100);
+  });
+
+  it("lists legacy over-capacity layouts in bounded cleanup pages", async () => {
+    seedValidLayouts(101);
+
+    const overCapacityResponse = await request(app)
+      .get("/api/layouts")
+      .expect(200);
+
+    expect(overCapacityResponse.body).toEqual(expect.objectContaining({
+      overCapacity: true,
+      layoutLimit: 100,
+    }));
+    expect(overCapacityResponse.body.layouts).toHaveLength(100);
+
+    const visibleLayoutId = overCapacityResponse.body.layouts[0].id as string;
+    await request(app)
+      .delete(`/api/layouts/${visibleLayoutId}`)
+      .set("Origin", appOrigin)
+      .expect(200);
+
+    await request(app)
+      .get("/api/layouts")
+      .expect(200)
+      .expect((response) => {
+        expect(response.body.layouts).toHaveLength(100);
+        expect(response.body.overCapacity).toBeUndefined();
+        expect(response.body.layoutLimit).toBeUndefined();
+      });
   });
 
   it("couples the final capacity decision to the synchronous file write", async () => {

--- a/server/layoutCapacity.http.test.ts
+++ b/server/layoutCapacity.http.test.ts
@@ -37,6 +37,12 @@ describe("layout persistence capacity", () => {
     }
   }
 
+  function seedNonLayoutEntries(count: number): void {
+    for (let index = 0; index < count; index += 1) {
+      writeFileSync(join(layoutsDir, `operator-note-${index}.txt`), "not a layout");
+    }
+  }
+
   beforeAll(async () => {
     dataDir = mkdtempSync(join(tmpdir(), "pixel-agents-layout-capacity-"));
     layoutsDir = join(dataDir, "layouts");
@@ -163,6 +169,43 @@ describe("layout persistence capacity", () => {
         expect(response.body.overCapacity).toBeUndefined();
         expect(response.body.layoutLimit).toBeUndefined();
       });
+  });
+
+  it("bounds scans and creation capacity across non-layout entries", async () => {
+    seedNonLayoutEntries(101);
+
+    await request(app)
+      .get("/api/layouts")
+      .expect(200)
+      .expect((response) => {
+        expect(response.body.layouts).toEqual([]);
+        expect(response.body.overCapacity).toBe(true);
+        expect(response.body.layoutLimit).toBe(100);
+      });
+
+    expect(readdirSync(layoutsDir)).not.toContain("default.json");
+    await request(app)
+      .post("/api/layouts")
+      .set("Origin", appOrigin)
+      .send(body)
+      .expect(507)
+      .expect({ error: "Layout limit reached (100)" });
+
+    rmSync(join(layoutsDir, "operator-note-0.txt"));
+    rmSync(join(layoutsDir, "operator-note-1.txt"));
+
+    await request(app)
+      .get("/api/layouts")
+      .expect(200)
+      .expect((response) => {
+        expect(response.body.layouts).toEqual([
+          expect.objectContaining({ id: "default" }),
+        ]);
+        expect(response.body.overCapacity).toBeUndefined();
+        expect(response.body.layoutLimit).toBeUndefined();
+      });
+
+    expect(readdirSync(layoutsDir)).toHaveLength(100);
   });
 
   it("couples the final capacity decision to the synchronous file write", async () => {

--- a/server/layoutCapacity.http.test.ts
+++ b/server/layoutCapacity.http.test.ts
@@ -1,0 +1,180 @@
+import { mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { Express } from "express";
+import type { Server as SocketIOServer } from "socket.io";
+import request from "supertest";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("layout persistence capacity", () => {
+  let app: Express;
+  let io: SocketIOServer;
+  let dataDir: string;
+  let layoutsDir: string;
+  const appOrigin = "https://pixel.test";
+  const body = {
+    name: "Capacity boundary",
+    width: 24,
+    height: 16,
+    furniture: [],
+    seats: {},
+  };
+
+  function seedMalformedLayouts(count: number, prefix = "existing"): void {
+    for (let index = 0; index < count; index += 1) {
+      writeFileSync(join(layoutsDir, `${prefix}-${index}.json`), "{}");
+    }
+  }
+
+  beforeAll(async () => {
+    dataDir = mkdtempSync(join(tmpdir(), "pixel-agents-layout-capacity-"));
+    layoutsDir = join(dataDir, "layouts");
+    mkdirSync(layoutsDir, { recursive: true });
+
+    vi.stubEnv("DATA_DIR", dataDir);
+    vi.stubEnv("DATA_SOURCE", "ingest");
+    vi.stubEnv("INGEST_API_TOKEN", "test-secret");
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("CORS_ORIGIN", appOrigin);
+
+    vi.resetModules();
+    const serverModule = await import("./index");
+    app = serverModule.app;
+    io = serverModule.io;
+  });
+
+  beforeEach(() => {
+    rmSync(layoutsDir, { recursive: true, force: true });
+    mkdirSync(layoutsDir, { recursive: true });
+  });
+
+  afterAll(() => {
+    io.close();
+    rmSync(dataDir, { recursive: true, force: true });
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+
+  it("allows the final slot and rejects further layout-file creation", async () => {
+    // Every JSON file contributes to the synchronous scan cost, even when its
+    // contents are malformed and skipped by listLayouts().
+    seedMalformedLayouts(99);
+
+    await request(app)
+      .post("/api/layouts")
+      .set("Origin", appOrigin)
+      .send(body)
+      .expect(200);
+
+    expect(readdirSync(layoutsDir).filter((file) => file.endsWith(".json"))).toHaveLength(100);
+
+    await request(app)
+      .post("/api/layouts")
+      .set("Origin", appOrigin)
+      .send(body)
+      .expect(507)
+      .expect({ error: "Layout limit reached (100)" });
+
+    await request(app)
+      .put("/api/layouts/new-upsert")
+      .set("Origin", appOrigin)
+      .send(body)
+      .expect(507)
+      .expect({ error: "Layout limit reached (100)" });
+
+    await request(app)
+      .get("/api/layouts/default")
+      .expect(507)
+      .expect({ error: "Layout limit reached (100)" });
+
+    // Capacity is a file-count bound, not a write freeze. Replacing an
+    // existing invalid file must remain possible so operators can repair
+    // persisted state without first deleting another layout.
+    await request(app)
+      .put("/api/layouts/existing-0")
+      .set("Origin", appOrigin)
+      .send(body)
+      .expect(200);
+
+    expect(readdirSync(layoutsDir).filter((file) => file.endsWith(".json"))).toHaveLength(100);
+  });
+
+  it("bounds default creation through the collection endpoint", async () => {
+    seedMalformedLayouts(99);
+
+    await request(app)
+      .get("/api/layouts")
+      .expect(200)
+      .expect((response) => {
+        expect(response.body.layouts).toEqual([
+          expect.objectContaining({ id: "default" }),
+        ]);
+      });
+
+    expect(readdirSync(layoutsDir).filter((file) => file.endsWith(".json"))).toHaveLength(100);
+
+    rmSync(layoutsDir, { recursive: true, force: true });
+    mkdirSync(layoutsDir, { recursive: true });
+    seedMalformedLayouts(100);
+
+    await request(app)
+      .get("/api/layouts")
+      .expect(507)
+      .expect({ error: "Layout limit reached (100)" });
+
+    expect(readdirSync(layoutsDir).filter((file) => file.endsWith(".json"))).toHaveLength(100);
+  });
+
+  it("couples the final capacity decision to the synchronous file write", async () => {
+    seedMalformedLayouts(99);
+
+    const responses = await Promise.all([
+      request(app).post("/api/layouts").set("Origin", appOrigin).send(body),
+      request(app).post("/api/layouts").set("Origin", appOrigin).send(body),
+    ]);
+
+    expect(responses.map((response) => response.status).sort()).toEqual([200, 507]);
+    expect(readdirSync(layoutsDir).filter((file) => file.endsWith(".json"))).toHaveLength(100);
+  });
+
+  it("preserves optimistic concurrency while replacing a layout at capacity", async () => {
+    seedMalformedLayouts(99);
+    const existingPath = join(layoutsDir, "existing-valid.json");
+    writeFileSync(existingPath, JSON.stringify({
+      id: "existing-valid",
+      ...body,
+      updatedAt: 1000,
+    }));
+
+    await request(app)
+      .put("/api/layouts/existing-valid")
+      .set("Origin", appOrigin)
+      .send({ ...body, name: "Stale update", baseUpdatedAt: 999 })
+      .expect(409);
+
+    expect(JSON.parse(readFileSync(existingPath, "utf-8")).name).toBe("Capacity boundary");
+
+    await request(app)
+      .put("/api/layouts/existing-valid")
+      .set("Origin", appOrigin)
+      .send({ ...body, name: "Current update", baseUpdatedAt: 1000 })
+      .expect(200);
+
+    expect(JSON.parse(readFileSync(existingPath, "utf-8")).name).toBe("Current update");
+    expect(readdirSync(layoutsDir).filter((file) => file.endsWith(".json"))).toHaveLength(100);
+  });
+
+  it("repairs an existing malformed default file at capacity", async () => {
+    seedMalformedLayouts(99);
+    writeFileSync(join(layoutsDir, "default.json"), "{}");
+
+    await request(app)
+      .get("/api/layouts/default")
+      .expect(200)
+      .expect((response) => {
+        expect(response.body).toEqual(expect.objectContaining({ id: "default" }));
+      });
+
+    expect(readdirSync(layoutsDir).filter((file) => file.endsWith(".json"))).toHaveLength(100);
+  });
+});

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -7,10 +7,13 @@ import { App } from './App';
 
 const testState = vi.hoisted(() => ({
   updateFurniture: vi.fn(),
+  clearLayoutError: vi.fn(),
   pixelOfficeProps: null as null | {
     onRotateFurniture: (id: string, rotation: number) => void;
   },
   layoutEditorProps: null as null | {
+    layoutError: string | null;
+    onClearLayoutError: () => void;
     onRotateFurniture: (id: string) => void;
   },
 }));
@@ -41,7 +44,9 @@ vi.mock('./hooks/useLayoutStore', () => ({
       seats: {},
     },
     isDirty: false,
+    layoutError: 'Layout limit reached (100). Delete unused layouts until the warning clears.',
     catalog: [],
+    clearLayoutError: testState.clearLayoutError,
     loadLayoutById: vi.fn(),
     saveActiveLayout: vi.fn(),
     createLayout: vi.fn(),
@@ -73,6 +78,7 @@ describe('App furniture rotation persistence', () => {
 
   beforeEach(() => {
     testState.updateFurniture.mockReset();
+    testState.clearLayoutError.mockReset();
     testState.pixelOfficeProps = null;
     testState.layoutEditorProps = null;
   });
@@ -122,5 +128,16 @@ describe('App furniture rotation persistence', () => {
     ])).toEqual([
       { id: 'desk-1', type: 'DESK', x: 3, y: 4, rotation: 0 },
     ]);
+  });
+
+  it('passes layout errors and their dismiss action into the editor', () => {
+    render(<App />);
+    fireEvent.click(screen.getByRole('button', { name: '✏️ Editor' }));
+
+    expect(testState.layoutEditorProps?.layoutError).toBe(
+      'Layout limit reached (100). Delete unused layouts until the warning clears.',
+    );
+    testState.layoutEditorProps?.onClearLayoutError();
+    expect(testState.clearLayoutError).toHaveBeenCalledOnce();
   });
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,8 +16,8 @@ import './App.css';
 export const App: React.FC = () => {
   const { agents, connected, toggleAgent, toggleAll, updateTags, updateRecipe, activeRoomId, setActiveRoomId, roomAgents } = useAgentStore();
   const {
-    layouts, activeLayout, isDirty, saveStatus, catalog,
-    loadLayoutById, saveActiveLayout, createLayout, deleteLayout, updateFurniture,
+    layouts, activeLayout, isDirty, saveStatus, layoutError, catalog,
+    clearLayoutError, loadLayoutById, saveActiveLayout, createLayout, deleteLayout, updateFurniture,
   } = useLayoutStore();
 
   const [editorMode, setEditorMode] = useState(false);
@@ -191,6 +191,7 @@ export const App: React.FC = () => {
               activeLayout={activeLayout}
               isDirty={isDirty}
               saveStatus={saveStatus}
+              layoutError={layoutError}
               layouts={layouts}
               editorMode={editorMode}
               selectedFurnitureType={selectedFurnitureType}
@@ -209,6 +210,7 @@ export const App: React.FC = () => {
               onSave={() => saveActiveLayout()}
               onLoad={loadLayoutById}
               onCreate={createLayout}
+              onClearLayoutError={clearLayoutError}
               onDeleteLayout={deleteLayout}
               onToggleEditor={() => { setEditorMode(false); setDeleteMode(false); }}
             />

--- a/src/components/LayoutEditor.create.test.tsx
+++ b/src/components/LayoutEditor.create.test.tsx
@@ -1,0 +1,135 @@
+import React, { useState } from 'react';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { LayoutEditor } from './LayoutEditor';
+import type { LayoutDoc } from '../hooks/useLayoutStore';
+
+const defaultLayout: LayoutDoc = {
+  id: 'default',
+  name: 'Default',
+  width: 24,
+  height: 16,
+  furniture: [],
+  seats: {},
+  updatedAt: 1,
+};
+
+function makeProps(overrides: Partial<React.ComponentProps<typeof LayoutEditor>> = {}) {
+  return {
+    catalog: [],
+    activeLayout: defaultLayout,
+    isDirty: false,
+    layoutError: null,
+    layouts: [defaultLayout],
+    editorMode: true,
+    selectedFurnitureType: null,
+    selectedFurnitureId: null,
+    deleteMode: false,
+    onSelectFurnitureType: vi.fn(),
+    onSelectFurnitureId: vi.fn(),
+    onPlaceFurniture: vi.fn(),
+    onMoveFurniture: vi.fn(),
+    onRotateFurniture: vi.fn(),
+    onDeleteFurniture: vi.fn(),
+    onToggleDeleteMode: vi.fn(),
+    onSave: vi.fn(),
+    onLoad: vi.fn(),
+    onCreate: vi.fn().mockResolvedValue(defaultLayout),
+    onClearLayoutError: vi.fn(),
+    onDeleteLayout: vi.fn().mockResolvedValue(true),
+    onToggleEditor: vi.fn(),
+    ...overrides,
+  };
+}
+
+function openLayoutManager() {
+  fireEvent.click(screen.getByTitle('Layout manager'));
+  return screen.getByPlaceholderText('New layout name...') as HTMLInputElement;
+}
+
+describe('LayoutEditor layout creation recovery', () => {
+  afterEach(cleanup);
+
+  it('preserves the entered name and shows the store warning after a failed create', async () => {
+    const errorMessage = 'Layout limit reached (100). Delete unused layouts until the warning clears.';
+
+    function Harness() {
+      const [layoutError, setLayoutError] = useState<string | null>(null);
+      return (
+        <LayoutEditor
+          {...makeProps({
+            layoutError,
+            onCreate: async () => {
+              setLayoutError(errorMessage);
+              return null;
+            },
+          })}
+        />
+      );
+    }
+
+    render(<Harness />);
+    const input = openLayoutManager();
+    fireEvent.change(input, { target: { value: 'Overflow recovery' } });
+    fireEvent.submit(input.closest('form')!);
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(errorMessage);
+    await waitFor(() => expect(input.value).toBe('Overflow recovery'));
+  });
+
+  it('clears the entered name only after a successful create', async () => {
+    const onCreate = vi.fn().mockResolvedValue({
+      ...defaultLayout,
+      id: 'new-layout',
+      name: 'New Layout',
+    });
+    render(<LayoutEditor {...makeProps({ onCreate })} />);
+    const input = openLayoutManager();
+    fireEvent.change(input, { target: { value: 'New Layout' } });
+    fireEvent.click(screen.getByRole('button', { name: '➕ Create' }));
+
+    expect(onCreate).toHaveBeenCalledWith('New Layout');
+    await waitFor(() => expect(input.value).toBe(''));
+  });
+
+  it('shows a pending state and prevents duplicate submissions', async () => {
+    let resolveCreate!: (layout: LayoutDoc | null) => void;
+    const onCreate = vi.fn(() => new Promise<LayoutDoc | null>(resolve => {
+      resolveCreate = resolve;
+    }));
+    render(<LayoutEditor {...makeProps({ onCreate })} />);
+    const input = openLayoutManager();
+    const form = input.closest('form')!;
+    fireEvent.change(input, { target: { value: 'Slow Layout' } });
+    fireEvent.submit(form);
+
+    const pendingButton = screen.getByRole('button', { name: 'Creating…' });
+    expect(pendingButton).toBeDisabled();
+    expect(input).toHaveProperty('readOnly', true);
+    fireEvent.submit(form);
+    expect(onCreate).toHaveBeenCalledOnce();
+
+    resolveCreate(null);
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: '➕ Create' })).not.toBeDisabled();
+      expect(input).toHaveProperty('readOnly', false);
+    });
+  });
+
+  it('calls the store dismiss action from the warning control', () => {
+    const onClearLayoutError = vi.fn();
+    render(
+      <LayoutEditor
+        {...makeProps({
+          layoutError: 'Failed to create layout. Try again.',
+          onClearLayoutError,
+        })}
+      />,
+    );
+    openLayoutManager();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Dismiss layout warning' }));
+    expect(onClearLayoutError).toHaveBeenCalledOnce();
+  });
+});

--- a/src/components/LayoutEditor.css
+++ b/src/components/LayoutEditor.css
@@ -228,6 +228,48 @@
   margin: 0 0 12px;
 }
 
+.layout-alert {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: start;
+  gap: 8px;
+  margin: 0 0 12px;
+  padding: 8px;
+  background: rgba(255, 0, 85, 0.09);
+  border: 1px solid rgba(255, 0, 85, 0.4);
+  border-left: 3px solid var(--acc-pink);
+  border-radius: 4px;
+}
+.layout-alert-icon {
+  color: var(--acc-pink);
+  font-size: 12px;
+  line-height: 1.4;
+}
+.layout-alert-message {
+  margin: 0;
+  color: var(--text-main);
+  font-family: var(--font-body);
+  font-size: 11px;
+  line-height: 1.4;
+  overflow-wrap: anywhere;
+}
+.layout-alert-dismiss {
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  background: transparent;
+  color: var(--text-muted);
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  line-height: 1;
+}
+.layout-alert-dismiss:hover {
+  color: var(--acc-pink);
+  border-color: rgba(255, 0, 85, 0.4);
+  background: rgba(255, 0, 85, 0.1);
+}
+
 .layout-list { display: flex; flex-direction: column; gap: 8px; max-height: 200px; overflow-y: auto; }
 
 .layout-item {
@@ -258,7 +300,7 @@
   font-family: var(--font-body);
   font-size: 12px;
 }
-.layout-create input:focus { outline: none; border-color: var(--acc-cyan); }
+.layout-create input:focus { border-color: var(--acc-cyan); }
 .layout-create button {
   background: rgba(0, 240, 255, 0.1);
   color: var(--acc-cyan);
@@ -271,6 +313,14 @@
   transition: all 0.2s;
 }
 .layout-create button:hover { background: rgba(0, 240, 255, 0.3); }
+.layout-create input:read-only,
+.layout-create button:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+.layout-create button:disabled:hover {
+  background: rgba(0, 240, 255, 0.1);
+}
 
 /* Delete confirmation dialog — Confirmation Barrier / Guard Pattern (issue #109).
    Portaled to document.body so it escapes the .app-main stacking context and

--- a/src/components/LayoutEditor.delete.test.tsx
+++ b/src/components/LayoutEditor.delete.test.tsx
@@ -60,6 +60,7 @@ function makeProps(overrides: Partial<Record<string, unknown>> = {}) {
     catalog: ['DESK'],
     activeLayout: defaultLayout,
     isDirty: false,
+    layoutError: null,
     layouts: [defaultLayout, customLayout],
     editorMode: true,
     selectedFurnitureType: null,
@@ -74,7 +75,8 @@ function makeProps(overrides: Partial<Record<string, unknown>> = {}) {
     onToggleDeleteMode: vi.fn(),
     onSave: vi.fn(),
     onLoad: vi.fn(),
-    onCreate: vi.fn(),
+    onCreate: vi.fn().mockResolvedValue(defaultLayout),
+    onClearLayoutError: vi.fn(),
     // Strict-boolean result contract (Sophie review @78f2bc3): the barrier
     // closes only on a literal `true`, so the default mock must resolve true.
     onDeleteLayout: vi.fn().mockResolvedValue(true),

--- a/src/components/LayoutEditor.mobile.test.tsx
+++ b/src/components/LayoutEditor.mobile.test.tsx
@@ -129,6 +129,7 @@ describe('Issue #87 — mobile toolbar / room switcher overlap', () => {
     catalog: ['DESK', 'PLANT'],
     activeLayout: mockLayout,
     isDirty: false,
+    layoutError: null,
     layouts: [mockLayout],
     editorMode: true,
     selectedFurnitureType: null,
@@ -143,7 +144,8 @@ describe('Issue #87 — mobile toolbar / room switcher overlap', () => {
     onToggleDeleteMode: vi.fn(),
     onSave: vi.fn(),
     onLoad: vi.fn(),
-    onCreate: vi.fn(),
+    onCreate: vi.fn().mockResolvedValue(mockLayout),
+    onClearLayoutError: vi.fn(),
     onDeleteLayout: vi.fn(),
     onToggleEditor: vi.fn(),
   };

--- a/src/components/LayoutEditor.tsx
+++ b/src/components/LayoutEditor.tsx
@@ -10,6 +10,7 @@ interface Props {
   isDirty: boolean;
   /** Save lifecycle feedback from useLayoutStore (optional for tests). */
   saveStatus?: SaveStatus;
+  layoutError: string | null;
   layouts: LayoutDoc[];
   editorMode: boolean;
   selectedFurnitureType: string | null;
@@ -24,7 +25,8 @@ interface Props {
   onToggleDeleteMode: () => void;
   onSave: () => void;
   onLoad: (id: string) => void;
-  onCreate: (name: string) => void;
+  onCreate: (name: string) => Promise<LayoutDoc | null>;
+  onClearLayoutError: () => void;
   onDeleteLayout: (id: string) => boolean | Promise<boolean>;
   onToggleEditor: () => void;
 }
@@ -111,6 +113,7 @@ export const LayoutEditor: React.FC<Props> = ({
   activeLayout,
   isDirty,
   saveStatus = 'idle',
+  layoutError,
   layouts,
   editorMode,
   selectedFurnitureType,
@@ -124,17 +127,20 @@ export const LayoutEditor: React.FC<Props> = ({
   onSave,
   onLoad,
   onCreate,
+  onClearLayoutError,
   onDeleteLayout,
   onToggleEditor,
 }) => {
   const [showPalette, setShowPalette] = useState(false);
   const [showLayouts, setShowLayouts] = useState(false);
   const [newName, setNewName] = useState('');
+  const [creating, setCreating] = useState(false);
   const [pendingDelete, setPendingDelete] = useState<LayoutDoc | null>(null);
   // Confirm lifecycle: disables the buttons while the async delete is in
   // flight (double-submit guard) and surfaces a failure without closing.
   const [deleting, setDeleting] = useState(false);
   const [deleteError, setDeleteError] = useState(false);
+  const creatingRef = useRef(false);
   const deletingRef = useRef(false);
   const dialogRef = useRef<HTMLDivElement>(null);
   const overlayRef = useRef<HTMLDivElement>(null);
@@ -267,6 +273,25 @@ export const LayoutEditor: React.FC<Props> = ({
     };
   }, [pendingDelete]);
 
+  const handleCreate = useCallback(async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const name = newName.trim();
+    if (!name || creatingRef.current) return;
+
+    creatingRef.current = true;
+    setCreating(true);
+    try {
+      const createdLayout = await onCreate(name);
+      if (createdLayout) setNewName('');
+    } catch {
+      // The layout store owns the user-facing error message. Keep the entered
+      // name intact so the user can recover without retyping it.
+    } finally {
+      creatingRef.current = false;
+      setCreating(false);
+    }
+  }, [newName, onCreate]);
+
   if (!editorMode) return null;
 
   const selectedFurniture = activeLayout?.furniture.find(f => f.id === selectedFurnitureId);
@@ -281,7 +306,7 @@ export const LayoutEditor: React.FC<Props> = ({
   const saveTitle =
     saveStatus === 'saving' ? 'Saving layout…'
     : saveStatus === 'saved' ? 'Layout saved'
-    : saveStatus === 'error' ? 'Couldn\'t save — the app retries automatically; click to retry now'
+    : saveStatus === 'error' ? 'Couldn\'t save — click to retry'
     : isDirty ? 'Save layout (unsaved changes)'
     : 'Save layout (no unsaved changes)';
   const saveDisabled = saveStatus === 'saving' || (!isDirty && saveStatus !== 'error');
@@ -394,6 +419,21 @@ export const LayoutEditor: React.FC<Props> = ({
       {showLayouts && (
         <div className="layout-manager">
           <h3>📐 Layouts</h3>
+          {layoutError && (
+            <div className="layout-alert" role="alert">
+              <span className="layout-alert-icon" aria-hidden="true">⚠</span>
+              <p className="layout-alert-message">{layoutError}</p>
+              <button
+                type="button"
+                className="layout-alert-dismiss"
+                onClick={onClearLayoutError}
+                aria-label="Dismiss layout warning"
+                title="Dismiss warning"
+              >
+                ✕
+              </button>
+            </div>
+          )}
           <div className="layout-list">
             {layouts.map(layout => (
               <div
@@ -421,23 +461,19 @@ export const LayoutEditor: React.FC<Props> = ({
               </div>
             ))}
           </div>
-          <div className="layout-create">
+          <form className="layout-create" onSubmit={handleCreate} aria-busy={creating}>
             <input
               type="text"
               placeholder="New layout name..."
+              aria-label="New layout name"
               value={newName}
               onChange={e => setNewName(e.target.value)}
-              onKeyDown={e => {
-                if (e.key === 'Enter' && newName.trim()) {
-                  onCreate(newName.trim());
-                  setNewName('');
-                }
-              }}
+              readOnly={creating}
             />
-            <button onClick={() => { if (newName.trim()) { onCreate(newName.trim()); setNewName(''); } }}>
-              ➕ Create
+            <button type="submit" disabled={creating || !newName.trim()}>
+              {creating ? 'Creating…' : '➕ Create'}
             </button>
-          </div>
+          </form>
         </div>
       )}
 

--- a/src/hooks/useLayoutStore.test.tsx
+++ b/src/hooks/useLayoutStore.test.tsx
@@ -294,6 +294,87 @@ describe('useLayoutStore', () => {
       );
     });
 
+    it('preserves the existing list and warning when a successful list response has malformed JSON', async () => {
+      await renderStoreProbe();
+      const initialFetch = fetch;
+      let listRequests = 0;
+      vi.stubGlobal('fetch', vi.fn(async (
+        input: string | URL | Request,
+        init?: RequestInit,
+      ) => {
+        const url = typeof input === 'string' ? input : input.toString();
+        if (url.endsWith('/api/layouts') && (!init || init.method === undefined)) {
+          listRequests++;
+          if (listRequests === 1) {
+            return new Response(JSON.stringify({
+              layouts: [OTHER_LAYOUT],
+              overCapacity: true,
+              layoutLimit: 100,
+            }), {
+              status: 200,
+              headers: { 'Content-Type': 'application/json' },
+            });
+          }
+          return new Response('{', {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          });
+        }
+        return initialFetch(input, init);
+      }));
+
+      await act(async () => {
+        await latest(snapshots).fetchLayouts();
+      });
+      const previousLayouts = latest(snapshots).layouts;
+      const previousError = latest(snapshots).layoutError;
+
+      await act(async () => {
+        await latest(snapshots).fetchLayouts();
+      });
+      expect(latest(snapshots).layouts).toBe(previousLayouts);
+      expect(latest(snapshots).layoutError).toBe(previousError);
+    });
+
+    it.each([
+      ['missing layouts', {}],
+      ['non-array layouts', { layouts: { default: MOCK_LAYOUT } }],
+    ])('preserves the existing list and warning for %s', async (_label, invalidBody) => {
+      await renderStoreProbe();
+      const initialFetch = fetch;
+      let listRequests = 0;
+      vi.stubGlobal('fetch', vi.fn(async (
+        input: string | URL | Request,
+        init?: RequestInit,
+      ) => {
+        const url = typeof input === 'string' ? input : input.toString();
+        if (url.endsWith('/api/layouts') && (!init || init.method === undefined)) {
+          listRequests++;
+          return new Response(JSON.stringify(listRequests === 1 ? {
+            layouts: [OTHER_LAYOUT],
+            overCapacity: true,
+            layoutLimit: 100,
+          } : invalidBody), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          });
+        }
+        return initialFetch(input, init);
+      }));
+
+      await act(async () => {
+        await latest(snapshots).fetchLayouts();
+      });
+      const previousLayouts = latest(snapshots).layouts;
+      const previousError = latest(snapshots).layoutError;
+
+      await act(async () => {
+        await latest(snapshots).fetchLayouts();
+      });
+      expect(latest(snapshots).layouts).toBe(previousLayouts);
+      expect(latest(snapshots).layoutError).toBe(previousError);
+    });
+
     it('clears an over-capacity warning after a normal list response', async () => {
       await renderStoreProbe();
       const initialFetch = fetch;

--- a/src/hooks/useLayoutStore.test.tsx
+++ b/src/hooks/useLayoutStore.test.tsx
@@ -173,6 +173,163 @@ describe('useLayoutStore', () => {
     expect(latest(snapshots).activeLayout?.id).toBe('default');
   });
 
+  describe('layout capacity errors', () => {
+    it('returns null and exposes an actionable error when create returns 507', async () => {
+      await renderStoreProbe();
+      const initialFetch = fetch;
+      vi.stubGlobal('fetch', vi.fn(async (
+        input: string | URL | Request,
+        init?: RequestInit,
+      ) => {
+        const url = typeof input === 'string' ? input : input.toString();
+        if (url.endsWith('/api/layouts') && init?.method === 'POST') {
+          return new Response(JSON.stringify({ error: 'Layout limit reached (100)' }), {
+            status: 507,
+            headers: { 'Content-Type': 'application/json' },
+          });
+        }
+        return initialFetch(input, init);
+      }));
+
+      let result: LayoutDoc | null | undefined;
+      await act(async () => {
+        result = await latest(snapshots).createLayout('Capacity test');
+      });
+
+      expect(result).toBeNull();
+      expect(latest(snapshots).layoutError).toBe(
+        'Layout limit reached (100). Delete unused layouts until the warning clears.',
+      );
+    });
+
+    it('marks a 507 save as terminal without scheduling a retry', async () => {
+      await renderStoreProbe();
+      vi.useFakeTimers();
+      const initialFetch = fetch;
+      let putCalls = 0;
+      vi.stubGlobal('fetch', vi.fn(async (
+        input: string | URL | Request,
+        init?: RequestInit,
+      ) => {
+        const url = typeof input === 'string' ? input : input.toString();
+        if (url.endsWith('/api/layouts/default') && init?.method === 'PUT') {
+          putCalls++;
+          return new Response(JSON.stringify({ error: 'Layout limit reached (100)' }), {
+            status: 507,
+            headers: { 'Content-Type': 'application/json' },
+          });
+        }
+        return initialFetch(input, init);
+      }));
+
+      await act(async () => {
+        await latest(snapshots).saveActiveLayout();
+      });
+      expect(putCalls).toBe(1);
+      expect(latest(snapshots).saveStatus).toBe('error');
+      expect(latest(snapshots).layoutError).toContain('Delete unused layouts');
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(60_000);
+      });
+      expect(putCalls).toBe(1);
+    });
+
+    it('preserves the existing list when fetchLayouts returns 507', async () => {
+      await renderStoreProbe();
+      await waitFor(() => expect(latest(snapshots).layouts).toHaveLength(2));
+      const previousLayouts = latest(snapshots).layouts;
+      const initialFetch = fetch;
+      vi.stubGlobal('fetch', vi.fn(async (
+        input: string | URL | Request,
+        init?: RequestInit,
+      ) => {
+        const url = typeof input === 'string' ? input : input.toString();
+        if (url.endsWith('/api/layouts') && (!init || init.method === undefined)) {
+          return new Response(JSON.stringify({ error: 'Layout limit reached (100)' }), {
+            status: 507,
+            headers: { 'Content-Type': 'application/json' },
+          });
+        }
+        return initialFetch(input, init);
+      }));
+
+      await act(async () => {
+        await latest(snapshots).fetchLayouts();
+      });
+
+      expect(latest(snapshots).layouts).toBe(previousLayouts);
+      expect(latest(snapshots).layoutError).toContain('Delete unused layouts');
+    });
+
+    it('uses the bounded list and warns when fetchLayouts reports over-capacity', async () => {
+      await renderStoreProbe();
+      const initialFetch = fetch;
+      vi.stubGlobal('fetch', vi.fn(async (
+        input: string | URL | Request,
+        init?: RequestInit,
+      ) => {
+        const url = typeof input === 'string' ? input : input.toString();
+        if (url.endsWith('/api/layouts') && (!init || init.method === undefined)) {
+          return new Response(JSON.stringify({
+            layouts: [OTHER_LAYOUT],
+            overCapacity: true,
+            layoutLimit: 100,
+          }), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          });
+        }
+        return initialFetch(input, init);
+      }));
+
+      await act(async () => {
+        await latest(snapshots).fetchLayouts();
+      });
+
+      expect(latest(snapshots).layouts).toEqual([OTHER_LAYOUT]);
+      expect(latest(snapshots).layoutError).toBe(
+        'Only 100 layouts are shown because the layout limit was exceeded. '
+        + 'Delete unused layouts until this warning clears.',
+      );
+    });
+
+    it('clears an over-capacity warning after a normal list response', async () => {
+      await renderStoreProbe();
+      const initialFetch = fetch;
+      let listRequests = 0;
+      vi.stubGlobal('fetch', vi.fn(async (
+        input: string | URL | Request,
+        init?: RequestInit,
+      ) => {
+        const url = typeof input === 'string' ? input : input.toString();
+        if (url.endsWith('/api/layouts') && (!init || init.method === undefined)) {
+          listRequests++;
+          return new Response(JSON.stringify({
+            layouts: listRequests === 1 ? [OTHER_LAYOUT] : [MOCK_LAYOUT, OTHER_LAYOUT],
+            overCapacity: listRequests === 1,
+            layoutLimit: 100,
+          }), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          });
+        }
+        return initialFetch(input, init);
+      }));
+
+      await act(async () => {
+        await latest(snapshots).fetchLayouts();
+      });
+      expect(latest(snapshots).layoutError).not.toBeNull();
+
+      await act(async () => {
+        await latest(snapshots).fetchLayouts();
+      });
+      expect(latest(snapshots).layoutError).toBeNull();
+      expect(latest(snapshots).layouts).toEqual([MOCK_LAYOUT, OTHER_LAYOUT]);
+    });
+  });
+
   it('saveActiveLayout always reads the latest active layout (invariant test)', async () => {
     await renderStoreProbe();
 

--- a/src/hooks/useLayoutStore.test.tsx
+++ b/src/hooks/useLayoutStore.test.tsx
@@ -336,6 +336,36 @@ describe('useLayoutStore', () => {
       expect(latest(snapshots).layoutError).toBe(previousError);
     });
 
+    it('rejects an invalid layout element without replacing the list and exposes a fetch error', async () => {
+      await renderStoreProbe();
+      await waitFor(() => expect(latest(snapshots).layouts).toHaveLength(2));
+      const previousLayouts = latest(snapshots).layouts;
+      expect(latest(snapshots).layoutError).toBeNull();
+      const initialFetch = fetch;
+      vi.stubGlobal('fetch', vi.fn(async (
+        input: string | URL | Request,
+        init?: RequestInit,
+      ) => {
+        const url = typeof input === 'string' ? input : input.toString();
+        if (url.endsWith('/api/layouts') && (!init || init.method === undefined)) {
+          return new Response(JSON.stringify({
+            layouts: [{ ...OTHER_LAYOUT, width: 0 }],
+          }), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          });
+        }
+        return initialFetch(input, init);
+      }));
+
+      await act(async () => {
+        await latest(snapshots).fetchLayouts();
+      });
+
+      expect(latest(snapshots).layouts).toBe(previousLayouts);
+      expect(latest(snapshots).layoutError).toBe('Failed to fetch layouts. Try again.');
+    });
+
     it.each([
       ['missing layouts', {}],
       ['non-array layouts', { layouts: { default: MOCK_LAYOUT } }],

--- a/src/hooks/useLayoutStore.ts
+++ b/src/hooks/useLayoutStore.ts
@@ -209,11 +209,18 @@ export function useLayoutStore() {
         console.error('Failed to fetch layouts:', message);
         return;
       }
-      if (!data || typeof data !== 'object' || !Array.isArray((data as Record<string, unknown>).layouts)) {
+      const responseBody = data && typeof data === 'object'
+        ? data as Record<string, unknown>
+        : null;
+      if (
+        !responseBody
+        || !Array.isArray(responseBody.layouts)
+        || !responseBody.layouts.every(isLayoutDoc)
+      ) {
         console.error('Failed to fetch layouts: invalid response body');
+        setLayoutError(current => current ?? 'Failed to fetch layouts. Try again.');
         return;
       }
-      const responseBody = data as Record<string, unknown> & { layouts: LayoutDoc[] };
       setLayouts(responseBody.layouts);
       if (responseBody.overCapacity === true) {
         const limit = Number.isSafeInteger(responseBody.layoutLimit)
@@ -229,7 +236,7 @@ export function useLayoutStore() {
       }
     } catch (err) {
       console.error('Failed to fetch layouts:', err);
-      setLayoutError('Failed to fetch layouts. Try again.');
+      setLayoutError(current => current ?? 'Failed to fetch layouts. Try again.');
     }
   }, []);
 

--- a/src/hooks/useLayoutStore.ts
+++ b/src/hooks/useLayoutStore.ts
@@ -195,18 +195,31 @@ export function useLayoutStore() {
   const fetchLayouts = useCallback(async () => {
     try {
       const res = await fetch(`${API_BASE}/layouts`);
-      const data = await res.json().catch(() => null);
+      const data: unknown = await res.json().catch(() => null);
       if (!res.ok) {
+        const responseError = data && typeof data === 'object' && 'error' in data
+          ? (data as Record<string, unknown>).error
+          : undefined;
         const message = res.status === 507
-          ? capacityErrorMessage(data?.error)
-          : data?.error ?? `Failed to fetch layouts (HTTP ${res.status})`;
+          ? capacityErrorMessage(responseError)
+          : typeof responseError === 'string'
+            ? responseError
+            : `Failed to fetch layouts (HTTP ${res.status})`;
         setLayoutError(message);
         console.error('Failed to fetch layouts:', message);
         return;
       }
-      setLayouts(data?.layouts || []);
-      if (data?.overCapacity === true) {
-        const limit = Number.isSafeInteger(data.layoutLimit) ? data.layoutLimit : 100;
+      if (!data || typeof data !== 'object' || !Array.isArray((data as Record<string, unknown>).layouts)) {
+        console.error('Failed to fetch layouts: invalid response body');
+        return;
+      }
+      const responseBody = data as Record<string, unknown> & { layouts: LayoutDoc[] };
+      setLayouts(responseBody.layouts);
+      if (responseBody.overCapacity === true) {
+        const limit = Number.isSafeInteger(responseBody.layoutLimit)
+          && (responseBody.layoutLimit as number) > 0
+          ? responseBody.layoutLimit as number
+          : 100;
         setLayoutError(
           `Only ${limit} layouts are shown because the layout limit was exceeded. `
           + 'Delete unused layouts until this warning clears.',

--- a/src/hooks/useLayoutStore.ts
+++ b/src/hooks/useLayoutStore.ts
@@ -54,6 +54,13 @@ function pickBaseUpdatedAt(
     : currentLayout.updatedAt;
 }
 
+function capacityErrorMessage(error: unknown): string {
+  const detail = typeof error === 'string' && error.trim()
+    ? error.trim().replace(/[.!?]+$/, '')
+    : 'Layout limit reached (100)';
+  return `${detail}. Delete unused layouts until the warning clears.`;
+}
+
 /**
  * Dispatched action: a new layout value, or a functional updater.
  * Every mutation flows through the reducer, which guarantees the ref
@@ -85,6 +92,7 @@ export function useLayoutStore() {
   );
 
   const [catalog, setCatalog] = useState<string[]>([]);
+  const [layoutError, setLayoutError] = useState<string | null>(null);
   const savePromiseRef = useRef<Promise<void>>(Promise.resolve());
   // Tracks the last server revision independently from the optimistic local
   // document. A stale response may advance this revision without being
@@ -109,6 +117,8 @@ export function useLayoutStore() {
   const isDirtyRef = useRef(false);
   // retryAttemptRef: tracks consecutive failed auto-saves for backoff.
   const retryAttemptRef = useRef(0);
+
+  const clearLayoutError = useCallback(() => setLayoutError(null), []);
 
   const scheduleSaveRetry = useCallback((retry: () => void) => {
     const delay = Math.min(2000 * Math.pow(2, retryAttemptRef.current), 30000);
@@ -185,10 +195,28 @@ export function useLayoutStore() {
   const fetchLayouts = useCallback(async () => {
     try {
       const res = await fetch(`${API_BASE}/layouts`);
-      const data = await res.json();
-      setLayouts(data.layouts || []);
+      const data = await res.json().catch(() => null);
+      if (!res.ok) {
+        const message = res.status === 507
+          ? capacityErrorMessage(data?.error)
+          : data?.error ?? `Failed to fetch layouts (HTTP ${res.status})`;
+        setLayoutError(message);
+        console.error('Failed to fetch layouts:', message);
+        return;
+      }
+      setLayouts(data?.layouts || []);
+      if (data?.overCapacity === true) {
+        const limit = Number.isSafeInteger(data.layoutLimit) ? data.layoutLimit : 100;
+        setLayoutError(
+          `Only ${limit} layouts are shown because the layout limit was exceeded. `
+          + 'Delete unused layouts until this warning clears.',
+        );
+      } else {
+        setLayoutError(null);
+      }
     } catch (err) {
       console.error('Failed to fetch layouts:', err);
+      setLayoutError('Failed to fetch layouts. Try again.');
     }
   }, []);
 
@@ -205,7 +233,11 @@ export function useLayoutStore() {
       const res = await fetch(`${API_BASE}/layouts/${id}`);
       if (!res.ok) {
         const errBody = await res.json().catch(() => ({ error: `HTTP ${res.status}` }));
-        console.error('Failed to load layout:', errBody.error ?? `HTTP ${res.status}`);
+        const message = res.status === 507
+          ? capacityErrorMessage(errBody.error)
+          : errBody.error ?? `Failed to load layout (HTTP ${res.status})`;
+        if (res.status === 507) setLayoutError(message);
+        console.error('Failed to load layout:', message);
         return null;
       }
       const data: unknown = await res.json();
@@ -245,7 +277,14 @@ export function useLayoutStore() {
         if (!response.ok) {
           const errorBody = await response.json().catch(() => null);
           console.error('Failed to save layout:', errorBody?.error ?? `HTTP ${response.status}`);
-          if (response.status === 409) {
+          if (response.status === 507) {
+            if (autoSaveTimerRef.current) {
+              clearTimeout(autoSaveTimerRef.current);
+              autoSaveTimerRef.current = null;
+            }
+            retryAttemptRef.current = 0;
+            setLayoutError(capacityErrorMessage(errorBody?.error));
+          } else if (response.status === 409) {
             await refreshPersistedRevision(merged.id);
             if (activeLayoutRef.current?.id === merged.id) {
               scheduleSaveRetry(() => { void saveActiveLayout(); });
@@ -306,21 +345,34 @@ export function useLayoutStore() {
     setActiveLayoutProgrammatic,
   ]);
 
-  const createLayout = useCallback(async (name: string) => {
+  const createLayout = useCallback(async (name: string): Promise<LayoutDoc | null> => {
     try {
       const res = await fetch(`${API_BASE}/layouts`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ name, width: 24, height: 16 }),
       });
-      const data = await res.json();
-      if (data.layout) {
-        setActiveLayoutProgrammatic(data.layout);
-        fetchLayouts();
+      const data = await res.json().catch(() => null);
+      if (!res.ok) {
+        const message = res.status === 507
+          ? capacityErrorMessage(data?.error)
+          : data?.error ?? `Failed to create layout (HTTP ${res.status})`;
+        setLayoutError(message);
+        console.error('Failed to create layout:', message);
+        return null;
       }
+      if (!isLayoutDoc(data?.layout)) {
+        setLayoutError('Failed to create layout: invalid response body.');
+        console.error('Failed to create layout: invalid response body');
+        return null;
+      }
+      setLayoutError(null);
+      setActiveLayoutProgrammatic(data.layout);
+      fetchLayouts();
       return data.layout;
     } catch (err) {
       console.error('Failed to create layout:', err);
+      setLayoutError('Failed to create layout. Try again.');
       return null;
     }
   }, [fetchLayouts, setActiveLayoutProgrammatic]);
@@ -494,7 +546,9 @@ export function useLayoutStore() {
     activeLayout,
     isDirty,
     saveStatus,
+    layoutError,
     catalog,
+    clearLayoutError,
     loadLayoutById,
     saveActiveLayout,
     createLayout,


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
## Summary

This PR caps the number of persisted layout JSON files at 100 to prevent an unauthenticated DoS amplification vector where each layout listing synchronously scans and parses every file on disk.

### Server-side enforcement (`server/index.ts`)

- Adds a `MAX_LAYOUT_FILES = 100` constant alongside the layout persistence helpers.
- Introduces `countLayoutFiles()` which counts **every** `.json` file in the layouts directory, including malformed ones — closing the loophole where invalid files could bypass a count-based bound while still being scanned on every listing.
- Introduces `hasLayoutFileCapacity(id)` that permits replacement of an existing path (so operators can still edit or repair files at capacity) but blocks new allocations once the limit is hit.
- Wires the capacity check into every file-creating API path:
  - `GET /api/layouts` — refuses to auto-seed the default layout when at capacity.
  - `GET /api/layouts/:id` — refuses to auto-create the default layout when at capacity.
  - `PUT /api/layouts/:id` — checked after body validation but before write, so both upsert and update paths are covered.
  - `POST /api/layouts` — ID generation moved above the check so the deterministic UUID isn't wasted on a rejected request.
- All capacity failures return `HTTP 507` with a stable `{ error: "Layout limit reached (100)" }` payload.
- Optimistic-concurrency conflict detection (HTTP 409 on stale `baseUpdatedAt`) is preserved unchanged.

### Documentation (`README.md`)

- Adds an operator-visible note in the Layouts section: the server stores at most 100 layout files and that an unused layout must be deleted before creating another at the limit.

### Test coverage (`server/layoutCapacity.http.test.ts`, new file)

Adds a focused HTTP regression suite using `supertest` against the Express app with an isolated temp `DATA_DIR`:

1. **Boundary enforcement** — seeds 99 malformed files, asserts the 100th `POST` succeeds (200) and the 101st `POST`, a fresh `PUT` upsert, and a `GET /api/layouts/default` auto-create all return 507 with the canonical error body. Confirms replacing an existing invalid file at capacity still returns 200 and the directory stays at 100 files.
2. **Collection default seeding** — verifies `GET /api/layouts` seeds the default when there is one slot remaining, and returns 507 when 100 files already exist without writing anything new.
3. **Optimistic concurrency at capacity** — confirms that stale `baseUpdatedAt` writes still return 409 and the on-disk file remains unchanged, while a matching `baseUpdatedAt` succeeds at capacity.
4. **Malformed default repair** — confirms that `GET /api/layouts/default` overwrites a malformed `default.json` with a valid layout at capacity instead of returning 507, preserving operator recovery from corrupted persisted state.

---

## Summary

This PR adds a hard cap on persisted layout files to prevent unbounded disk growth, addresses issue #153.

## Changes

**Server (`server/index.ts`)**
- Introduces `MAX_LAYOUT_FILES = 100` constant for persisted layouts.
- Adds `countLayoutFiles()` helper that counts every JSON file in the layouts directory, including malformed files, so invalid persisted state cannot bypass the resource bound.
- Refactors `saveLayout()` to return a boolean indicating whether the write succeeded.
  - Computes capacity by checking the file count *only when the target file does not already exist* — replacing an existing file (including a malformed one an operator is repairing) always remains allowed.
  - Validates the layout, constructs the filesystem path from the schema-validated document, and writes it in a single synchronous turn so capacity and write cannot race.
- Updates all layout endpoints to translate a failed `saveLayout()` into a `507 Insufficient Storage` response with message `Layout limit reached (100)`:
  - `GET /api/layouts` (auto-create default when empty)
  - `GET /api/layouts/:id` (auto-create default on first read)
  - `PUT /api/layouts/:id` (update)
  - `POST /api/layouts` (create new)
- Moves UUID generation in `POST /api/layouts` so it happens only after request validation succeeds.

**Documentation (`README.md`)**
- Documents the new behavior in the Layouts management section: the server stores at most 100 layout files, and the user must delete an unused layout before creating another once the limit is reached.

**Tests (`server/layoutCapacity.http.test.ts`, new)**
- Adds HTTP-level coverage using supertest against a real Express app with an isolated `DATA_DIR`:
  - Verifies the 100th slot is allowed and the 101st `POST`, `PUT` of a new ID, and `GET /api/layouts/default` (auto-create path) all return `507`.
  - Verifies replacing an existing file (including a malformed one) still succeeds at capacity, so operators can repair persisted state.
  - Verifies `GET /api/layouts` returns the default when at 99 files, then returns `507` when at 100 malformed files, without growing the directory.
  - Verifies that two concurrent `POST` requests at the boundary produce exactly one success and one `507`, confirming the capacity decision and write are coupled in one event-loop turn.
  - Verifies optimistic concurrency (`baseUpdatedAt` conflict detection) still applies when replacing a layout at capacity.
  - Verifies that a malformed `default.json` at capacity gets repaired by the auto-create path on `GET /api/layouts/default`.

---

## Summary

This fix caps the number of layout files that the server persists to disk at 100, preventing unbounded growth from repeated layout creation.

### What's new

The server now enforces a hard limit of **100 layout files** on disk. When that limit is reached, the API refuses to create new layouts and returns **HTTP 507 (Insufficient Storage)** with a clear error message: `"Layout limit reached (100)"`. Users must delete an unused layout before creating another.

### Behavior by endpoint

- `POST /api/layouts` — creating a new layout beyond the cap returns 507.
- `PUT /api/layouts/:id` — **updating an existing layout still works**, even at the cap. This matters because:
  - Operators can repair an invalid persisted file without first deleting another layout.
  - Optimistic concurrency (the `baseUpdatedAt` check) is preserved during capacity-bound updates.
- `GET /api/layouts` — listing an empty directory auto-creates the default layout; if the cap is already full, the request returns 507 instead of silently violating the bound.
- `GET /api/layouts/default` — auto-creating the default layout when missing is also subject to the cap.

### Implementation details

- A new `countLayoutFiles()` helper scans the layouts directory and counts **every** `.json` file, including malformed ones. This is deliberate: malformed files still consume the scan/budget cost, so excluding them would let corrupt state bypass the bound.
- The capacity check in `saveLayout()` runs **synchronously** alongside the write, so two concurrent creation requests cannot both succeed past the cap (covered by a concurrent test).
- Existing files remain replaceable, so updates and repairs keep working at the limit.

### Documentation

The README's "Layouts" section now states the 100-file limit and explains that users must delete an unused layout before creating another once the cap is reached.

### Tests

A new test suite (`server/layoutCapacity.http.test.ts`) covers:
- The final slot being allowed and the next request being rejected across `POST`, `PUT`, and `GET /default`.
- The collection endpoint (`GET /api/layouts`) refusing to auto-create the default when the cap is already full.
- Concurrent creation requests racing for the last slot — exactly one succeeds.
- Optimistic concurrency still functioning when updating an existing layout at capacity.
- Repairing a malformed `default.json` file at capacity.

Fixes the resource-exhaustion issue where the server would keep writing layout files indefinitely.

---

**Summary**

This PR caps the persisted layout files at the documented limit of 100 and provides a recoverable warning UI for installations that already exceed it. Instead of failing silently or refusing to load, the server returns a bounded page of layouts with an `overCapacity` flag, and the client surfaces a dismissible alert explaining that the user must delete layouts until the warning clears.

**Backend changes (`server/index.ts`)**
- Replaces `readdirSync`-based scanning with a bounded `opendirSync` reader (`readLayoutFileNames`) that caps the directory walk at a requested limit, keeping both the count and the list bounded.
- `listLayouts` now returns `{ layouts, overCapacity }`; when more than 100 JSON entries exist it returns the first 100 layouts plus an `overCapacity: true`/`layoutLimit: 100` flag in the `/api/layouts` response.
- The default-layout auto-seed on an empty response is suppressed when the directory is over capacity, so the warning state is not immediately cleared by a synthetic write.
- README is updated to explain the new bounded-cleanup behavior for legacy installations.

**Frontend store (`src/hooks/useLayoutStore.ts`)**
- Adds a `layoutError` state plus a `clearLayoutError` action, both exposed through the hook.
- `fetchLayouts` parses JSON safely, sets a tailored error message on HTTP 507 (capacity) or generic failures, and when the server reports `overCapacity` warns that only the bounded page is visible. A subsequent in-limit response clears the warning.
- `createLayout` is now async (`Promise<LayoutDoc | null>`): a 507 sets the actionable capacity error and returns `null`; other failures set a generic error. Successful creation clears the warning.
- `loadLayoutById` surfaces a capacity error on 507 without throwing.
- `saveActiveLayout` treats 507 as a terminal error: it cancels the auto-retry timer, resets the retry backoff, and surfaces the capacity warning instead of looping.

**UI changes (`src/components/LayoutEditor.tsx`, `LayoutEditor.css`, `App.tsx`)**
- `LayoutEditor` accepts a `layoutError` prop and `onClearLayoutError` callback, rendering a dismissible `role="alert"` banner above the layout list when an error is present.
- The create form is converted to a proper `<form onSubmit>` with a pending state ("Creating…" button, disabled inputs) and a double-submit guard, so failures keep the entered name intact for retry while success clears it.
- `App` wires the new store fields through to the editor.
- CSS adds the `.layout-alert` styles and disabled/read-only states for the create row; the stray focus-outline rule is also tidied.

**Tests**
- `server/layoutCapacity.http.test.ts`: seeds 101 valid layouts and asserts that `GET /api/layouts` returns 100 layouts with `overCapacity: true`/`layoutLimit: 100`, and that deleting one of the visible entries clears the warning on the next request.
- `src/hooks/useLayoutStore.test.tsx`: covers the new store behavior — create returning null and surfacing the capacity error, save marking 507 as terminal without retry, list fetch preserving prior state on 507, and the over-capacity warning being set from a 200 response with `overCapacity` and cleared by a normal response.
- `src/components/LayoutEditor.create.test.tsx` (new) and updated `delete.test.tsx`/`mobile.test.tsx` props: verify that the entered name is preserved after a failed create, cleared on success, that a pending create blocks duplicate submissions, and that the warning dismiss button calls `onClearLayoutError`.
- `src/App.test.tsx`: asserts the new `layoutError`/`clearLayoutError` wiring reaches the editor.

---

# Cap Persisted Layout Files

## Summary
Broadens the server's persisted-layout capacity policy so non-layout entries (e.g. operator `.txt` notes) also count toward the 100-entry ceiling, and hardens the client's layout-list fetcher against malformed/non-object JSON responses.

## Server changes (`server/index.ts`)
- Replaced `readLayoutFileNames` / `countLayoutFiles` with `readLayoutDirectory` / `countLayoutEntries`. The new helper iterates the layouts directory and returns both the JSON file list **and** the total entry count.
- The scan stops once it has observed `limit` entries, so legacy installs with hundreds of unrelated files no longer pay O(N) directory traversal.
- `countLayoutEntries()` and `listLayouts()` over-capacity checks now use the total entry count instead of the JSON-file count, so non-`.json` files consume capacity.
- `saveLayout()`'s pre-write capacity check uses the entry count, preserving the "synchronous check + write in one turn" guarantee.

## Test changes (`server/layoutCapacity.http.test.ts`)
- Adds a helper to seed 101 non-layout `.txt` entries and a new test that verifies:
  - `GET /api/layouts` returns `overCapacity: true` with `layoutLimit: 100` when only non-layout entries occupy the directory.
  - `POST /api/layouts` returns HTTP 507 (`Layout limit reached (100)`) without creating `default.json`.
  - Removing two non-layout entries clears the over-capacity state and allows a subsequent layout list to include the default layout.

## Client changes (`src/hooks/useLayoutStore.ts`)
- `fetchLayouts()` now treats the response body as `unknown` and validates it before consuming:
  - Error-path responses extract `error` defensively (handles non-object bodies and non-string error values).
  - Success responses must be an object with an array `layouts`; otherwise the previous layouts and error state are preserved and a console error is logged. This protects against malformed JSON, `{ "layouts": {...} }`, or empty bodies clobbering the current list or warning.

## Client tests (`src/hooks/useLayoutStore.test.tsx`)
- Adds three tests asserting that a successful but malformed/invalid list response (malformed JSON, missing `layouts` field, or non-array `layouts`) preserves the previously fetched layouts **and** any prior over-capacity warning instead of clearing them.

## Docs (`README.md`)
- Clarifies that the 100-entry limit applies to everything in the layouts directory (JSON or otherwise) and that operators can manually remove non-layout files to clear a persistent capacity warning.

---

## Summary

This PR bundles three behavioral improvements and a doc/test update into `fix/issue-153`.

### Server — CLI polling health tracking (server/index.ts, dataSource, README)
- `pollSessions` now uses shared `OPENCLAW_SESSIONS_EXEC_OPTIONS` (including a 10 MiB `maxBuffer`) and surfaces the underlying `error` so the poll loop can log full context.
- Introduced a `cliPollHealth` state machine via `updateCliPollHealth`:
  - On a `sourceError` that does **not** trigger a data-source transition, the **first** failure logs in full (`error` level), subsequent same-kind failures are suppressed, and a `warn` summary is emitted every 20 consecutive failed cycles (≈1 minute at the default interval).
  - On a successful poll following failures, a single `info` "cli polling recovered" line is logged with the prior failure kind and count.
- The fallback log line is renamed from "CLI executable unavailable" to the broader "CLI unavailable without operator action" and now includes the `err` payload.
- README documents the expanded set of operator-action-required failures (`ENOENT`, `ENOTDIR`, `EISDIR`, `EACCES`, `EPERM`, `ENOEXEC`, `EFTYPE`, `ELOOP`, `ENAMETOOLONG`, and the 10 MiB `maxBuffer` overflow) that drive the sticky `auto` → ingest transition, and the new logging behavior.

### Client — defensive layout validation (src/hooks/useLayoutStore.ts, useLayoutStore.test.tsx)
- `fetchLayouts` now validates every element of the returned `layouts` array with `isLayoutDoc`. If validation fails, the existing list is preserved and a `layoutError` ("Failed to fetch layouts. Try again.") is surfaced, so users see and can dismiss the error instead of silently keeping stale data with a misleading empty list.
- Both the validation path and the thrown-error path use the `current => current ?? …` form so a new error never clobbers an existing one already shown in the UI.
- New test: feeds a malformed layout (`width: 0`) from `/api/layouts` and asserts the list is unchanged and `layoutError` is set to the expected message.

### Docs (README.md)
- `useAgentStore` description clarified: fetches agent state via REST fallback and switches to Socket.IO only after the first live snapshot.
<!-- kody-pr-summary:end -->

## Summary by Sourcery

Enforce a 100-entry layout-directory limit and provide bounded cleanup visibility with actionable client-side recovery warnings.

New Features:
- Add bounded layout-directory listing with an over-capacity response so legacy installations can be cleaned up without unbounded scans.
- Surface actionable layout-capacity warnings in the layout store and editor, including dismissible alerts and recoverable create failures.

Bug Fixes:
- Prevent persisted layout-directory growth beyond 100 entries and return HTTP 507 when new layout files cannot be created.
- Preserve replacement, repair, and optimistic-concurrency updates at capacity while preventing capacity errors from triggering endless save retries.

Enhancements:
- Bound layout scans and account for non-layout directory entries when determining capacity.
- Improve layout creation interactions with async submission state, duplicate-submit protection, and preservation of failed input.

Documentation:
- Document the 100-entry layout capacity and cleanup guidance for over-capacity installations.

Tests:
- Add server, store, component, and application coverage for capacity boundaries, bounded legacy listings, repairs, concurrency, error handling, retries, and layout-creation recovery.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a 100-entry layout capacity limit with clear warnings when capacity is reached.
  * Existing layouts can still be replaced when storage is full.
  * Added dismissible error alerts and improved feedback during layout creation.
  * Prevented duplicate layout submissions while creation is in progress.

* **Bug Fixes**
  * Improved capacity-error handling and prevented unnecessary save retries.
  * Non-layout files now count toward storage capacity.

* **Documentation**
  * Documented capacity limits and how to manage unused layouts and files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->