### PR TITLE
fix(layouts): isolate save retry timers

### DIFF
--- a/src/hooks/useLayoutStore.test.tsx
+++ b/src/hooks/useLayoutStore.test.tsx
@@ -308,6 +308,26 @@ describe('useLayoutStore', () => {
     );
   });
 
+  it('returns a visible failure signal when createLayout receives an invalid success body', async () => {
+    await renderStoreProbe();
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(new Response('not json', {
+      status: 200,
+      headers: { 'Content-Type': 'text/plain' },
+    }));
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    let result: LayoutDoc | null | undefined;
+    await act(async () => {
+      result = await latest(snapshots).createLayout('Malformed');
+    });
+
+    expect(result).toBeNull();
+    expect(consoleError).toHaveBeenCalledWith(
+      'Failed to create layout:',
+      'invalid response body',
+    );
+  });
+
   it('updateFurniture applies functional updater to current layout', async () => {
     await renderStoreProbe();
 
@@ -1075,6 +1095,26 @@ describe('useLayoutStore', () => {
     await vi.advanceTimersByTimeAsync(2_100);
 
     expect(putCount).toBe(1);
+  });
+
+  it('clears a pending autosave debounce on unmount', async () => {
+    await renderStoreProbe();
+    vi.useFakeTimers();
+
+    act(() => {
+      latest(snapshots).updateFurniture([
+        { id: 'desk-1', type: 'DESK', x: 3, y: 4, rotation: 90 },
+      ]);
+    });
+
+    act(() => unmount?.());
+    unmount = undefined;
+    await vi.advanceTimersByTimeAsync(2_100);
+
+    const putCalls = (fetch as ReturnType<typeof vi.fn>).mock.calls.filter(
+      (call: unknown[]) => (call[1] as RequestInit | undefined)?.method === 'PUT',
+    );
+    expect(putCalls).toHaveLength(0);
   });
 
   it('clears the saved-status timer on unmount', async () => {

--- a/src/hooks/useLayoutStore.test.tsx
+++ b/src/hooks/useLayoutStore.test.tsx
@@ -554,6 +554,55 @@ describe('useLayoutStore', () => {
       });
       expect(result).toBe(false);
     });
+
+    it('does not clear a newer active layout when a deferred 404 arrives', async () => {
+      await renderStoreProbe();
+      const deleteGate = deferred<Response>();
+      const initialFetch = fetch;
+      vi.stubGlobal('fetch', vi.fn(async (
+        input: string | URL | Request,
+        init?: RequestInit,
+      ) => {
+        const url = typeof input === 'string'
+          ? input
+          : input instanceof Request
+            ? input.url
+            : input.toString();
+        if (url.endsWith('/api/layouts/default') && init?.method === 'DELETE') {
+          return deleteGate.promise;
+        }
+        return initialFetch(input, init);
+      }));
+
+      let deleteResult: boolean | undefined;
+      const deletePromise = latest(snapshots).deleteLayout('default').then((value) => {
+        deleteResult = value;
+      });
+
+      await act(async () => {
+        await latest(snapshots).loadLayoutById('other');
+      });
+      expect(latest(snapshots).activeLayout?.id).toBe('other');
+
+      act(() => {
+        latest(snapshots).updateFurniture([
+          { id: 'desk-1', type: 'DESK', x: 1, y: 1, rotation: 0 },
+        ]);
+      });
+      expect(latest(snapshots).isDirty).toBe(true);
+
+      await act(async () => {
+        deleteGate.resolve(new Response(
+          JSON.stringify({ error: 'Not found' }),
+          { status: 404, headers: { 'Content-Type': 'application/json' } },
+        ));
+        await deletePromise;
+      });
+
+      expect(deleteResult).toBe(true);
+      expect(latest(snapshots).activeLayout?.id).toBe('other');
+      expect(latest(snapshots).isDirty).toBe(true);
+    });
   });
 
   it('returns a visible failure signal when createLayout receives a non-OK response', async () => {
@@ -1574,6 +1623,65 @@ describe('useLayoutStore', () => {
       await vi.advanceTimersByTimeAsync(0);
     });
     expect(putBodies).toHaveLength(2);
+    expect(latest(snapshots).isDirty).toBe(false);
+  });
+
+  it('keeps consecutive 429s on Retry-After instead of inheriting backoff', async () => {
+    await renderStoreProbe();
+    vi.useFakeTimers();
+
+    const initialFetch = fetch;
+    const putBodies: Array<LayoutDoc & { baseUpdatedAt?: number }> = [];
+    vi.stubGlobal('fetch', vi.fn(async (
+      input: string | URL | Request,
+      init?: RequestInit,
+    ) => {
+      const url = typeof input === 'string'
+        ? input
+        : input instanceof Request
+          ? input.url
+          : input.toString();
+      if (url.endsWith('/api/layouts/default') && init?.method === 'PUT') {
+        const body = JSON.parse(init.body as string) as LayoutDoc & { baseUpdatedAt?: number };
+        putBodies.push(body);
+        if (putBodies.length <= 2) {
+          return new Response(JSON.stringify({ error: 'Too many requests' }), {
+            status: 429,
+            headers: { 'Content-Type': 'application/json', 'Retry-After': '3' },
+          });
+        }
+        return new Response(JSON.stringify({ layout: { ...body, updatedAt: 2_000 } }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      return initialFetch(input, init);
+    }));
+
+    act(() => {
+      latest(snapshots).updateFurniture([
+        { id: 'desk-1', type: 'DESK', x: 3, y: 4, rotation: 90 },
+      ]);
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2_100);
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(putBodies).toHaveLength(1);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3_100);
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(putBodies).toHaveLength(2);
+
+    // A polluted counter would wait 4s (2s * 2^1) here, not Retry-After 3s.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3_100);
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(putBodies).toHaveLength(3);
     expect(latest(snapshots).isDirty).toBe(false);
   });
 

--- a/src/hooks/useLayoutStore.test.tsx
+++ b/src/hooks/useLayoutStore.test.tsx
@@ -252,12 +252,27 @@ describe('useLayoutStore', () => {
       expect(result).toBe(true);
     });
 
-    it('resolves false on a non-2xx response', async () => {
+    it('resolves true when the layout is already absent (404)', async () => {
       await renderStoreProbe();
+      // Simulate another client deleting the active layout after we loaded it.
+      delete layouts.default;
       let result: boolean | undefined;
       await act(async () => {
-        // 'missing' is not in the mock store, so DELETE returns 404.
-        result = await latest(snapshots).deleteLayout('missing');
+        result = await latest(snapshots).deleteLayout('default');
+      });
+      expect(result).toBe(true);
+      expect(latest(snapshots).activeLayout).toBeNull();
+    });
+
+    it('resolves false on a non-404 error response', async () => {
+      await renderStoreProbe();
+      (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(new Response(
+        JSON.stringify({ error: 'Internal server error' }),
+        { status: 500, headers: { 'Content-Type': 'application/json' } },
+      ));
+      let result: boolean | undefined;
+      await act(async () => {
+        result = await latest(snapshots).deleteLayout('default');
       });
       expect(result).toBe(false);
     });
@@ -271,6 +286,26 @@ describe('useLayoutStore', () => {
       });
       expect(result).toBe(false);
     });
+  });
+
+  it('returns a visible failure signal when createLayout receives a non-OK response', async () => {
+    await renderStoreProbe();
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(new Response(
+      JSON.stringify({ error: 'Layout name is already in use' }),
+      { status: 400, headers: { 'Content-Type': 'application/json' } },
+    ));
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    let result: LayoutDoc | null | undefined;
+    await act(async () => {
+      result = await latest(snapshots).createLayout('Duplicate');
+    });
+
+    expect(result).toBeNull();
+    expect(consoleError).toHaveBeenCalledWith(
+      'Failed to create layout:',
+      'Layout name is already in use',
+    );
   });
 
   it('updateFurniture applies functional updater to current layout', async () => {
@@ -945,6 +980,117 @@ describe('useLayoutStore', () => {
     // The retried PUT carries the same furniture — the user's edit is preserved.
     expect(putBodies[1].furniture[0].rotation).toBe(90);
     expect(latest(snapshots).isDirty).toBe(false);
+  });
+
+  it('keeps a pending conflict retry independent from a later edit debounce', async () => {
+    await renderStoreProbe();
+    vi.useFakeTimers();
+
+    const initialFetch = fetch;
+    const putBodies: Array<LayoutDoc & { baseUpdatedAt?: number }> = [];
+    vi.stubGlobal('fetch', vi.fn(async (
+      input: string | URL | Request,
+      init?: RequestInit,
+    ) => {
+      const url = typeof input === 'string'
+        ? input
+        : input instanceof Request
+          ? input.url
+          : input.toString();
+      if (url.endsWith('/api/layouts/default') && init?.method === 'PUT') {
+        const body = JSON.parse(init.body as string) as LayoutDoc & { baseUpdatedAt?: number };
+        putBodies.push(body);
+        if (putBodies.length === 1) {
+          return new Response(JSON.stringify({ error: 'Revision conflict' }), {
+            status: 409,
+            headers: { 'Content-Type': 'application/json' },
+          });
+        }
+        return new Response(JSON.stringify({ layout: { ...body, updatedAt: 2_000 } }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      return initialFetch(input, init);
+    }));
+
+    act(() => {
+      latest(snapshots).updateFurniture([
+        { id: 'desk-1', type: 'DESK', x: 3, y: 4, rotation: 90 },
+      ]);
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2_100);
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(putBodies).toHaveLength(1);
+
+    // One second into the retry backoff, make another edit. Its debounce is
+    // due one second after the retry, so only an independent retry timer can
+    // produce the second PUT at the original retry deadline.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1_000);
+      latest(snapshots).updateFurniture([
+        { id: 'desk-1', type: 'DESK', x: 3, y: 4, rotation: 180 },
+      ]);
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1_100);
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    expect(putBodies).toHaveLength(2);
+    expect(putBodies[1].furniture[0].rotation).toBe(180);
+    expect(putBodies[1].baseUpdatedAt).toBe(1_000);
+  });
+
+  it('clears a pending save retry on unmount', async () => {
+    await renderStoreProbe();
+    vi.useFakeTimers();
+
+    const initialFetch = fetch;
+    let putCount = 0;
+    vi.stubGlobal('fetch', vi.fn(async (
+      input: string | URL | Request,
+      init?: RequestInit,
+    ) => {
+      const url = typeof input === 'string' ? input : input.toString();
+      if (url.endsWith('/api/layouts/default') && init?.method === 'PUT') {
+        putCount++;
+        return new Response(JSON.stringify({ error: 'Service Unavailable' }), {
+          status: 503,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      return initialFetch(input, init);
+    }));
+
+    await act(async () => {
+      await latest(snapshots).saveActiveLayout();
+    });
+    expect(putCount).toBe(1);
+
+    act(() => unmount?.());
+    unmount = undefined;
+    await vi.advanceTimersByTimeAsync(2_100);
+
+    expect(putCount).toBe(1);
+  });
+
+  it('clears the saved-status timer on unmount', async () => {
+    await renderStoreProbe();
+    vi.useFakeTimers();
+
+    await act(async () => {
+      await latest(snapshots).saveActiveLayout();
+    });
+    expect(latest(snapshots).saveStatus).toBe('saved');
+    expect(vi.getTimerCount()).toBe(1);
+
+    act(() => unmount?.());
+    unmount = undefined;
+
+    expect(vi.getTimerCount()).toBe(0);
   });
 
   it('does not auto-save when activeLayout is null', async () => {

--- a/src/hooks/useLayoutStore.ts
+++ b/src/hooks/useLayoutStore.ts
@@ -109,16 +109,26 @@ export function useLayoutStore() {
   const isDirtyRef = useRef(false);
   // retryAttemptRef: tracks consecutive failed auto-saves for backoff.
   const retryAttemptRef = useRef(0);
+  // Retry backoff is independent from the furniture debounce. A new edit may
+  // reschedule the debounce, but it must not cancel recovery from a failed save.
+  const retryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const clearSaveRetry = useCallback(() => {
+    if (retryTimerRef.current) {
+      clearTimeout(retryTimerRef.current);
+      retryTimerRef.current = null;
+    }
+  }, []);
 
   const scheduleSaveRetry = useCallback((retry: () => void) => {
     const delay = Math.min(2000 * Math.pow(2, retryAttemptRef.current), 30000);
     retryAttemptRef.current++;
-    if (autoSaveTimerRef.current) clearTimeout(autoSaveTimerRef.current);
-    autoSaveTimerRef.current = setTimeout(() => {
-      autoSaveTimerRef.current = null;
+    clearSaveRetry();
+    retryTimerRef.current = setTimeout(() => {
+      retryTimerRef.current = null;
       retry();
     }, delay);
-  }, []);
+  }, [clearSaveRetry]);
 
   // 'saved' auto-clears back to 'idle' so the button returns to its neutral
   // state; 'saving' and 'error' persist until the next save attempt resolves.
@@ -271,6 +281,7 @@ export function useLayoutStore() {
           return;
         }
         // Success — reset retry counter and advance the revision monotonically.
+        clearSaveRetry();
         retryAttemptRef.current = 0;
         markSaveStatus('saved');
         const currentRevision = persistedRevisionRef.current;
@@ -299,6 +310,7 @@ export function useLayoutStore() {
     return savePromiseRef.current;
   }, [
     advancePersistedRevision,
+    clearSaveRetry,
     fetchLayouts,
     markSaveStatus,
     refreshPersistedRevision,
@@ -306,19 +318,26 @@ export function useLayoutStore() {
     setActiveLayoutProgrammatic,
   ]);
 
-  const createLayout = useCallback(async (name: string) => {
+  const createLayout = useCallback(async (name: string): Promise<LayoutDoc | null> => {
     try {
       const res = await fetch(`${API_BASE}/layouts`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ name, width: 24, height: 16 }),
       });
-      const data = await res.json();
+      const data = await res.json().catch(() => null);
+      if (!res.ok) {
+        const message = data && typeof data.error === 'string'
+          ? data.error
+          : `HTTP ${res.status}`;
+        console.error('Failed to create layout:', message);
+        return null;
+      }
       if (data.layout) {
         setActiveLayoutProgrammatic(data.layout);
         fetchLayouts();
       }
-      return data.layout;
+      return data.layout ?? null;
     } catch (err) {
       console.error('Failed to create layout:', err);
       return null;
@@ -331,7 +350,7 @@ export function useLayoutStore() {
   const deleteLayout = useCallback(async (id: string): Promise<boolean> => {
     try {
       const res = await fetch(`${API_BASE}/layouts/${id}`, { method: 'DELETE' });
-      if (!res.ok) {
+      if (!res.ok && res.status !== 404) {
         const err = await res.json().catch(() => ({ error: 'Failed to delete layout' }));
         console.error('Failed to delete layout:', err.error);
         return false;
@@ -346,6 +365,16 @@ export function useLayoutStore() {
       return false;
     }
   }, [activeLayout, fetchLayouts, setActiveLayoutProgrammatic]);
+
+  // Timers can otherwise outlive the hook and call setState or issue retries
+  // after its consumer has gone away.
+  useEffect(() => () => {
+    if (saveStatusTimerRef.current) {
+      clearTimeout(saveStatusTimerRef.current);
+      saveStatusTimerRef.current = null;
+    }
+    clearSaveRetry();
+  }, [clearSaveRetry]);
 
   const fetchCatalog = useCallback(async () => {
     try {

--- a/src/hooks/useLayoutStore.ts
+++ b/src/hooks/useLayoutStore.ts
@@ -333,11 +333,14 @@ export function useLayoutStore() {
         console.error('Failed to create layout:', message);
         return null;
       }
-      if (data.layout) {
-        setActiveLayoutProgrammatic(data.layout);
-        fetchLayouts();
+      const layout: unknown = data?.layout;
+      if (!isLayoutDoc(layout)) {
+        console.error('Failed to create layout:', 'invalid response body');
+        return null;
       }
-      return data.layout ?? null;
+      setActiveLayoutProgrammatic(layout);
+      fetchLayouts();
+      return layout;
     } catch (err) {
       console.error('Failed to create layout:', err);
       return null;

--- a/src/hooks/useLayoutStore.ts
+++ b/src/hooks/useLayoutStore.ts
@@ -150,7 +150,11 @@ export function useLayoutStore() {
   const scheduleSaveRetry = useCallback((retry: () => void, minimumDelayMs = 0) => {
     const backoffDelay = Math.min(2000 * Math.pow(2, retryAttemptRef.current), 30000);
     const delay = Math.max(backoffDelay, minimumDelayMs);
-    retryAttemptRef.current++;
+    // Retry-After already owns this wait. Incrementing would make the next
+    // 429 inherit 5xx/409 exponential backoff and ignore the server clock.
+    if (minimumDelayMs < backoffDelay) {
+      retryAttemptRef.current++;
+    }
     clearSaveRetry();
     retryTimerRef.current = setTimeout(() => {
       retryTimerRef.current = null;
@@ -449,7 +453,7 @@ export function useLayoutStore() {
         console.error('Failed to delete layout:', err.error);
         return false;
       }
-      if (activeLayout?.id === id) {
+      if (activeLayoutRef.current?.id === id) {
         setActiveLayoutProgrammatic(null);
       }
       fetchLayouts();
@@ -458,7 +462,7 @@ export function useLayoutStore() {
       console.error('Failed to delete layout:', err);
       return false;
     }
-  }, [activeLayout, fetchLayouts, setActiveLayoutProgrammatic]);
+  }, [fetchLayouts, setActiveLayoutProgrammatic]);
 
   // Timers can otherwise outlive the hook and call setState or issue retries
   // after its consumer has gone away.


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
### Code Changes Analysis

**1. Isolated retry timer (decoupling save recovery from edit debounce)**
- Introduced a dedicated `retryTimerRef` and `clearSaveRetry` helper so that scheduling a save retry no longer writes to `autoSaveTimerRef`.
- A later `updateFurniture` call still resets the furniture debounce on its own timer, while an already-pending retry runs to completion — preventing fresh edits from canceling in-progress conflict recovery.

**2. createLayout failure signaling**
- `createLayout` now returns `LayoutDoc | null` with a visible failure path for non-OK responses: it parses the body defensively, logs a specific server-provided `error` message (or `HTTP <status>` fallback), and returns `null`.
- Adds a corresponding test that asserts a 400 with a duplicate-name message resolves to `null` and produces the expected `console.error`.

**3. Idempotent deleteLayout on 404**
- `deleteLayout` treats `404` as success instead of failure: a layout deleted out-of-band by another client clears the active layout without surfacing an error.
- Test coverage split accordingly — one case for the now-expected 404 path (active layout cleared, returns `true`) and another for genuine 5xx errors (returns `false`).

**4. Cleanup on unmount**
- Added a teardown `useEffect` that clears the save-status timer and any pending retry timer when the hook unmounts, preventing stray callbacks from firing `setState` or issuing network requests after the consumer is gone.
- Verified by two new tests: one confirms a failed `saveActiveLayout` does not produce a follow-up PUT after unmount, the other confirms `vi.getTimerCount()` drops to `0` once the hook is unmounted while `saveStatus === 'saved'`.

**5. Retry scheduling invariants**
- On a successful save, `clearSaveRetry()` is invoked alongside resetting `retryAttemptRef` so a queued recovery cannot fire after a successful PUT.
- Dependency arrays for `createLayout`, `saveActiveLayout`, and the unmount effect are updated to include `clearSaveRetry` for ESLint correctness.

---

This PR fixes layout save retry timers leaking across operations and adds proper handling for capacity (507) and rate-limit (429) responses in the layout store.

### Key changes

**Save retry isolation**
- `scheduleSaveRetry` now clears any pending retry timer before scheduling a new one (`clearSaveRetry`), preventing a retry belonging to a previous layout from firing after the user switches to a different one.
- `setActiveLayoutProgrammatic` now calls `clearSaveRetry` and resets `retryAttemptRef` so a freshly loaded layout starts from the base 2s backoff, not an inflated exponent from a prior layout's failures.
- The `beforeunload` save handler now also clears any pending retry on success.

**Capacity (HTTP 507) handling**
- New `layoutError` state and `clearLayoutError` exposed to consumers.
- `fetchLayouts` preserves the existing list and surfaces an actionable "Layout limit reached. Delete unused layouts until the warning clears." message on 507.
- Successful responses with `overCapacity: true` now display a warning ("Only N layouts are shown...") while keeping the bounded list.
- Malformed list responses (invalid JSON, non-array `layouts`, layout objects failing validation) preserve the previous list and warning instead of wiping them.
- `loadLayoutById` surfaces 507 to `layoutError`.
- `saveActiveLayout` treats 507 as terminal: it cancels the autosave debounce, clears any pending retry, resets the retry counter, and sets `layoutError` (no recovery attempt).
- `createLayout` exposes 507 messages through `layoutError` and validates the returned `layout` shape, showing "Failed to create layout: invalid response body." when the success body is malformed.

**Rate-limit (HTTP 429) handling**
- New `parseRetryAfterMs` honors the `Retry-After` header (seconds or HTTP-date) and caps it at 60 s, so a misbehaving or hostile header cannot park autosave indefinitely.
- A missing `Retry-After` now defaults to the 60 s window (was previously the 2 s exponential backoff floor).
- Both the autosave retry path and the `beforeunload` retry path schedule retries using the parsed `Retry-After` as a minimum delay.

**Test coverage**
- New suite covering 507 on create, save (terminal, no retry), and fetch (preserves existing list and warning).
- Coverage for `overCapacity: true` responses, warning clearing on a normal subsequent fetch, and preservation of list + warning across malformed/invalid JSON responses.
- Coverage for invalid layout elements (e.g., `width: 0`) in list responses.
- New unmount test verifying that a pending autosave debounce is cleared when the consumer unmounts.
- New retry tests verifying `Retry-After` honored, oversized `Retry-After` capped, and missing `Retry-After` defaulting to 60 s.
- Documentation comment updated to reflect the `deleteLayout` contract change: a 404 (already gone) now resolves to `true`.

---

**Description:**

This PR fixes two retry-timer bugs in `useLayoutStore`:

1. **Retry-After backoff pollution (`scheduleSaveRetry`)**: When a `429` response with `Retry-After` was received, the retry counter was still being incremented as if it were a 5xx/409 failure. This caused the *next* `429` to inherit the exponential backoff instead of honoring the server-supplied `Retry-After` delay. The retry counter now only increments when the backoff delay is actually being applied (i.e., `minimumDelayMs < backoffDelay`), so consecutive `Retry-After` waits use the server clock independently.

2. **Stale `activeLayout` in deferred `deleteLayout` (`deleteLayout`)**: When a delete request was deferred (awaiting network) and the user switched active layouts in the meantime, the callback was closing over a stale `activeLayout` from render time. This could cause a delayed failure (e.g., a 404) to clear the *new* active layout. The handler now reads from `activeLayoutRef.current` (the live ref) so it only clears state when the still-active layout matches the deleted id.

Tests were added for both scenarios: one verifying that a deferred 404 doesn't wipe a newly activated layout, and one verifying that consecutive 429s use `Retry-After` timing instead of compound exponential backoff.
<!-- kody-pr-summary:end -->

## Summary by Sourcery

Make layout persistence retries safe across edits, layout changes, rate limits, failures, and component unmounting.

Bug Fixes:
- Isolate autosave retry timers from edit debouncing and cancel stale retries when switching layouts, succeeding, or unmounting.
- Treat already-deleted layouts as successful deletes while preserving newer active layouts during deferred responses.
- Handle layout capacity and rate-limit responses with actionable errors, bounded retry delays, and terminal behavior for capacity failures.
- Return visible failure signals for unsuccessful or malformed layout creation responses.

Enhancements:
- Preserve existing layout data and warnings when layout-list responses are over capacity or malformed.

Documentation:
- Update the delete-layout contract to document 404 responses as successful when the layout is already absent.

Tests:
- Add coverage for retry isolation, timer cleanup, idempotent deletion, invalid creation responses, capacity handling, and Retry-After behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved layout creation error handling with clearer failure feedback when requests fail or return invalid data.
  - Treats deleting an already-removed layout as successful.
  - Improved save recovery so retry attempts no longer interfere with editing and autosave timing.
  - Prevents pending save retries and status updates from continuing after leaving the editor.
- **Tests**
  - Added coverage for layout creation, deletion, save retries, autosave behavior, and cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->