### PR TITLE
fix(game): respect rotation and obstacles in pathfinding

### DIFF
--- a/src/game/GameEngine.integration.test.ts
+++ b/src/game/GameEngine.integration.test.ts
@@ -414,6 +414,20 @@ describe('GameEngine integration: obstacle-aware movement', () => {
     expect(character.x).toBeCloseTo(4, 5);
     expect(character.y).toBeCloseTo(8, 5);
   });
+
+  it('closes a safe sub-tile gap when BFS needs no waypoints', () => {
+    engine.setLayout([], { walker: { x: 2, y: 4 } });
+    engine.addCharacter({ id: 'walker', name: 'Walker', x: 2.4, y: 4, state: 'idle' });
+
+    engine.updateCharacter('walker', { state: 'typing' });
+
+    const character = engine.characters.get('walker')!;
+    expect(character.path).toEqual([]);
+    for (let step = 0; step < 10; step++) engine.update(0.1);
+
+    expect(character.x).toBeCloseTo(2, 5);
+    expect(character.y).toBeCloseTo(4, 5);
+  });
 });
 
 // ── Sub-agent lifecycle describe ─────────────────────────────────────────────

--- a/src/game/GameEngine.integration.test.ts
+++ b/src/game/GameEngine.integration.test.ts
@@ -28,6 +28,7 @@ import type { EditorCallbacks } from './EditorController';
 import type { PlacedFurniture } from '../../shared/types';
 import { SUBAGENT_FADE_DURATION } from './SubAgentFSM';
 import { getDayPhase } from './Schedule';
+import type { Point } from './Pathfinder';
 import type { ReadonlyLoadedCharacter } from './SpriteLoader';
 import { sfx } from '../audio/SoundFX';
 
@@ -62,6 +63,12 @@ type RecordingContext = {
 // proceed normally because TS `private` is a compile-time annotation only.
 type SubAgentCharacter = {
   id: string;
+  x: number;
+  y: number;
+  targetX: number;
+  targetY: number;
+  path: Point[];
+  pathIndex: number;
   fadeAlpha: number;
   dying: boolean;
   spawnTime: number;
@@ -85,12 +92,15 @@ type TestGameEngine = {
     state: string;
     lastMessage?: string;
   }): void;
+  updateCharacter(id: string, updates: Partial<{
+    state: string;
+  }>): void;
   setEditorMode(enabled: boolean): void;
   setSelectedFurnitureType(type: string | null): void;
   setSelectedFurnitureId(id: string | null): void;
   setEditorCallbacks(cb: EditorCallbacks): void;
   setGameCallbacks(cb: GameCallbacks): void;
-  setLayout(furniture: PlacedFurniture[]): void;
+  setLayout(furniture: PlacedFurniture[], seats?: Record<string, { x: number; y: number }>): void;
   getPlacedFurniture(): PlacedFurniture[];
   spawnSubAgent(parentId: string, subId: string, subName: string): void;
   killSubAgent(subId: string): void;
@@ -302,6 +312,107 @@ describe('GameEngine integration: editor adapters', () => {
     );
     expect(engine.getPlacedFurniture()[0].rotation).toBe(90);
     expect(editorCallbacks.onRotateFurniture).toHaveBeenCalledWith('desk-1', 90);
+  });
+});
+
+describe('GameEngine integration: obstacle-aware movement', () => {
+  let engine: TestGameEngine;
+  let canvas: HTMLCanvasElement;
+
+  beforeEach(() => {
+    const made = makeCanvasWithStubbedContext();
+    canvas = made.canvas;
+    engine = new GameEngine(canvas, GRID) as unknown as TestGameEngine;
+  });
+
+  afterEach(() => {
+    engine.stop();
+    vi.restoreAllMocks();
+    vi.clearAllMocks();
+  });
+
+  const clickGrid = (gridX: number, gridY: number) => {
+    const target = clientCenterOf(gridX, gridY);
+    canvas.dispatchEvent(new MouseEvent('click', { clientX: target.x, clientY: target.y }));
+  };
+
+  it('routes around the rendered footprint of rotated fallback furniture', () => {
+    // Missing furniture sprites intentionally use the conservative 2x1
+    // footprint. At 90 degrees that occupies (4,3) and (4,4), not (5,3).
+    engine.setLayout([
+      { id: 'rotated-fallback', type: 'MISSING_SPRITE', x: 4, y: 3, rotation: 90 },
+    ]);
+    engine.addCharacter({ id: 'walker', name: 'Walker', x: 2, y: 4, state: 'idle' });
+
+    clickGrid(2, 4);
+    clickGrid(6, 4);
+
+    const character = engine.characters.get('walker')!;
+    const rotatedObstacleTiles = new Set(['4,3', '4,4']);
+    expect(character.path.every(({ x, y }) => !rotatedObstacleTiles.has(`${x},${y}`)))
+      .toBe(true);
+
+    for (let step = 0; step < 100; step++) {
+      engine.update(0.1);
+      expect(rotatedObstacleTiles.has(`${Math.round(character.x)},${Math.round(character.y)}`))
+        .toBe(false);
+      if (Math.abs(character.x - 6) < 0.05 && Math.abs(character.y - 4) < 0.05) break;
+    }
+    expect(character.x).toBeCloseTo(6, 1);
+    expect(character.y).toBeCloseTo(4, 1);
+  });
+
+  it('stops at the expanded-ring destination instead of entering blocked furniture', () => {
+    const boxedTarget: PlacedFurniture[] = [5, 6, 7].flatMap(y => [5, 7].map(x => ({
+      id: `box-${x}-${y}`,
+      type: 'MISSING_SPRITE',
+      x,
+      y,
+      rotation: 0,
+    })));
+    engine.setLayout(boxedTarget, { walker: { x: 6, y: 6 } });
+    engine.addCharacter({ id: 'walker', name: 'Walker', x: 2, y: 6, state: 'idle' });
+
+    engine.updateCharacter('walker', { state: 'typing' });
+
+    const character = engine.characters.get('walker')!;
+    expect(character.path[character.path.length - 1]).toEqual({ x: 4, y: 6 });
+    expect({ x: character.targetX, y: character.targetY }).toEqual({ x: 4, y: 6 });
+
+    const obstacleTiles = new Set(
+      boxedTarget.flatMap(({ x, y }) => [`${x},${y}`, `${x + 1},${y}`]),
+    );
+    for (let step = 0; step < 100; step++) {
+      engine.update(0.1);
+      expect(obstacleTiles.has(`${Math.round(character.x)},${Math.round(character.y)}`))
+        .toBe(false);
+    }
+    expect(character.x).toBeCloseTo(4, 1);
+    expect(character.y).toBeCloseTo(6, 1);
+  });
+
+  it('does not use straight-line movement when no path exists through a solid wall', () => {
+    const wall: PlacedFurniture[] = Array.from({ length: 14 }, (_, index) => ({
+      id: `wall-${index + 1}`,
+      type: 'MISSING_SPRITE',
+      x: 12,
+      y: index + 1,
+      rotation: 0,
+    }));
+    engine.setLayout(wall);
+    engine.addCharacter({ id: 'walker', name: 'Walker', x: 4, y: 8, state: 'idle' });
+
+    clickGrid(4, 8);
+    clickGrid(18, 8);
+
+    const character = engine.characters.get('walker')!;
+    for (let step = 0; step < 100; step++) {
+      engine.update(0.1);
+      expect(character.x).toBeLessThan(12);
+    }
+
+    expect(character.x).toBeCloseTo(4, 5);
+    expect(character.y).toBeCloseTo(8, 5);
   });
 });
 

--- a/src/game/GameEngine.integration.test.ts
+++ b/src/game/GameEngine.integration.test.ts
@@ -441,6 +441,40 @@ describe('GameEngine integration: obstacle-aware movement', () => {
     expect(character.x).toBeCloseTo(2, 5);
     expect(character.y).toBeCloseTo(4, 5);
   });
+
+  it('does not close a sub-tile gap into a blocked shared tile', () => {
+    const desk: PlacedFurniture = {
+      id: 'desk',
+      type: 'MISSING_SPRITE',
+      x: 4,
+      y: 3,
+      rotation: 0,
+    };
+    engine.setLayout([desk], { walker: { x: 4, y: 3 } });
+    engine.addCharacter({ id: 'walker', name: 'Walker', x: 4.2, y: 3.2, state: 'idle' });
+
+    engine.updateCharacter('walker', { state: 'typing' });
+
+    const character = engine.characters.get('walker')!;
+    const blocked = new Set(['4,3', '5,3']);
+    const destination = character.path[character.path.length - 1];
+    expect(destination).toBeDefined();
+    expect(character.path.every(({ x, y }) => !blocked.has(`${x},${y}`))).toBe(true);
+    expect(blocked.has(`${destination.x},${destination.y}`)).toBe(false);
+
+    for (let step = 0; step < 100; step++) {
+      engine.update(0.1);
+      if (
+        Math.abs(character.x - destination.x) < 0.05
+        && Math.abs(character.y - destination.y) < 0.05
+      ) break;
+    }
+
+    expect(blocked.has(`${Math.round(character.x)},${Math.round(character.y)}`))
+      .toBe(false);
+    expect(character.x).toBeCloseTo(destination.x, 1);
+    expect(character.y).toBeCloseTo(destination.y, 1);
+  });
 });
 
 // ── Sub-agent lifecycle describe ─────────────────────────────────────────────

--- a/src/game/GameEngine.ts
+++ b/src/game/GameEngine.ts
@@ -479,9 +479,15 @@ export class GameEngine {
               ? (wpDx > 0 ? 'right' : 'left')
               : (wpDy > 0 ? 'down' : 'up');
           }
-        } else if (char.path.length > 0 || targetSharesRoundedTile) {
-          // Close the safe sub-tile gap after consuming the final waypoint,
-          // or when BFS needed no waypoints within the current tile.
+        } else if (
+          char.path.length > 0
+          || (
+            targetSharesRoundedTile
+            && !this.obstacleGrid?.[Math.round(char.targetY)]?.[Math.round(char.targetX)]
+          )
+        ) {
+          // Close the remaining gap after the last waypoint, or a same-tile
+          // offset on a free tile. A blocked shared tile is not a safe close.
           char.x += Math.sign(dx) * Math.min(speed * dt, Math.abs(dx));
           char.y += Math.sign(dy) * Math.min(speed * dt, Math.abs(dy));
           char.direction = Math.abs(dx) > Math.abs(dy)

--- a/src/game/GameEngine.ts
+++ b/src/game/GameEngine.ts
@@ -453,6 +453,8 @@ export class GameEngine {
       const dx = char.targetX - char.x;
       const dy = char.targetY - char.y;
       const speed = 3;
+      const targetSharesRoundedTile = Math.round(char.x) === Math.round(char.targetX)
+        && Math.round(char.y) === Math.round(char.targetY);
 
       if (Math.abs(dx) > 0.05 || Math.abs(dy) > 0.05) {
         // If we have a path, follow waypoints
@@ -477,8 +479,9 @@ export class GameEngine {
               ? (wpDx > 0 ? 'right' : 'left')
               : (wpDy > 0 ? 'down' : 'up');
           }
-        } else if (char.path.length > 0) {
-          // Close the sub-tile gap after consuming the final waypoint.
+        } else if (char.path.length > 0 || targetSharesRoundedTile) {
+          // Close the safe sub-tile gap after consuming the final waypoint,
+          // or when BFS needed no waypoints within the current tile.
           char.x += Math.sign(dx) * Math.min(speed * dt, Math.abs(dx));
           char.y += Math.sign(dy) * Math.min(speed * dt, Math.abs(dy));
           char.direction = Math.abs(dx) > Math.abs(dy)

--- a/src/game/GameEngine.ts
+++ b/src/game/GameEngine.ts
@@ -357,7 +357,7 @@ export class GameEngine {
       const sprite = this.furniture.get(f.type);
       const fw = sprite ? sprite.footprintW : 2;
       const fh = sprite ? sprite.footprintH : 1;
-      return { x: f.x, y: f.y, w: fw, h: fh };
+      return { x: f.x, y: f.y, w: fw, h: fh, rotation: f.rotation };
     });
     this.obstacleGrid = buildObstacleMap(this.config.gridWidth, this.config.gridHeight, furnitureRects);
     this.obstacleDirty = false;
@@ -386,13 +386,19 @@ export class GameEngine {
     this.ensureObstacles();
     if (!this.obstacleGrid) return [{ x: char.targetX, y: char.targetY }];
 
-    return bfsPathfind(
+    const path = bfsPathfind(
       this.obstacleGrid,
       { x: Math.round(char.x), y: Math.round(char.y) },
       { x: Math.round(char.targetX), y: Math.round(char.targetY) },
       this.config.gridWidth,
       this.config.gridHeight,
     );
+    const destination = path[path.length - 1];
+    if (destination) {
+      char.targetX = destination.x;
+      char.targetY = destination.y;
+    }
+    return path;
   }
 
   // ── Update ───────────────────────────────────────────
@@ -471,13 +477,18 @@ export class GameEngine {
               ? (wpDx > 0 ? 'right' : 'left')
               : (wpDy > 0 ? 'down' : 'up');
           }
-        } else {
-          // Straight line fallback (no path or path complete, still moving)
+        } else if (char.path.length > 0) {
+          // Close the sub-tile gap after consuming the final waypoint.
           char.x += Math.sign(dx) * Math.min(speed * dt, Math.abs(dx));
           char.y += Math.sign(dy) * Math.min(speed * dt, Math.abs(dy));
           char.direction = Math.abs(dx) > Math.abs(dy)
             ? (dx > 0 ? 'right' : 'left')
             : (dy > 0 ? 'down' : 'up');
+        } else {
+          // An empty path means the destination is unreachable. Cancel the
+          // target instead of walking straight through the blocking tiles.
+          char.targetX = char.x;
+          char.targetY = char.y;
         }
       } else if (char.path.length > 0) {
         // Arrived — clear path

--- a/src/game/Pathfinder.test.ts
+++ b/src/game/Pathfinder.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+
+import { bfsPathfind, buildObstacleMap } from './Pathfinder';
+
+describe('Pathfinder', () => {
+  it('searches beyond a blocked target\'s first ring for the nearest free tiles', () => {
+    const grid = buildObstacleMap(9, 9, [
+      { x: 3, y: 3, w: 3, h: 3 },
+    ]);
+
+    const path = bfsPathfind(grid, { x: 1, y: 4 }, { x: 4, y: 4 }, 9, 9);
+
+    expect(path[path.length - 1]).toEqual({ x: 2, y: 4 });
+    expect(path.every(({ x, y }) => !grid[y][x])).toBe(true);
+  });
+
+  it('returns no route when a free target is sealed behind obstacles', () => {
+    const grid = buildObstacleMap(9, 9, []);
+    for (let y = 3; y <= 5; y++) {
+      for (let x = 3; x <= 5; x++) {
+        if (x !== 4 || y !== 4) grid[y][x] = true;
+      }
+    }
+
+    expect(bfsPathfind(grid, { x: 1, y: 4 }, { x: 4, y: 4 }, 9, 9)).toEqual([]);
+  });
+
+  it.each([
+    { rotation: 0, blocked: ['4,4', '5,4'] },
+    { rotation: 90, blocked: ['4,4', '4,5'] },
+    { rotation: 180, blocked: ['3,4', '4,4'] },
+    { rotation: 270, blocked: ['4,3', '4,4'] },
+  ])('rotates a 2x1 obstacle footprint and origin by $rotation degrees', ({ rotation, blocked }) => {
+    const furniture = [{ x: 4, y: 4, w: 2, h: 1, rotation }];
+
+    const grid = buildObstacleMap(9, 9, furniture);
+    const blockedNearFurniture: string[] = [];
+    for (let y = 2; y <= 6; y++) {
+      for (let x = 2; x <= 6; x++) {
+        if (grid[y][x]) blockedNearFurniture.push(`${x},${y}`);
+      }
+    }
+
+    expect(blockedNearFurniture).toEqual(blocked);
+  });
+});

--- a/src/game/Pathfinder.test.ts
+++ b/src/game/Pathfinder.test.ts
@@ -49,4 +49,16 @@ describe('Pathfinder', () => {
       { x: 4, y: 4, w: 2, h: 1, rotation: 45 },
     ])).toThrow(/quarter turn/i);
   });
+
+  it('routes a blocked same-tile origin to the nearest free ring', () => {
+    const grid = buildObstacleMap(9, 9, [
+      { x: 4, y: 4, w: 2, h: 1 },
+    ]);
+
+    const path = bfsPathfind(grid, { x: 4.2, y: 4.2 }, { x: 4.4, y: 4.4 }, 9, 9);
+
+    expect(path.length).toBeGreaterThan(0);
+    expect(path.every(({ x, y }) => !grid[y][x])).toBe(true);
+    expect(path.some(({ x, y }) => x === 4 && y === 4)).toBe(false);
+  });
 });

--- a/src/game/Pathfinder.test.ts
+++ b/src/game/Pathfinder.test.ts
@@ -43,4 +43,10 @@ describe('Pathfinder', () => {
 
     expect(blockedNearFurniture).toEqual(blocked);
   });
+
+  it('rejects obstacle rotations outside the validated quarter turns', () => {
+    expect(() => buildObstacleMap(9, 9, [
+      { x: 4, y: 4, w: 2, h: 1, rotation: 45 },
+    ])).toThrow(/quarter turn/i);
+  });
 });

--- a/src/game/Pathfinder.ts
+++ b/src/game/Pathfinder.ts
@@ -17,7 +17,7 @@ export interface Point {
 export function buildObstacleMap(
   gridW: number,
   gridH: number,
-  furniture: Array<{ x: number; y: number; w: number; h: number }>,
+  furniture: Array<{ x: number; y: number; w: number; h: number; rotation?: number }>,
   extraBlocked?: Set<string>,
 ): boolean[][] {
   const grid: boolean[][] = Array.from({ length: gridH }, () => Array(gridW).fill(false));
@@ -34,10 +34,28 @@ export function buildObstacleMap(
 
   // Block furniture tiles
   for (const item of furniture) {
-    for (let dy = 0; dy < item.h; dy++) {
-      for (let dx = 0; dx < item.w; dx++) {
-        const gx = item.x + dx;
-        const gy = item.y + dy;
+    const rotation = ((item.rotation ?? 0) % 360 + 360) % 360;
+    const swapsAxes = rotation === 90 || rotation === 270;
+    const footprintW = swapsAxes ? item.h : item.w;
+    const footprintH = swapsAxes ? item.w : item.h;
+    let originX = item.x;
+    let originY = item.y;
+
+    // Furniture is rendered around the centre of its anchor tile, so the
+    // obstacle origin must move around that same pivot on quarter turns.
+    if (rotation === 90) {
+      originX += 1 - item.h;
+    } else if (rotation === 180) {
+      originX += 1 - item.w;
+      originY += 1 - item.h;
+    } else if (rotation === 270) {
+      originY += 1 - item.w;
+    }
+
+    for (let dy = 0; dy < footprintH; dy++) {
+      for (let dx = 0; dx < footprintW; dx++) {
+        const gx = originX + dx;
+        const gy = originY + dy;
         if (gy >= 0 && gy < gridH && gx >= 0 && gx < gridW) {
           grid[gy][gx] = true;
         }
@@ -83,7 +101,7 @@ export function bfsPathfind(
 
   // Start is blocked — try adjacent
   const starts = findNearestFree(obstacleGrid, sx, sy, gridW, gridH);
-  if (starts.length === 0) return [{ x: ex, y: ey }]; // fallback
+  if (starts.length === 0) return [];
 
   // BFS from all start positions
   const visited = new Set<string>();
@@ -133,7 +151,7 @@ export function bfsPathfind(
     }
   }
 
-  if (!found) return [{ x: ex, y: ey }]; // fallback: straight line
+  if (!found) return [];
 
   // Reconstruct path
   const path: Point[] = [];
@@ -144,13 +162,14 @@ export function bfsPathfind(
     key = parent.get(key) ?? null;
   }
 
-  // Remove the start position itself
-  if (path.length > 0) path.shift();
+  // Remove the actual start position, but retain a nearest-free tile used to
+  // escape when the rounded character origin itself is blocked.
+  if (path[0]?.x === sx && path[0]?.y === sy) path.shift();
 
   return path;
 }
 
-/** Find free tiles adjacent to a blocked position */
+/** Find all free tiles on the nearest Chebyshev-distance ring. */
 function findNearestFree(
   grid: boolean[][],
   x: number,
@@ -163,21 +182,20 @@ function findNearestFree(
     return [{ x, y }];
   }
 
-  // Search in expanding rings
-  const dirs = [
-    { x: 0, y: -1 }, { x: 0, y: 1 },
-    { x: -1, y: 0 }, { x: 1, y: 0 },
-    { x: -1, y: -1 }, { x: 1, y: -1 },
-    { x: -1, y: 1 }, { x: 1, y: 1 },
-  ];
+  for (let radius = 1; radius <= Math.max(w, h); radius++) {
+    const results: Point[] = [];
+    for (let dy = -radius; dy <= radius; dy++) {
+      for (let dx = -radius; dx <= radius; dx++) {
+        if (Math.max(Math.abs(dx), Math.abs(dy)) !== radius) continue;
 
-  const results: Point[] = [];
-  for (const d of dirs) {
-    const nx = x + d.x;
-    const ny = y + d.y;
-    if (ny >= 0 && ny < h && nx >= 0 && nx < w && !grid[ny][nx]) {
-      results.push({ x: nx, y: ny });
+        const nx = x + dx;
+        const ny = y + dy;
+        if (ny >= 0 && ny < h && nx >= 0 && nx < w && !grid[ny][nx]) {
+          results.push({ x: nx, y: ny });
+        }
+      }
     }
+    if (results.length > 0) return results;
   }
-  return results;
+  return [];
 }

--- a/src/game/Pathfinder.ts
+++ b/src/game/Pathfinder.ts
@@ -34,7 +34,11 @@ export function buildObstacleMap(
 
   // Block furniture tiles
   for (const item of furniture) {
-    const rotation = ((item.rotation ?? 0) % 360 + 360) % 360;
+    const rawRotation = item.rotation ?? 0;
+    if (rawRotation % 90 !== 0) {
+      throw new RangeError('Furniture rotation must be a quarter turn');
+    }
+    const rotation = ((rawRotation % 360) + 360) % 360;
     const swapsAxes = rotation === 90 || rotation === 270;
     const footprintW = swapsAxes ? item.h : item.w;
     const footprintH = swapsAxes ? item.w : item.h;

--- a/src/game/Pathfinder.ts
+++ b/src/game/Pathfinder.ts
@@ -96,8 +96,9 @@ export function bfsPathfind(
   const ex = Math.round(end.x);
   const ey = Math.round(end.y);
 
-  // Same tile — no path needed
-  if (sx === ex && sy === ey) return [];
+  // Same free tile — no path needed. A blocked shared tile still needs
+  // nearest-free resolution so we do not treat occupancy as a free gap close.
+  if (sx === ex && sy === ey && !obstacleGrid[sy]?.[sx]) return [];
 
   // End is blocked — try adjacent tiles
   const targets = findNearestFree(obstacleGrid, ex, ey, gridW, gridH);

--- a/src/game/Pathfinder.ts
+++ b/src/game/Pathfinder.ts
@@ -188,16 +188,21 @@ function findNearestFree(
 
   for (let radius = 1; radius <= Math.max(w, h); radius++) {
     const results: Point[] = [];
-    for (let dy = -radius; dy <= radius; dy++) {
-      for (let dx = -radius; dx <= radius; dx++) {
-        if (Math.max(Math.abs(dx), Math.abs(dy)) !== radius) continue;
-
-        const nx = x + dx;
-        const ny = y + dy;
-        if (ny >= 0 && ny < h && nx >= 0 && nx < w && !grid[ny][nx]) {
-          results.push({ x: nx, y: ny });
-        }
+    const tryCell = (dx: number, dy: number) => {
+      const nx = x + dx;
+      const ny = y + dy;
+      if (ny >= 0 && ny < h && nx >= 0 && nx < w && !grid[ny][nx]) {
+        results.push({ x: nx, y: ny });
       }
+    };
+    // Perimeter only: top/bottom include the corners, left/right skip them.
+    for (let dx = -radius; dx <= radius; dx++) {
+      tryCell(dx, -radius);
+      tryCell(dx, radius);
+    }
+    for (let dy = -radius + 1; dy <= radius - 1; dy++) {
+      tryCell(-radius, dy);
+      tryCell(radius, dy);
     }
     if (results.length > 0) return results;
   }


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
## Summary

This PR makes character pathfinding consistent with the visual reality of rotated furniture, ensuring agents navigate around obstacles instead of clipping through them and stop gracefully when a destination is unreachable.

### Functional changes

1. **Obstacle footprints honor furniture rotation**
   `buildObstacleMap` now accepts a `rotation` field on each furniture rect. Quarter turns (90/180/270) swap the footprint's width and height and shift the origin around the anchor tile's center, matching how the renderer positions the sprite. The GameEngine now forwards `rotation` when constructing obstacle rectangles.

2. **Expanded-ring search replaces 8-neighbor fallback**
   `findNearestFree` now expands Chebyshev rings outward from a blocked tile until at least one free tile is found, instead of only checking the eight immediate neighbors. This lets both `bfsPathfind` and the movement loop reach a destination near an obstacle rather than crossing it.

3. **Unreachable destinations are reported, not faked**
   When no path exists, `bfsPathfind` returns an empty array instead of a single tile pointing at the original target. The GameEngine now updates the character's `targetX`/`targetY` to the final reachable tile of the BFS path, and the movement loop clears the target (rather than walking straight through furniture) when the path is empty.

4. **Sub-tile gap cleanup**
   The movement loop now gently closes the final sub-tile distance after consuming the last waypoint, preventing characters from stalling just short of their destination.

5. **Nearest-free bridge tile is preserved**
   `bfsPathfind` retains the first path step when the rounded character origin needed a nearest-free bridge cell, so the character correctly walks that first step instead of teleporting past it.

### Testing

- 7 new failing tests in the RED phase cover expanded-ring search, rotation-origin shifts, wall-crossing prevention, blocked-endpoint reconciliation, and sub-tile arrival.
- A new `Pathfinder.test.ts` suite exercises `bfsPathfind` and `buildObstacleMap` directly, including a parametrized rotation check covering 0/90/180/270 degrees.
- New GameEngine integration tests assert that characters avoid rotated obstacle tiles, stop at the expanded-ring destination outside a box of furniture, and don't cross a solid wall when no path exists.
- Verification: 20 focused tests pass, 381/381 full + coverage tests pass (Pathfinder 94.56% lines / 80.26% branches), `npm run typecheck`, `npm run build`, and `npm audit --omit=dev` (0 vulnerabilities) all clean.

Fixes #160.

---

# fix(game): respect rotation and obstacles in pathfinding

## Summary

This PR hardens furniture placement and pathfinding around obstacles, ensuring that the engine correctly respects rotated furniture footprints, validates rotation inputs, and handles the edge case where a character's target lies within the same tile.

## Changes

### Furniture rotation validation (`src/game/Pathfinder.ts`)
- **Rotation validation**: `buildObstacleMap` now rejects furniture rotations that are not multiples of 90 degrees with a clear `RangeError`. This prevents subtle foot-print miscalculations caused by unsupported intermediate angles.

### Pathfinding refinement (`src/game/Pathfinder.ts`)
- **`findNearestFree` perimeter scan**: Replaced the nested-double-loop Chebyshev-distance scan (which re-evaluated interior cells at every radius) with a per-radius perimeter walk. Top/bottom rows include both corners; left/right columns skip them. This keeps the existing expansion order while avoiding redundant work.

### Movement step closure (`src/game/GameEngine.ts`)
- **Sub-tile gap closure**: Added a check for whether the character's target rounds to the same tile as the current position. When the BFS path is empty but the character is still short of its in-tile target, the movement loop now closes that safe sub-tile gap rather than stalling.

### Layout immutability (`src/game/GameEngine.ts`)
- **`setLayout` defensive copy**: The engine now copies incoming furniture objects before storing them, so downstream edits (such as drag or rotate) no longer mutate the caller's array or its entries.

## Tests

- **`Pathfinder.test.ts`**: Added a test asserting that rotations outside quarter turns are rejected.
- **`GameEngine.integration.test.ts`**:
  - The drag/rotate integration test now freezes the caller-supplied layout array and its items, then asserts the original entries remain untouched after drag and rotate operations.
  - Added an obstacle-aware movement test verifying that a character placed within the same tile as its target still closes the remaining sub-tile gap without requiring waypoints.

---

### Summary

This PR fixes a pathfinding bug where characters could attempt to "close the gap" into a sub-tile target that shares an occupied tile with an obstacle. The fix ensures the pathfinder treats blocked shared tiles as obstacles (routing around them via the nearest free tile) and that the game engine does not allow final-gap movement into a blocked tile.

### Changes

**Pathfinder (`src/game/Pathfinder.ts`)**
- Updated the early-exit condition in `bfsPathfind` so that when the start and end tiles are the same, but that tile is blocked by an obstacle, the function does not short-circuit. Instead, it falls through to the nearest-free-target resolution, producing a path through adjacent free tiles.

**Pathfinder tests (`src/game/Pathfinder.test.ts`)**
- Added a test verifying that, given a 2-wide horizontal obstacle starting at `(4,4)`, a path from `(4.2, 4.2)` to `(4.4, 4.4)` is generated, that all resulting waypoints are free, and that no waypoint lands inside the blocked tile at `(4, 4)`.

**GameEngine (`src/game/GameEngine.ts`)**
- Tightened the condition that permits the character to close the remaining sub-tile gap to its target. The engine now only closes the gap when:
  - There are remaining waypoints to consume, OR
  - The target shares the character's rounded tile AND that tile is not blocked by an obstacle.
- This prevents characters from continuing a final-gap step straight into an obstacle when they happen to be on the same tile as a blocked tile.

**GameEngine integration test (`src/game/GameEngine.integration.test.ts`)**
- Added a regression test that places a desk so it blocks the walker's target tile, instructs the walker to type, and asserts that:
  - No path waypoint enters the blocked tile.
  - The final destination is on a free tile.
  - After simulation steps, the character reaches the free destination without ever rounding into the blocked tile.

### Impact
Characters now correctly avoid obstacles even when their high-level target coordinate rounds to the same tile as the obstacle, rather than walking into or stopping on the blocked tile. This eliminates a pathfinding edge case where the obstacle-grid check was not honored during same-tile gap closure.
<!-- kody-pr-summary:end -->

## Summary by Sourcery

Make character movement respect rotated furniture and stop safely when destinations cannot be reached.

Bug Fixes:
- Prevent characters from clipping through rotated or impassable furniture by aligning obstacle footprints with rendered rotations and cancelling unreachable movement targets.

Enhancements:
- Improve pathfinding by searching expanding free-tile rings, preserving bridge steps from blocked origins, and safely closing sub-tile gaps on reachable destinations.
- Defensively copy layouts before storing them and validate furniture rotations to supported quarter turns.

Tests:
- Add Pathfinder unit tests and GameEngine integration coverage for rotated obstacles, expanded-ring destinations, blocked origins, solid walls, and safe sub-tile arrival.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Character movement now accounts for furniture rotation when navigating around obstacles.
  - Characters route toward the nearest reachable destination when the requested tile is blocked.
  - Movement avoids passing through solid walls or taking unsafe straight-line shortcuts.
  - Characters complete short-distance and same-tile movements more reliably.
  - Unreachable destinations are canceled instead of leaving characters attempting an invalid route.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->