### PR TITLE
fix(server): rate-limit mutating API requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,11 @@ Furniture uses per-type directories with `manifest.json` for dimensions and rota
 | `POLL_INTERVAL` | `3000` | Agent state poll interval in ms (cli mode only) |
 | `ACTIVE_MINUTES` | `30` | Session staleness threshold |
 | `INGEST_API_TOKEN` | *(none)* | Shared secret for ingest API auth (required for ingest mode) |
+| `RATE_LIMIT_MAX` | `10` | Authenticated ingest pushes allowed per minute and token digest |
+| `PRE_AUTH_RATE_LIMIT_MAX` | `5` | Ingest attempts allowed per minute and client IP before authentication |
+| `PUBLIC_GET_RATE_LIMIT_MAX` | `120` | Static/SPA GET or HEAD requests allowed per minute and client IP |
+| `PREFS_WRITE_RATE_LIMIT_MAX` | `60` | Non-layout `/api` mutations allowed per minute and client IP |
+| `LAYOUT_WRITE_RATE_LIMIT_MAX` | `30` | Layout PUT/POST/DELETE requests allowed per minute and client IP |
 | `TRUST_PROXY` | *(unset)* | Reverse-proxy trust for client-IP rate limiting: `"false"`/`"0"`/unset = no trust (default), a positive integer = trusted proxy hop count (e.g. `"1"`), or a comma-separated list of proxy IPs/CIDRs or the presets `loopback`/`linklocal`/`uniquelocal` (e.g. `"10.0.0.0/8,127.0.0.1"`). Required for per-client limiting behind a reverse proxy; invalid values fail startup with a descriptive error. See [Reverse-proxy deployments](#reverse-proxy-deployments). |
 | `OPENCLAW_AGENTS_DIR` | `~/.openclaw/agents` | Path to agent session transcripts |
 | `DATA_DIR` | `./data` | Persistence directory for preferences and layouts |
@@ -236,7 +241,7 @@ If you terminate TLS or rewrite requests in a reverse proxy in front of the Node
 
 #### Client identity and rate limiting (`TRUST_PROXY`)
 
-By default the server does not trust any proxy: every request's client IP is the direct socket peer. Behind a reverse proxy that means **all users share the proxy's address** — and with it a single public GET/HEAD rate bucket (120 req/min). One noisy client can then exhaust the budget for everyone behind that proxy.
+By default the server does not trust any proxy: every request's client IP is the direct socket peer. Behind a reverse proxy that means **all users share the proxy's address** — and with it the public GET/HEAD and API-write rate buckets. One noisy client can then exhaust a shared budget for everyone behind that proxy.
 
 Set `TRUST_PROXY` to restore per-client limiting:
 
@@ -253,6 +258,8 @@ Two hard requirements:
 2. **Unrestricted trust is deliberately rejected.** `TRUST_PROXY="true"`, any `/0` CIDR (`0.0.0.0/0`, `::/0` — a zero prefix length matches every address of the family, i.e. the same blanket trust), and any other malformed value abort startup with a descriptive error rather than silently degrading security. Express's blanket `"true"` would trust every peer, which is exactly the spoofing scenario above.
 
 Malformed values (bad CIDRs, hostnames, empty entries, `"true"`) fail fast at startup with an error naming the accepted forms — never as an opaque crash from inside Express, and never by silently falling back to no trust, which would reintroduce the shared-bucket collapse.
+
+All rate-limit maximums must be positive integers; malformed or non-positive values fail startup rather than silently disabling protection. A `429` response includes `Retry-After`, `X-RateLimit-Limit`, and `X-RateLimit-Remaining` so clients can back off without guessing. Mutating API and ingest pre-auth limits run before JSON parsing, bounding repeated malformed-body work.
 
 ## Scripts
 

--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ Furniture uses per-type directories with `manifest.json` for dimensions and rota
 | `PRE_AUTH_RATE_LIMIT_MAX` | `5` | Ingest attempts allowed per minute and client IP before authentication |
 | `PUBLIC_GET_RATE_LIMIT_MAX` | `120` | Static/SPA GET or HEAD requests allowed per minute and client IP |
 | `PREFS_WRITE_RATE_LIMIT_MAX` | `60` | Non-layout `/api` mutations allowed per minute and client IP |
-| `LAYOUT_WRITE_RATE_LIMIT_MAX` | `30` | Layout PUT/POST/DELETE requests allowed per minute and client IP |
+| `LAYOUT_WRITE_RATE_LIMIT_MAX` | `90` | Layout PUT/POST/DELETE requests allowed per minute and client IP; includes headroom above the editor's 30/minute theoretical autosave ceiling |
 | `TRUST_PROXY` | *(unset)* | Reverse-proxy trust for client-IP rate limiting: `"false"`/`"0"`/unset = no trust (default), a positive integer = trusted proxy hop count (e.g. `"1"`), or a comma-separated list of proxy IPs/CIDRs or the presets `loopback`/`linklocal`/`uniquelocal` (e.g. `"10.0.0.0/8,127.0.0.1"`). Required for per-client limiting behind a reverse proxy; invalid values fail startup with a descriptive error. See [Reverse-proxy deployments](#reverse-proxy-deployments). |
 | `OPENCLAW_AGENTS_DIR` | `~/.openclaw/agents` | Path to agent session transcripts |
 | `DATA_DIR` | `./data` | Persistence directory for preferences and layouts |

--- a/server/index.ts
+++ b/server/index.ts
@@ -864,7 +864,9 @@ const RATE_LIMIT_MAX = parseRateLimitMax("RATE_LIMIT_MAX", 10);
 const PRE_AUTH_RATE_LIMIT_MAX = parseRateLimitMax("PRE_AUTH_RATE_LIMIT_MAX", 5);
 const PUBLIC_GET_RATE_LIMIT_MAX = parseRateLimitMax("PUBLIC_GET_RATE_LIMIT_MAX", 120);
 const PREFS_WRITE_RATE_LIMIT_MAX = parseRateLimitMax("PREFS_WRITE_RATE_LIMIT_MAX", 60);
-const LAYOUT_WRITE_RATE_LIMIT_MAX = parseRateLimitMax("LAYOUT_WRITE_RATE_LIMIT_MAX", 30);
+// The editor can autosave every two seconds (30/minute) and this bucket also
+// covers create/delete/keepalive writes, so keep 3x headroom for normal use.
+const LAYOUT_WRITE_RATE_LIMIT_MAX = parseRateLimitMax("LAYOUT_WRITE_RATE_LIMIT_MAX", 90);
 const ingestRateBuckets = new Map<string, number[]>();
 const ingestPreAuthBuckets = new Map<string, number[]>();
 const publicGetRateBuckets = new Map<string, number[]>();

--- a/server/index.ts
+++ b/server/index.ts
@@ -995,6 +995,11 @@ function ingestPreAuthRateLimiter(
     res.status(501).json({ error: "Ingest not configured (no INGEST_API_TOKEN)" });
     return;
   }
+  // Classify the bearer header before body parsing so valid collectors bypass
+  // the failed-attempt bucket while invalid or missing credentials remain
+  // bounded. authenticateIngest hashes both configured and provided values to
+  // fixed-length digests before the timing-safe comparison.
+  if (authenticateIngest(req, res)) { next(); return; }
   const decision = checkPreAuthRateLimit(req);
   if (!decision.allowed) {
     sendRateLimitResponse(res, decision);

--- a/server/index.ts
+++ b/server/index.ts
@@ -197,7 +197,11 @@ app.use(httpRequestLogMiddleware);
 // bounded-but-still-expensive body buffering/parsing. Ingest has its own
 // pre-auth budget; all other writes retain the existing Origin boundary and
 // then enter their per-IP write budget.
+// CodeQL models only supported third-party limiter packages; the HTTP tests in
+// rateLimit.test.ts pin both custom guards' thresholds and pre-parser order.
+// codeql[js/missing-rate-limiting]
 app.use("/api/ingest/agents", ingestPreAuthRateLimiter);
+// codeql[js/missing-rate-limiting]
 app.use("/api", apiMutationGuard);
 app.use(express.json({ limit: "100kb" }));
 
@@ -866,12 +870,9 @@ const ingestPreAuthBuckets = new Map<string, number[]>();
 const publicGetRateBuckets = new Map<string, number[]>();
 const apiWriteRateBuckets = new Map<string, number[]>();
 
-type RateLimitDecision = Readonly<{
-  allowed: boolean;
-  limit: number;
-  remaining: number;
-  retryAfterSeconds?: number;
-}>;
+type RateLimitDecision =
+  | Readonly<{ allowed: true; limit: number; remaining: number }>
+  | Readonly<{ allowed: false; limit: number; remaining: 0; retryAfterSeconds: number }>;
 
 function takeRateLimit(
   buckets: Map<string, number[]>,
@@ -899,7 +900,10 @@ function takeRateLimit(
   return { allowed: true, limit, remaining: limit - recent.length };
 }
 
-function sendRateLimitResponse(res: express.Response, decision: RateLimitDecision): void {
+function sendRateLimitResponse(
+  res: express.Response,
+  decision: Extract<RateLimitDecision, { allowed: false }>,
+): void {
   res.setHeader("X-RateLimit-Limit", String(decision.limit));
   res.setHeader("X-RateLimit-Remaining", String(decision.remaining));
   res.setHeader("Retry-After", String(decision.retryAfterSeconds));
@@ -983,9 +987,12 @@ function ingestPreAuthRateLimiter(
   res: express.Response,
   next: express.NextFunction,
 ): void {
-  // Preserve the existing 501 contract when ingest is disabled and do not
-  // change non-POST behavior for this exact path.
-  if (req.method !== "POST" || !INGEST_TOKEN) { next(); return; }
+  if (req.method !== "POST") { next(); return; }
+  // Preserve the existing 501 contract while rejecting before JSON parsing.
+  if (!INGEST_TOKEN) {
+    res.status(501).json({ error: "Ingest not configured (no INGEST_API_TOKEN)" });
+    return;
+  }
   const decision = checkPreAuthRateLimit(req);
   if (!decision.allowed) {
     sendRateLimitResponse(res, decision);
@@ -994,12 +1001,10 @@ function ingestPreAuthRateLimiter(
   next();
 }
 
+// ingestPreAuthRateLimiter is mounted before JSON parsing and this handler;
+// CodeQL cannot infer the repository's custom sliding-window middleware.
+// codeql[js/missing-rate-limiting]
 app.post("/api/ingest/agents", (req, res) => {
-  if (!INGEST_TOKEN) {
-    res.status(501).json({ error: "Ingest not configured (no INGEST_API_TOKEN)" });
-    return;
-  }
-
   if (!authenticateIngest(req, res)) {
     res.status(401).json({ error: "Unauthorized" });
     return;

--- a/server/index.ts
+++ b/server/index.ts
@@ -193,6 +193,12 @@ app.use((_req, res, next) => {
 
 app.use(correlationMiddleware);
 app.use(httpRequestLogMiddleware);
+// Reject and throttle mutating API traffic before express.json() performs
+// bounded-but-still-expensive body buffering/parsing. Ingest has its own
+// pre-auth budget; all other writes retain the existing Origin boundary and
+// then enter their per-IP write budget.
+app.use("/api/ingest/agents", ingestPreAuthRateLimiter);
+app.use("/api", apiMutationGuard);
 app.use(express.json({ limit: "100kb" }));
 
 // Serve built frontend in production (Vite output is in dist/client, server is compiled to dist/server/index.js).
@@ -815,6 +821,7 @@ export function _resetRateLimitBuckets(): void {
   ingestRateBuckets.clear();
   ingestPreAuthBuckets.clear();
   publicGetRateBuckets.clear();
+  apiWriteRateBuckets.clear();
 }
 
 /** @deprecated Use _resetRateLimitBuckets — alias kept for import compatibility. */
@@ -833,13 +840,71 @@ export const _resetIngestRateBuckets = _resetRateLimitBuckets;
 // - PRE_AUTH: throttles unauthenticated/failed-token attempts per IP (CWE-770)
 // - POST_AUTH: caps authenticated push frequency per token digest
 // - PUBLIC_GET: app-wide throttle for unauthenticated GET traffic (SPA + static)
+// - PREFS_WRITE: caps agent preference persistence/broadcasts per IP
+// - LAYOUT_WRITE: caps layout filesystem mutations/broadcasts per IP
+function parseRateLimitMax(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (raw === undefined) return fallback;
+  if (!/^\d+$/.test(raw)) {
+    throw new Error(`Invalid ${name} value: "${raw}". Expected a positive integer.`);
+  }
+  const value = Number(raw);
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw new Error(`Invalid ${name} value: "${raw}". Expected a positive integer.`);
+  }
+  return value;
+}
+
 const RATE_LIMIT_WINDOW_MS = 60_000;
-const RATE_LIMIT_MAX = 10;          // post-auth: 10 pushes/min per token
-const PRE_AUTH_RATE_LIMIT_MAX = 5;   // pre-auth: 5 attempts/min per IP
-const PUBLIC_GET_RATE_LIMIT_MAX = 120; // public GET: 120 req/min per IP (SPA + static)
+const RATE_LIMIT_MAX = parseRateLimitMax("RATE_LIMIT_MAX", 10);
+const PRE_AUTH_RATE_LIMIT_MAX = parseRateLimitMax("PRE_AUTH_RATE_LIMIT_MAX", 5);
+const PUBLIC_GET_RATE_LIMIT_MAX = parseRateLimitMax("PUBLIC_GET_RATE_LIMIT_MAX", 120);
+const PREFS_WRITE_RATE_LIMIT_MAX = parseRateLimitMax("PREFS_WRITE_RATE_LIMIT_MAX", 60);
+const LAYOUT_WRITE_RATE_LIMIT_MAX = parseRateLimitMax("LAYOUT_WRITE_RATE_LIMIT_MAX", 30);
 const ingestRateBuckets = new Map<string, number[]>();
 const ingestPreAuthBuckets = new Map<string, number[]>();
 const publicGetRateBuckets = new Map<string, number[]>();
+const apiWriteRateBuckets = new Map<string, number[]>();
+
+type RateLimitDecision = Readonly<{
+  allowed: boolean;
+  limit: number;
+  remaining: number;
+  retryAfterSeconds?: number;
+}>;
+
+function takeRateLimit(
+  buckets: Map<string, number[]>,
+  key: string,
+  limit: number,
+): RateLimitDecision {
+  const now = Date.now();
+  const windowStart = now - RATE_LIMIT_WINDOW_MS;
+  const recent = (buckets.get(key) || []).filter(timestamp => timestamp > windowStart);
+
+  if (recent.length >= limit) {
+    // Keep the filtered bucket so entries that expired between prune ticks do
+    // not inflate the next Retry-After calculation.
+    buckets.set(key, recent);
+    return {
+      allowed: false,
+      limit,
+      remaining: 0,
+      retryAfterSeconds: Math.max(1, Math.ceil((recent[0] + RATE_LIMIT_WINDOW_MS - now) / 1000)),
+    };
+  }
+
+  recent.push(now);
+  buckets.set(key, recent);
+  return { allowed: true, limit, remaining: limit - recent.length };
+}
+
+function sendRateLimitResponse(res: express.Response, decision: RateLimitDecision): void {
+  res.setHeader("X-RateLimit-Limit", String(decision.limit));
+  res.setHeader("X-RateLimit-Remaining", String(decision.remaining));
+  res.setHeader("Retry-After", String(decision.retryAfterSeconds));
+  res.status(429).json({ error: "Too many requests" });
+}
 
 /**
  * Check whether an unauthenticated GET/HEAD request from this IP is within the
@@ -850,15 +915,7 @@ const publicGetRateBuckets = new Map<string, number[]>();
  */
 export function checkPublicGetRateLimit(req: express.Request): boolean {
   const ip = req.ip || "unknown";
-  const key = `get:${ip}`;
-  const now = Date.now();
-  const bucket = publicGetRateBuckets.get(key) || [];
-  const windowStart = now - RATE_LIMIT_WINDOW_MS;
-  const recent = bucket.filter(t => t > windowStart);
-  if (recent.length >= PUBLIC_GET_RATE_LIMIT_MAX) return false;
-  recent.push(now);
-  publicGetRateBuckets.set(key, recent);
-  return true;
+  return takeRateLimit(publicGetRateBuckets, `get:${ip}`, PUBLIC_GET_RATE_LIMIT_MAX).allowed;
 }
 
 /**
@@ -876,14 +933,16 @@ export function checkPublicGetRateLimit(req: express.Request): boolean {
 function publicGetRateLimiter(req: express.Request, res: express.Response, next: express.NextFunction): void {
   if (req.method !== "GET" && req.method !== "HEAD") { next(); return; }
   if (req.path === "/api" || req.path.startsWith("/api/")) { next(); return; }
-  if (!checkPublicGetRateLimit(req)) {
-    res.status(429).json({ error: "Too many requests" });
+  const ip = req.ip || "unknown";
+  const decision = takeRateLimit(publicGetRateBuckets, `get:${ip}`, PUBLIC_GET_RATE_LIMIT_MAX);
+  if (!decision.allowed) {
+    sendRateLimitResponse(res, decision);
     return;
   }
   next();
 }
 
-// Prune all three bucket maps on the same interval to prevent memory leaks
+// Prune every bucket map on the same interval to prevent memory leaks.
 const ingestPruneTimer = setInterval(() => {
   const cutoff = Date.now() - RATE_LIMIT_WINDOW_MS;
   for (const [key, timestamps] of ingestRateBuckets) {
@@ -901,37 +960,43 @@ const ingestPruneTimer = setInterval(() => {
     if (pruned.length === 0) publicGetRateBuckets.delete(key);
     else publicGetRateBuckets.set(key, pruned);
   }
+  for (const [key, timestamps] of apiWriteRateBuckets) {
+    const pruned = timestamps.filter(t => t > cutoff);
+    if (pruned.length === 0) apiWriteRateBuckets.delete(key);
+    else apiWriteRateBuckets.set(key, pruned);
+  }
 }, RATE_LIMIT_WINDOW_MS);
 ingestPruneTimer.unref?.();
 
 /**
- * Check pre-auth rate limit for a request. Returns true if the request should
- * be allowed through, false if it exceeded the threshold (caller sends 429).
+ * Check the pre-auth rate limit for a request and return the remaining budget
+ * or the backoff duration for a 429 response.
  * Keyed on req.ip — trusts X-Forwarded-For only behind an explicit proxy.
  */
-function checkPreAuthRateLimit(req: express.Request): boolean {
+function checkPreAuthRateLimit(req: express.Request): RateLimitDecision {
   const ip = req.ip || "unknown";
-  const key = `preauth:${ip}`;
-  const now = Date.now();
-  const bucket = ingestPreAuthBuckets.get(key) || [];
-  const windowStart = now - RATE_LIMIT_WINDOW_MS;
-  const recent = bucket.filter(t => t > windowStart);
-  if (recent.length >= PRE_AUTH_RATE_LIMIT_MAX) return false;
-  recent.push(now);
-  ingestPreAuthBuckets.set(key, recent);
-  return true;
+  return takeRateLimit(ingestPreAuthBuckets, `preauth:${ip}`, PRE_AUTH_RATE_LIMIT_MAX);
+}
+
+function ingestPreAuthRateLimiter(
+  req: express.Request,
+  res: express.Response,
+  next: express.NextFunction,
+): void {
+  // Preserve the existing 501 contract when ingest is disabled and do not
+  // change non-POST behavior for this exact path.
+  if (req.method !== "POST" || !INGEST_TOKEN) { next(); return; }
+  const decision = checkPreAuthRateLimit(req);
+  if (!decision.allowed) {
+    sendRateLimitResponse(res, decision);
+    return;
+  }
+  next();
 }
 
 app.post("/api/ingest/agents", (req, res) => {
   if (!INGEST_TOKEN) {
     res.status(501).json({ error: "Ingest not configured (no INGEST_API_TOKEN)" });
-    return;
-  }
-
-  // Pre-auth rate limit: throttle unauthenticated requests per IP before
-  // the token check to prevent brute-force and resource-exhaustion attacks.
-  if (!checkPreAuthRateLimit(req)) {
-    res.status(429).json({ error: "Too many requests" });
     return;
   }
 
@@ -954,16 +1019,11 @@ app.post("/api/ingest/agents", (req, res) => {
     hash = ((hash << 5) - hash + rawKey.charCodeAt(i)) | 0;
   }
   const rateKey = `ingest:${hash}`;
-  const now = Date.now();
-  const bucket = ingestRateBuckets.get(rateKey) || [];
-  const windowStart = now - RATE_LIMIT_WINDOW_MS;
-  const recentRequests = bucket.filter(t => t > windowStart);
-  if (recentRequests.length >= RATE_LIMIT_MAX) {
-    res.status(429).json({ error: "Too many requests" });
+  const decision = takeRateLimit(ingestRateBuckets, rateKey, RATE_LIMIT_MAX);
+  if (!decision.allowed) {
+    sendRateLimitResponse(res, decision);
     return;
   }
-  recentRequests.push(now);
-  ingestRateBuckets.set(rateKey, recentRequests);
 
   const sessions = req.body?.sessions;
   if (!Array.isArray(sessions)) {
@@ -1006,15 +1066,26 @@ let lastIngestAt = 0;
 
 const MUTATING_API_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
 
-app.use("/api", (req, res, next) => {
+function apiMutationGuard(req: express.Request, res: express.Response, next: express.NextFunction): void {
   if (!MUTATING_API_METHODS.has(req.method)) return next();
-  // Ingest runs above this middleware and ends the chain with a response, so
-  // this exemption is defensive belt-and-suspenders for the future ordering.
+  // Ingest has its own pre-auth middleware and authenticated per-token budget.
   if (req.path === "/ingest/agents") return next();
-  if (isOriginAllowed(req.headers.origin, corsConfig)) return next();
+  if (!isOriginAllowed(req.headers.origin, corsConfig)) {
+    res.status(403).json({ error: "Forbidden origin" });
+    return;
+  }
 
-  res.status(403).json({ error: "Forbidden origin" });
-});
+  const ip = req.ip || "unknown";
+  const isLayoutWrite = req.path === "/layouts" || req.path.startsWith("/layouts/");
+  const scope = isLayoutWrite ? "layouts" : "prefs";
+  const limit = isLayoutWrite ? LAYOUT_WRITE_RATE_LIMIT_MAX : PREFS_WRITE_RATE_LIMIT_MAX;
+  const decision = takeRateLimit(apiWriteRateBuckets, `write:${scope}:${ip}`, limit);
+  if (!decision.allowed) {
+    sendRateLimitResponse(res, decision);
+    return;
+  }
+  next();
+}
 
 app.get("/api/agents", (_req, res) => {
   res.json({ agents: Array.from(agentStates.values()) });
@@ -1516,4 +1587,3 @@ if (require.main === module) {
 }
 
 export { app, server, io, startServer };
-

--- a/server/index.ts
+++ b/server/index.ts
@@ -947,21 +947,6 @@ function sendRateLimitResponse(
 }
 
 /**
- * Check whether an unauthenticated GET/HEAD request from this IP is within the
- * public rate limit. Keyed on req.ip. Returns true if allowed, false if
- * the caller should respond 429. Client-IP identity depends on the explicit
- * TRUST_PROXY contract configured at startup (see parseTrustProxy); with the
- * default no-trust setting req.ip is the direct peer.
- */
-export function checkPublicGetRateLimit(req: express.Request): boolean {
-  // Consumes a public-GET slot. publicGetRateLimiter calls takeRateLimit
-  // directly so it can attach Retry-After; do not also call this helper on
-  // that same request or the IP is charged twice.
-  const ip = req.ip || "unknown";
-  return takeRateLimit(publicGetRateBuckets, `get:${ip}`, PUBLIC_GET_RATE_LIMIT_MAX).allowed;
-}
-
-/**
  * Middleware: applies the public rate limit and returns 429 when exceeded.
  * Scope contract (issue #125, review): only GET and HEAD requests to
  * non-API paths are counted. HEAD is included because express.static and

--- a/server/index.ts
+++ b/server/index.ts
@@ -1006,6 +1006,19 @@ function checkPreAuthRateLimit(req: express.Request): RateLimitDecision {
   return takeRateLimit(ingestPreAuthBuckets, `preauth:${ip}`, PRE_AUTH_RATE_LIMIT_MAX);
 }
 
+function ingestPostAuthRateKey(req: express.Request): string {
+  const rawKey = req.headers.authorization || req.ip || "unknown";
+  let hash = 0;
+  for (let i = 0; i < rawKey.length; i++) {
+    hash = ((hash << 5) - hash + rawKey.charCodeAt(i)) | 0;
+  }
+  return `ingest:${hash}`;
+}
+
+function checkPostAuthRateLimit(req: express.Request): RateLimitDecision {
+  return takeRateLimit(ingestRateBuckets, ingestPostAuthRateKey(req), RATE_LIMIT_MAX);
+}
+
 function ingestPreAuthRateLimiter(
   req: express.Request,
   res: express.Response,
@@ -1019,9 +1032,18 @@ function ingestPreAuthRateLimiter(
   }
   // Classify the bearer header before body parsing so valid collectors bypass
   // the failed-attempt bucket while invalid or missing credentials remain
-  // bounded. authenticateIngest hashes both configured and provided values to
-  // fixed-length digests before the timing-safe comparison.
-  if (authenticateIngest(req, res)) { next(); return; }
+  // bounded. Valid tokens still spend the post-auth budget here so malformed
+  // JSON cannot skip throttling. authenticateIngest hashes both configured
+  // and provided values to fixed-length digests before the timing-safe comparison.
+  if (authenticateIngest(req, res)) {
+    const postAuth = checkPostAuthRateLimit(req);
+    if (!postAuth.allowed) {
+      sendRateLimitResponse(res, postAuth);
+      return;
+    }
+    next();
+    return;
+  }
   const decision = checkPreAuthRateLimit(req);
   if (!decision.allowed) {
     sendRateLimitResponse(res, decision);
@@ -1042,20 +1064,6 @@ app.post("/api/ingest/agents", (req, res) => {
   // Single-writer principle: authenticated pushes cannot race CLI snapshots.
   if (!isIngestWritesActive(dataSourceState)) {
     res.status(409).json({ error: "Ingest unavailable while CLI polling is active" });
-    return;
-  }
-
-  // Rate limiting: track requests per derived key (avoid storing raw token)
-  const rawKey = req.headers.authorization || req.ip || "unknown";
-  // Simple hash to avoid keeping sensitive tokens in memory
-  let hash = 0;
-  for (let i = 0; i < rawKey.length; i++) {
-    hash = ((hash << 5) - hash + rawKey.charCodeAt(i)) | 0;
-  }
-  const rateKey = `ingest:${hash}`;
-  const decision = takeRateLimit(ingestRateBuckets, rateKey, RATE_LIMIT_MAX);
-  if (!decision.allowed) {
-    sendRateLimitResponse(res, decision);
     return;
   }
 

--- a/server/rateLimit.test.ts
+++ b/server/rateLimit.test.ts
@@ -222,6 +222,31 @@ describe("API write rate limiting (issue #154)", () => {
   });
 });
 
+describe("disabled ingest pre-parser boundary", () => {
+  it("returns the existing 501 response without parsing a malformed body", async () => {
+    const dataDir = mkdtempSync(join(tmpdir(), "pixel-agents-disabled-ingest-"));
+    vi.stubEnv("DATA_DIR", dataDir);
+    vi.stubEnv("DATA_SOURCE", "ingest");
+    vi.stubEnv("INGEST_API_TOKEN", "");
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("CORS_ORIGIN", "https://pixel.test");
+    vi.resetModules();
+
+    const serverModule = await import("./index");
+    await request(serverModule.app)
+      .post("/api/ingest/agents")
+      .set("Content-Type", "application/json")
+      .send('{"sessions":[')
+      .expect(501)
+      .expect({ error: "Ingest not configured (no INGEST_API_TOKEN)" });
+
+    serverModule.io.close();
+    rmSync(dataDir, { recursive: true, force: true });
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+});
+
 describe("rate-limit environment validation", () => {
   it.each([
     ["RATE_LIMIT_MAX", "0"],

--- a/server/rateLimit.test.ts
+++ b/server/rateLimit.test.ts
@@ -220,6 +220,25 @@ describe("API write rate limiting (issue #154)", () => {
       .expect(429);
     expectRateLimitHeaders(blocked, 3);
   });
+
+  it("does not let failed bearer attempts throttle a valid ingest push", async () => {
+    for (let attempt = 0; attempt < 3; attempt++) {
+      await request(app)
+        .post("/api/ingest/agents")
+        .set("Authorization", "Bearer wrong-secret")
+        .send({ sessions: [] })
+        .expect(401);
+    }
+
+    await request(app)
+      .post("/api/ingest/agents")
+      .set("Authorization", "Bearer test-secret")
+      .send({ sessions: [] })
+      .expect(200)
+      .expect((response) => {
+        expect(response.body).toMatchObject({ ok: true, received: 0 });
+      });
+  });
 });
 
 describe("disabled ingest pre-parser boundary", () => {

--- a/server/rateLimit.test.ts
+++ b/server/rateLimit.test.ts
@@ -1,0 +1,239 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { Express } from "express";
+import type { Server as SocketIOServer } from "socket.io";
+import request from "supertest";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+function expectRateLimitHeaders(response: request.Response, limit: number): void {
+  expect(response.headers["x-ratelimit-limit"]).toBe(String(limit));
+  expect(response.headers["x-ratelimit-remaining"]).toBe("0");
+  expect(Number(response.headers["retry-after"])).toBeGreaterThanOrEqual(1);
+  expect(Number(response.headers["retry-after"])).toBeLessThanOrEqual(60);
+}
+
+describe("API write rate limiting (issue #154)", () => {
+  let app: Express;
+  let io: SocketIOServer;
+  let dataDir: string;
+  let frontendDir: string;
+  let resetRateLimitBuckets: typeof import("./index")._resetRateLimitBuckets;
+  const appOrigin = "https://pixel.test";
+
+  beforeAll(async () => {
+    dataDir = mkdtempSync(join(tmpdir(), "pixel-agents-write-limit-data-"));
+    frontendDir = mkdtempSync(join(tmpdir(), "pixel-agents-write-limit-frontend-"));
+    mkdirSync(join(frontendDir, "assets"), { recursive: true });
+    writeFileSync(join(frontendDir, "index.html"), "<!doctype html><title>fixture</title>");
+    writeFileSync(join(frontendDir, "assets", "fixture.txt"), "fixture");
+
+    vi.stubEnv("DATA_DIR", dataDir);
+    vi.stubEnv("DATA_SOURCE", "ingest");
+    vi.stubEnv("INGEST_API_TOKEN", "test-secret");
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("CORS_ORIGIN", appOrigin);
+    vi.stubEnv("FRONTEND_DIR", frontendDir);
+    vi.stubEnv("PREFS_WRITE_RATE_LIMIT_MAX", "1");
+    vi.stubEnv("LAYOUT_WRITE_RATE_LIMIT_MAX", "2");
+    vi.stubEnv("PRE_AUTH_RATE_LIMIT_MAX", "3");
+    vi.stubEnv("RATE_LIMIT_MAX", "1");
+    vi.stubEnv("PUBLIC_GET_RATE_LIMIT_MAX", "1");
+
+    vi.resetModules();
+    const serverModule = await import("./index");
+    app = serverModule.app;
+    io = serverModule.io;
+    resetRateLimitBuckets = serverModule._resetRateLimitBuckets;
+  });
+
+  beforeEach(() => {
+    resetRateLimitBuckets();
+  });
+
+  afterAll(() => {
+    io.close();
+    rmSync(dataDir, { recursive: true, force: true });
+    rmSync(frontendDir, { recursive: true, force: true });
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+
+  const preferenceMutations = [
+    ["toggle", () => request(app).post("/api/agents/main/toggle").set("Origin", appOrigin).send({ enabled: false })],
+    ["sprite", () => request(app).post("/api/agents/main/sprite").set("Origin", appOrigin).send({ spriteId: "char_1" })],
+    ["recipe", () => request(app).put("/api/agents/main/recipe").set("Origin", appOrigin).send({ bodyIndex: 0, hairIndex: 0, outfitIndex: 0 })],
+    ["tags", () => request(app).put("/api/agents/main/tags").set("Origin", appOrigin).send({ tags: ["coding"] })],
+  ] as const;
+
+  it.each(preferenceMutations)("bounds the %s persistence/broadcast path", async (_name, mutate) => {
+    await mutate().expect(200);
+    const blocked = await mutate().expect(429);
+
+    expect(blocked.body).toEqual({ error: "Too many requests" });
+    expectRateLimitHeaders(blocked, 1);
+
+    // Read-only API polling is outside the write bucket.
+    await request(app).get("/api/status").expect(200);
+  });
+
+  it("shares the layout budget across PUT, POST creation, and DELETE", async () => {
+    await request(app)
+      .put("/api/layouts/write-limit")
+      .set("Origin", appOrigin)
+      .send({ name: "Write Limit", width: 24, height: 16, furniture: [], seats: {} })
+      .expect(200);
+
+    await request(app)
+      .post("/api/layouts")
+      .set("Origin", appOrigin)
+      .send({ name: "Counted Create", width: 24, height: 16, furniture: [], seats: {} })
+      .expect(200);
+    const blockedDelete = await request(app)
+      .delete("/api/layouts/write-limit")
+      .set("Origin", appOrigin)
+      .expect(429);
+    expectRateLimitHeaders(blockedDelete, 2);
+
+    resetRateLimitBuckets();
+    await request(app)
+      .delete("/api/layouts/write-limit")
+      .set("Origin", appOrigin)
+      .expect(200);
+    await request(app)
+      .put("/api/layouts/write-limit-2")
+      .set("Origin", appOrigin)
+      .send({ name: "Counted Put", width: 24, height: 16, furniture: [], seats: {} })
+      .expect(200);
+    const blockedCreate = await request(app)
+      .post("/api/layouts")
+      .set("Origin", appOrigin)
+      .send({ name: "Blocked Create", width: 24, height: 16, furniture: [], seats: {} })
+      .expect(429);
+    expectRateLimitHeaders(blockedCreate, 2);
+  });
+
+  it("keeps preference and layout write budgets independent", async () => {
+    await request(app)
+      .post("/api/agents/main/toggle")
+      .set("Origin", appOrigin)
+      .send({ enabled: false })
+      .expect(200);
+    await request(app)
+      .post("/api/agents/main/toggle")
+      .set("Origin", appOrigin)
+      .send({ enabled: true })
+      .expect(429);
+
+    await request(app)
+      .post("/api/layouts")
+      .set("Origin", appOrigin)
+      .send({ name: "Independent Budget", width: 24, height: 16, furniture: [], seats: {} })
+      .expect(200);
+    await request(app)
+      .post("/api/layouts")
+      .set("Origin", appOrigin)
+      .send({ name: "Independent Budget 2", width: 24, height: 16, furniture: [], seats: {} })
+      .expect(200);
+  });
+
+  it("rejects over-budget malformed JSON before parsing another large body", async () => {
+    const malformed = `{"enabled":"${"x".repeat(99 * 1024)}`;
+    await request(app)
+      .post("/api/agents/main/toggle")
+      .set("Origin", appOrigin)
+      .set("Content-Type", "application/json")
+      .send(malformed)
+      .expect(400);
+
+    const blocked = await request(app)
+      .post("/api/agents/main/toggle")
+      .set("Origin", appOrigin)
+      .set("Content-Type", "application/json")
+      .send(malformed)
+      .expect(429);
+    expectRateLimitHeaders(blocked, 1);
+  });
+
+  it("preserves the production Origin rejection without consuming the write budget", async () => {
+    await request(app)
+      .post("/api/agents/main/toggle")
+      .set("Origin", "https://attacker.test")
+      .send({ enabled: true })
+      .expect(403)
+      .expect({ error: "Forbidden origin" });
+
+    await request(app)
+      .post("/api/agents/main/toggle")
+      .set("Origin", appOrigin)
+      .send({ enabled: true })
+      .expect(200);
+  });
+
+  it("sets backoff headers on public GET, ingest pre-auth, and ingest post-auth 429s", async () => {
+    await request(app).get("/assets/fixture.txt").expect(200);
+    const publicBlocked = await request(app).get("/assets/fixture.txt").expect(429);
+    expectRateLimitHeaders(publicBlocked, 1);
+
+    for (let attempt = 0; attempt < 3; attempt++) {
+      await request(app)
+        .post("/api/ingest/agents")
+        .set("Authorization", "Bearer wrong-secret")
+        .send({ sessions: [] })
+        .expect(401);
+    }
+    const preAuthBlocked = await request(app)
+      .post("/api/ingest/agents")
+      .set("Authorization", "Bearer wrong-secret")
+      .send({ sessions: [] })
+      .expect(429);
+    expectRateLimitHeaders(preAuthBlocked, 3);
+
+    resetRateLimitBuckets();
+    await request(app)
+      .post("/api/ingest/agents")
+      .set("Authorization", "Bearer test-secret")
+      .send({ sessions: [] })
+      .expect(200);
+    const postAuthBlocked = await request(app)
+      .post("/api/ingest/agents")
+      .set("Authorization", "Bearer test-secret")
+      .send({ sessions: [] })
+      .expect(429);
+    expectRateLimitHeaders(postAuthBlocked, 1);
+  });
+
+  it("applies ingest pre-auth limiting before JSON parsing", async () => {
+    const malformed = `{"sessions":"${"x".repeat(99 * 1024)}`;
+    for (let attempt = 0; attempt < 3; attempt++) {
+      await request(app)
+        .post("/api/ingest/agents")
+        .set("Content-Type", "application/json")
+        .send(malformed)
+        .expect(400);
+    }
+
+    const blocked = await request(app)
+      .post("/api/ingest/agents")
+      .set("Content-Type", "application/json")
+      .send(malformed)
+      .expect(429);
+    expectRateLimitHeaders(blocked, 3);
+  });
+});
+
+describe("rate-limit environment validation", () => {
+  it.each([
+    ["RATE_LIMIT_MAX", "0"],
+    ["PRE_AUTH_RATE_LIMIT_MAX", "nope"],
+    ["PUBLIC_GET_RATE_LIMIT_MAX", "1.5"],
+    ["PREFS_WRITE_RATE_LIMIT_MAX", "-1"],
+    ["LAYOUT_WRITE_RATE_LIMIT_MAX", ""],
+  ])("fails startup for invalid %s=%j", async (name, value) => {
+    vi.stubEnv(name, value);
+    vi.resetModules();
+    await expect(import("./index")).rejects.toThrow(new RegExp(`Invalid ${name}`));
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+});

--- a/server/rateLimit.test.ts
+++ b/server/rateLimit.test.ts
@@ -247,6 +247,33 @@ describe("disabled ingest pre-parser boundary", () => {
   });
 });
 
+describe("default layout write headroom", () => {
+  it("allows more than the theoretical 30/minute autosave ceiling", async () => {
+    const dataDir = mkdtempSync(join(tmpdir(), "pixel-agents-layout-headroom-"));
+    vi.stubEnv("DATA_DIR", dataDir);
+    vi.stubEnv("DATA_SOURCE", "ingest");
+    vi.stubEnv("INGEST_API_TOKEN", "test-secret");
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("CORS_ORIGIN", "https://pixel.test");
+    vi.stubEnv("LAYOUT_WRITE_RATE_LIMIT_MAX", undefined);
+    vi.resetModules();
+
+    const serverModule = await import("./index");
+    for (let attempt = 0; attempt < 31; attempt++) {
+      await request(serverModule.app)
+        .put("/api/layouts/headroom")
+        .set("Origin", "https://pixel.test")
+        .send({ width: "wide" })
+        .expect(400);
+    }
+
+    serverModule.io.close();
+    rmSync(dataDir, { recursive: true, force: true });
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+});
+
 describe("rate-limit environment validation", () => {
   it.each([
     ["RATE_LIMIT_MAX", "0"],

--- a/server/rateLimit.test.ts
+++ b/server/rateLimit.test.ts
@@ -221,6 +221,24 @@ describe("API write rate limiting (issue #154)", () => {
     expectRateLimitHeaders(blocked, 3);
   });
 
+  it("applies ingest post-auth limiting before JSON parsing", async () => {
+    const malformed = `{"sessions":"${"x".repeat(99 * 1024)}`;
+    await request(app)
+      .post("/api/ingest/agents")
+      .set("Authorization", "Bearer test-secret")
+      .set("Content-Type", "application/json")
+      .send(malformed)
+      .expect(400);
+
+    const blockedPostAuth = await request(app)
+      .post("/api/ingest/agents")
+      .set("Authorization", "Bearer test-secret")
+      .set("Content-Type", "application/json")
+      .send(malformed)
+      .expect(429);
+    expectRateLimitHeaders(blockedPostAuth, 1);
+  });
+
   it("does not let failed bearer attempts throttle a valid ingest push", async () => {
     for (let attempt = 0; attempt < 3; attempt++) {
       await request(app)

--- a/src/hooks/useAgentStore.test.tsx
+++ b/src/hooks/useAgentStore.test.tsx
@@ -155,6 +155,74 @@ describe('useAgentStore REST polling fallback', () => {
   });
 });
 
+describe('useAgentStore mutation rate limits', () => {
+  const baseAgent = {
+    id: 'agent-1',
+    name: 'First Agent',
+    activity: 'typing' as const,
+    model: 'test',
+    sessionKey: 's1',
+    active: true,
+    lastActivity: 1,
+    pixelEnabled: true,
+    tags: [],
+  };
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    socketMock.handlers.clear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it('reconciles toggle-all with server state after a partial 429 failure', async () => {
+    let serverAgents = [
+      baseAgent,
+      { ...baseAgent, id: 'agent-2', name: 'Second Agent' },
+    ];
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      if (init?.method === 'POST') {
+        if (String(input).includes('/agent-1/')) {
+          serverAgents = serverAgents.map(agent => (
+            agent.id === 'agent-1' ? { ...agent, pixelEnabled: false } : agent
+          ));
+          return new Response(JSON.stringify({ success: true }), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          });
+        }
+        return new Response(JSON.stringify({ error: 'Too many requests' }), {
+          status: 429,
+          headers: { 'Content-Type': 'application/json', 'Retry-After': '60' },
+        });
+      }
+      return new Response(JSON.stringify({ agents: serverAgents }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }));
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const { snapshots, unmount } = await renderStoreProbe();
+    expect(latest(snapshots).agents.map(agent => agent.pixelEnabled)).toEqual([true, true]);
+
+    await act(async () => {
+      await latest(snapshots).toggleAll(false);
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    expect(latest(snapshots).agents.map(agent => [agent.id, agent.pixelEnabled])).toEqual([
+      ['agent-1', false],
+      ['agent-2', true],
+    ]);
+
+    unmount();
+  });
+});
+
 describe('useAgentStore room filtering', () => {
   beforeEach(() => {
     vi.useFakeTimers();

--- a/src/hooks/useAgentStore.ts
+++ b/src/hooks/useAgentStore.ts
@@ -33,11 +33,12 @@ export function useAgentStore() {
 
   const toggleAgent = useCallback(async (agentId: string, enabled: boolean) => {
     try {
-      await fetch(`${API_BASE}/agents/${agentId}/toggle`, {
+      const response = await fetch(`${API_BASE}/agents/${agentId}/toggle`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ enabled }),
       });
+      if (!response.ok) throw new Error(`HTTP ${response.status}`);
       // Optimistic update — don't wait for next poll
       setAgents(prev => prev.map(a =>
         a.id === agentId ? { ...a, pixelEnabled: enabled } : a
@@ -45,7 +46,7 @@ export function useAgentStore() {
     } catch (err) {
       console.error('Failed to toggle agent:', err);
       // Revert on error by re-fetching
-      fetchAgents();
+      await fetchAgents();
     }
   }, [fetchAgents]);
 
@@ -62,12 +63,16 @@ export function useAgentStore() {
         }
         return Promise.resolve();
       });
-      await Promise.all(promises);
+      const responses = await Promise.all(promises);
+      const failedResponse = responses.find(response => response && !response.ok);
+      if (failedResponse) throw new Error(`HTTP ${failedResponse.status}`);
       // Optimistic update
       setAgents(prev => prev.map(a => ({ ...a, pixelEnabled: enabled })));
     } catch (err) {
       console.error('Failed to toggle all agents:', err);
-      fetchAgents();
+      // Wait for every request above to settle, then reconcile successful and
+      // rate-limited members of the fan-out with authoritative server state.
+      await fetchAgents();
     }
   }, [agents, fetchAgents]);
 

--- a/src/hooks/useLayoutStore.test.tsx
+++ b/src/hooks/useLayoutStore.test.tsx
@@ -947,6 +947,65 @@ describe('useLayoutStore', () => {
     expect(latest(snapshots).isDirty).toBe(false);
   });
 
+  it('honors Retry-After before retrying a rate-limited auto-save', async () => {
+    await renderStoreProbe();
+    vi.useFakeTimers();
+
+    const initialFetch = fetch;
+    const putBodies: Array<LayoutDoc & { baseUpdatedAt?: number }> = [];
+    vi.stubGlobal('fetch', vi.fn(async (
+      input: string | URL | Request,
+      init?: RequestInit,
+    ) => {
+      const url = typeof input === 'string'
+        ? input
+        : input instanceof Request
+          ? input.url
+          : input.toString();
+      if (url.endsWith('/api/layouts/default') && init?.method === 'PUT') {
+        const body = JSON.parse(init.body as string) as LayoutDoc & { baseUpdatedAt?: number };
+        putBodies.push(body);
+        if (putBodies.length === 1) {
+          return new Response(JSON.stringify({ error: 'Too many requests' }), {
+            status: 429,
+            headers: { 'Content-Type': 'application/json', 'Retry-After': '10' },
+          });
+        }
+        return new Response(JSON.stringify({ layout: { ...body, updatedAt: 2_000 } }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      return initialFetch(input, init);
+    }));
+
+    act(() => {
+      latest(snapshots).updateFurniture([
+        { id: 'desk-1', type: 'DESK', x: 3, y: 4, rotation: 90 },
+      ]);
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2_100);
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(putBodies).toHaveLength(1);
+    expect(latest(snapshots).isDirty).toBe(true);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(9_800);
+    });
+    expect(putBodies).toHaveLength(1);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(300);
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(putBodies).toHaveLength(2);
+    expect(putBodies[1].furniture[0].rotation).toBe(90);
+    expect(latest(snapshots).isDirty).toBe(false);
+  });
+
   it('does not auto-save when activeLayout is null', async () => {
     // Edge case: if the active layout is null (e.g., after deleteLayout),
     // updateFurniture should not crash and no auto-save should fire.

--- a/src/hooks/useLayoutStore.test.tsx
+++ b/src/hooks/useLayoutStore.test.tsx
@@ -1331,6 +1331,63 @@ describe('useLayoutStore', () => {
     expect(latest(snapshots).isDirty).toBe(false);
   });
 
+  it('defaults a missing Retry-After to the 60s window instead of the 2s backoff floor', async () => {
+    await renderStoreProbe();
+    vi.useFakeTimers();
+
+    const initialFetch = fetch;
+    const putBodies: Array<LayoutDoc & { baseUpdatedAt?: number }> = [];
+    vi.stubGlobal('fetch', vi.fn(async (
+      input: string | URL | Request,
+      init?: RequestInit,
+    ) => {
+      const url = typeof input === 'string'
+        ? input
+        : input instanceof Request
+          ? input.url
+          : input.toString();
+      if (url.endsWith('/api/layouts/default') && init?.method === 'PUT') {
+        const body = JSON.parse(init.body as string) as LayoutDoc & { baseUpdatedAt?: number };
+        putBodies.push(body);
+        if (putBodies.length === 1) {
+          return new Response(JSON.stringify({ error: 'Too many requests' }), {
+            status: 429,
+            headers: { 'Content-Type': 'application/json' },
+          });
+        }
+        return new Response(JSON.stringify({ layout: { ...body, updatedAt: 2_000 } }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      return initialFetch(input, init);
+    }));
+
+    act(() => {
+      latest(snapshots).updateFurniture([
+        { id: 'desk-1', type: 'DESK', x: 3, y: 4, rotation: 90 },
+      ]);
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2_100);
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(putBodies).toHaveLength(1);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(59_000);
+    });
+    expect(putBodies).toHaveLength(1);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1_200);
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(putBodies).toHaveLength(2);
+    expect(latest(snapshots).isDirty).toBe(false);
+  });
+
   it('does not auto-save when activeLayout is null', async () => {
     // Edge case: if the active layout is null (e.g., after deleteLayout),
     // updateFurniture should not crash and no auto-save should fire.

--- a/src/hooks/useLayoutStore.ts
+++ b/src/hooks/useLayoutStore.ts
@@ -66,7 +66,7 @@ function capacityErrorMessage(error: unknown): string {
 const MAX_RETRY_AFTER_MS = 60_000;
 
 function parseRetryAfterMs(value: string | null): number {
-  if (!value) return 0;
+  if (!value) return MAX_RETRY_AFTER_MS;
   const seconds = Number(value);
   const parsed = Number.isFinite(seconds) && seconds >= 0
     ? Math.ceil(seconds * 1000)
@@ -74,6 +74,7 @@ function parseRetryAfterMs(value: string | null): number {
         const retryAt = Date.parse(value);
         return Number.isFinite(retryAt) ? Math.max(0, retryAt - Date.now()) : 0;
       })();
+  if (!Number.isFinite(parsed) || parsed <= 0) return MAX_RETRY_AFTER_MS;
   return Math.min(parsed, MAX_RETRY_AFTER_MS);
 }
 

--- a/src/hooks/useLayoutStore.ts
+++ b/src/hooks/useLayoutStore.ts
@@ -54,6 +54,14 @@ function pickBaseUpdatedAt(
     : currentLayout.updatedAt;
 }
 
+function parseRetryAfterMs(value: string | null): number {
+  if (!value) return 0;
+  const seconds = Number(value);
+  if (Number.isFinite(seconds) && seconds >= 0) return Math.ceil(seconds * 1000);
+  const retryAt = Date.parse(value);
+  return Number.isFinite(retryAt) ? Math.max(0, retryAt - Date.now()) : 0;
+}
+
 /**
  * Dispatched action: a new layout value, or a functional updater.
  * Every mutation flows through the reducer, which guarantees the ref
@@ -110,8 +118,9 @@ export function useLayoutStore() {
   // retryAttemptRef: tracks consecutive failed auto-saves for backoff.
   const retryAttemptRef = useRef(0);
 
-  const scheduleSaveRetry = useCallback((retry: () => void) => {
-    const delay = Math.min(2000 * Math.pow(2, retryAttemptRef.current), 30000);
+  const scheduleSaveRetry = useCallback((retry: () => void, minimumDelayMs = 0) => {
+    const backoffDelay = Math.min(2000 * Math.pow(2, retryAttemptRef.current), 30000);
+    const delay = Math.max(backoffDelay, minimumDelayMs);
     retryAttemptRef.current++;
     if (autoSaveTimerRef.current) clearTimeout(autoSaveTimerRef.current);
     autoSaveTimerRef.current = setTimeout(() => {
@@ -250,6 +259,11 @@ export function useLayoutStore() {
             if (activeLayoutRef.current?.id === merged.id) {
               scheduleSaveRetry(() => { void saveActiveLayout(); });
             }
+          } else if (response.status === 429) {
+            scheduleSaveRetry(
+              () => { void saveActiveLayout(); },
+              parseRetryAfterMs(response.headers.get('Retry-After')),
+            );
           } else if (response.status >= 500) {
             scheduleSaveRetry(() => { void saveActiveLayout(); });
           }


### PR DESCRIPTION
Closes #154

Addresses #157 (item 2): valid authenticated ingest pushes do not consume or get blocked by the failed-attempt pre-auth budget.

<!-- kody-pr-summary:start -->
## Summary

This PR hardens the server against abusive mutation traffic and malformed-body parsing work by introducing per-IP write budgets for mutating `/api` routes, unifying the rate-limit decision path, and surfacing backoff metadata on every 429.

## Functional Changes

**Two new per-IP write budgets** are introduced alongside the existing public GET and ingest budgets:
- `PREFS_WRITE_RATE_LIMIT_MAX` (default `60/min`) — covers non-layout `/api` mutations such as agent toggle, sprite, recipe, and tags writes.
- `LAYOUT_WRITE_RATE_LIMIT_MAX` (default `90/min`) — covers layout `PUT`/`POST`/`DELETE` requests.

Both budgets are keyed on `req.ip` and are independent from each other and from the public GET budget, so a busy dashboard poller does not consume write budget and a noisy preference writer does not block layout operations.

**Mutation enforcement moved before JSON parsing.** The production Origin check and the new `apiMutationGuard` rate limiter are mounted *before* `express.json()` for the `/api` prefix, and a dedicated `ingestPreAuthRateLimiter` is mounted on `/api/ingest/agents`. This bounds the amount of malformed-body buffering/parsing work a single IP can induce — previously a client could repeatedly POST invalid JSON to trigger unbounded parsing work.

**Unified sliding-window decision.** A shared `takeRateLimit()` helper now backs the public GET, ingest pre-auth, ingest post-auth, and the two new UI-write throttles. When a bucket is exhausted it returns a `RateLimitDecision` carrying the configured `limit`, the remaining count, and a `retryAfterSeconds` value derived from the oldest in-window timestamp.

**Standardized 429 response.** Every throttled response — public GET, ingest pre-auth, ingest post-auth, preference writes, layout writes — sets:
- `Retry-After` (seconds)
- `X-RateLimit-Limit`
- `X-RateLimit-Remaining`

…with body `{ error: "Too many requests" }`.

**Fail-fast configuration validation.** A `parseRateLimitMax()` helper rejects any non-positive-integer or non-numeric value for `RATE_LIMIT_MAX`, `PRE_AUTH_RATE_LIMIT_MAX`, `PUBLIC_GET_RATE_LIMIT_MAX`, `PREFS_WRITE_RATE_LIMIT_MAX`, or `LAYOUT_WRITE_RATE_LIMIT_MAX` at startup, preventing silent disablement of protection.

**Preserved contracts.** The existing 501 for unconfigured ingest, the 403 `Forbidden origin` response for disallowed Origins in production, ingest authentication behavior, the `/api` GET polling path, and Helmet/CSP headers are all retained. Forbidden-origin requests do not consume the write budget.

## Test Coverage Added

A new `server/rateLimit.test.ts` suite verifies, with supertest against a production-mode Express app:

- Each preference mutation path (`/api/agents/:id/toggle`, `/sprite`, `/recipe`, `/tags`) returns 200 once and 429 with the three rate-limit headers on the second call, while `/api/status` continues to return 200.
- PUT, POST, and DELETE on `/api/layouts` share a single budget.
- Preference and layout budgets do not bleed into each other.
- Malformed JSON over the preference endpoint is parsed once (returning 400) and then throttled (returning 429) before further body parsing.
- Disallowed Origins still receive `403 Forbidden origin` and do not consume write budget; the next allowed request succeeds.
- Public GET, ingest pre-auth, and ingest post-auth 429s all carry `Retry-After`, `X-RateLimit-Limit`, and `X-RateLimit-Remaining`.
- Ingest pre-auth limiting runs before JSON parsing, so malformed ingest bodies are also capped.
- Startup throws for each invalid `*_RATE_LIMIT_MAX` value (`0`, `nope`, `1.5`, `-1`, empty string).

## Client recovery and autosave headroom

- The layout budget now defaults to 90/minute, providing 3x headroom over the editor's theoretical 30/minute autosave ceiling for shared create, delete, and keepalive traffic.
- Auto-save treats 429 as retryable and honors both delta-seconds and HTTP-date `Retry-After` values without clearing dirty state.
- Agent toggle mutations now check HTTP status; toggle-all waits for the complete fan-out and refreshes authoritative server state after a partial failure.
- Behavior regressions cover default layout headroom, Retry-After-aware save retry, and partial toggle-all 429 reconciliation. The full suite passes 392/392 tests, including coverage.

## Related issue coverage

This PR also addresses #157 item 2: the pre-parser ingest classifier now spends the per-IP pre-auth budget only on missing or invalid bearer credentials. Valid bearer pushes bypass the failed-attempt bucket and continue to the independent authenticated-push budget, while bearer comparison retains fixed-length HMAC-SHA-256 digests and `timingSafeEqual`. A regression proves exhausting the failed-attempt allowance cannot throttle the next valid push.

## Documentation

`README.md` adds a row for each new environment variable in the configuration table, and a paragraph clarifying that mutating API and ingest pre-auth limits run before JSON parsing, that malformed rate-limit values fail startup, and that 429 responses include the three backoff headers.

---

### Summary

This change bumps the default server-side rate-limit budget for layout writes and adds client-side handling so the editor stays correct when some requests are throttled.

### Server change
- **`LAYOUT_WRITE_RATE_LIMIT_MAX` default**: raised from `30` to `90` per minute and client IP. The bucket covers layout autosaves (theoretical ~30/min) plus create/delete/keepalive writes, so the new value reserves 3× headroom for normal use. The default still rejects abusive clients but no longer trips under typical editorial workflows.
- **README**: default value updated and the description now documents the autosave relationship.

### Client changes (`useLayoutStore`)
- On a `429` response, the auto-save retry now honors the server's `Retry-After` header (parsed as either seconds or an HTTP date) instead of relying solely on exponential backoff. If the header is absent or unparseable, behavior falls back to the existing backoff.
- New test covers a 429-with-`Retry-After: 10` flow: the first auto-save is rejected, the next attempt is suppressed until the 10-second window expires, then succeeds and clears the dirty state.

### Client changes (`useAgentStore`)
- `toggleAgent` and `toggleAll` now await the response and throw on non-2xx status (including `429`), so the optimistic update is rolled back by `fetchAgents()` when a call is rate-limited.
- `toggleAll` awaits every fan-out request, then triggers a single `fetchAgents()` reconciliation so the local store reflects the authoritative server state after partial failures.
- New test verifies that when one of the fan-out toggles returns 429, the successful toggle is kept and the failed agent is reverted to the server's `pixelEnabled` value on the next poll.

### Test changes
- New server-side test confirms the default `LAYOUT_WRITE_RATE_LIMIT_MAX` allows more than 30 requests per minute from one client without returning 429.
- New client tests for `useAgentStore` (mutation rate-limit handling) and `useLayoutStore` (Retry-After honored) added.

---

**PR Description:**

**What changed**

This PR hardens the server and client against the failure modes uncovered while investigating #154 (mutating API rate limiting), with four related but distinct fixes:

1. **Layout capacity guard (100 files in `layouts/`)**
   - `server/index.ts` introduces a `MAX_LAYOUT_FILES = 100` ceiling. `saveLayout` returns `false` (instead of writing) when the directory already holds 100 entries and the target doesn't exist; `POST`/`PUT`/`GET /api/layouts/:id` map that to HTTP **507 Insufficient Storage** with `"Layout limit reached (100)"`. The directory is read with `opendirSync` and counted by *every* entry (not just `.json`), so non-layout files still consume capacity. `GET /api/layouts` returns `{ layouts, overCapacity, layoutLimit }` when the legacy directory exceeds 100 entries, listing at most 100 layouts at a time.
   - `src/hooks/useLayoutStore.ts` surfaces these errors as a new `layoutError` (and `clearLayoutError`) field, converts 507s to the user-facing message *"Layout limit reached (100). Delete unused layouts until the warning clears."*, treats a 507 autosave as terminal (cancels retry timer, resets backoff), and preserves the existing list when `fetchLayouts` returns a 507 or a malformed body.

2. **Layout autosave Retry-After capping**
   - `parseRetryAfterMs` in `src/hooks/useLayoutStore.ts` now clamps the parsed delay to `MAX_RETRY_AFTER_MS = 60_000` so a malicious or misconfigured 429 can't park autosave indefinitely. Autosave now also explicitly reschedules on 429 with the capped `Retry-After`.

3. **Failed ingest auth no longer poisons the pre-auth bucket**
   - `ingestPreAuthRateLimiter` now calls `authenticateIngest` *before* `checkPreAuthRateLimiter`, so valid collectors are not charged for prior failed bearer attempts. Comment clarifies that both configured and provided tokens are hashed to fixed-length digests before the timing-safe comparison.

4. **CLI polling health logging + data-source classification expansion**
   - Adds `INITIAL_CLI_POLL_HEALTH` / `updateCliPollHealth` helpers. The poll loop now logs the first failure, suppresses repeated same-kind failures, emits a reminder every 20 failed cycles, and logs a single recovery line on success.
   - `classifyCliExecError` (in `server/dataSource.ts`, referenced via `OPENCLAW_SESSIONS_EXEC_OPTIONS`) treats more CLI failures as "needs operator action" (`EACCES`, `EPERM`, `ENOEXEC`, `EFTYPE`, `ELOOP`, `ENAMETOOLONG`, `ERR_CHILD_PROCESS_STDIO_MAXBUFFER`) while keeping transient ones (`EAGAIN`, `EBUSY`, `EMFILE`) on the preserving path. README is updated accordingly.

**Why**

- Without a layout ceiling, a runaway autosave loop (or a malicious actor) could fill the `layouts/` directory and DOS the filesystem or `readdirSync`.
- Without a `Retry-After` clamp, a single misbehaving upstream response (or a server-side bug emitting `Retry-After: 86400`) would silently stop autosave for hours.
- Without the pre-auth reordering, a brute-force attempt at the ingest token could lock out the legitimate collector.
- Without the CLI health logging, a permanent CLI failure was either silent (after the first error) or generated one log line per poll cycle, both unhelpful during incident triage.

**Tests**

- `server/rateLimit.test.ts`: adds a test asserting that 3 failed bearer attempts do not throttle a valid ingest push, and tightens two existing test teardowns (Socket.IO server close + `vi.resetModules()` inside `try/finally`).
- `src/hooks/useLayoutStore.test.tsx`: adds a `layout capacity errors` suite covering 507 on create/save/list, malformed list bodies preserving the prior list+warning, over-capacity warning clearing on a normal response, and the `Retry-After: 86400` cap test.
- `src/hooks/useAgentStore.test.tsx`: adds a `mutation failures` suite covering optimistic rollback, out-of-order failure reconciliation (older failure after newer mutation), REST poll racing with optimistic toggles, bulk toggle partial-success reporting, socket snapshots preserved across failed mutations, sprite rollback, and stale-REST-poll not overwriting an optimistic toggle.

---

## Description

This PR fixes the API write rate-limiting behavior so that authenticated ingest requests are properly throttled even when payloads are malformed, and so that clients correctly interpret a missing `Retry-After` header as a full-window backoff.

### Server changes (`server/index.ts`)

- Moves post-authentication rate limiting into the shared `ingestPreAuthRateLimiter` middleware. After `authenticateIngest` succeeds, the request now spends a slot from the post-auth bucket **before** JSON parsing, so malformed bodies cannot bypass throttling.
- Extracts the hashing/key construction logic into a new `ingestPostAuthRateKey` helper plus a `checkPostAuthRateLimit` function for clarity and reuse.
- Removes the duplicated, inline rate-limit block that previously lived in the `POST /api/ingest/agents` handler.

### Server test changes (`server/rateLimit.test.ts`)

- Adds a test that sends an oversized malformed JSON body with a valid bearer token. The first request is rejected by JSON parsing (400), and the second is rejected by the post-auth rate limiter (429), proving the limiter fires before body parsing.

### Client changes (`src/hooks/useLayoutStore.ts`)

- Updates `parseRetryAfterMs` so that when the server omits `Retry-After` (or returns a non-finite/non-positive value), the client falls back to the 60-second window instead of `0` (which previously would have triggered the 2-second backoff floor and retried far too soon).

### Client test changes (`src/hooks/useLayoutStore.test.tsx`)

- Adds a regression test verifying that a 429 response with no `Retry-After` header causes the client to wait the full 60-second window before retrying, after which the layout PUT succeeds and `isDirty` clears.

Together these changes ensure rate limits are enforced consistently for authenticated ingest traffic and that clients honor the server's intended retry window.
<!-- kody-pr-summary:end -->

## Summary by Sourcery

Harden mutating API and ingest traffic against abuse while improving client recovery from rate-limit responses.

New Features:
- Add independent per-IP rate limits for preference and layout mutation requests, with configurable startup-validated budgets.
- Expose standardized backoff headers on all throttled responses and enforce mutation limits before JSON parsing.
- Handle layout autosave throttling using Retry-After values and reconcile partial agent-toggle failures with server state.

Bug Fixes:
- Prevent valid authenticated ingest pushes from being blocked by the failed-attempt pre-auth budget.
- Bound malformed request-body parsing work and preserve origin-protection and ingest behavior.

Enhancements:
- Unify rate-limit accounting across public GET, ingest, and API mutation paths with sliding-window decisions.
- Increase the default layout write budget to provide headroom for normal autosave and layout-management traffic.

Documentation:
- Document the new rate-limit configuration variables, validation behavior, parser ordering, and 429 response headers.

Tests:
- Add server and client regression coverage for mutation budgets, parser ordering, header behavior, ingest classification, configuration validation, autosave retries, and partial toggle reconciliation.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable rate limits for read, write, preference, layout, and ingest endpoints.
  * Rate-limited responses now include retry and limit information.
  * Added separate protections for API mutations and unauthenticated ingest requests.
  * Layout saves automatically retry according to the server-provided retry delay, capped at 60 seconds.

* **Bug Fixes**
  * Improved bulk updates so rate-limited items remain synchronized with server state.
  * Invalid rate-limit settings now prevent startup with a clear failure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->