### PR TITLE
fix(server): harden ingest child and persistence

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,7 +43,7 @@ npm start                                # production build; build first
 
 - `DATA_DIR` defaults to `join(__dirname, "data")`, so dev writes under `server/data/` and standalone compiled startup writes under `dist/server/server/data/`; do not assume repo-root `data/`. Docker sets `DATA_DIR=/app/data`.
 - Use `OPENCLAW_BIN` for the CLI path. The `OPENCLAW_CLI` name still shown in README is stale.
-- Layout IDs must pass `/^[a-zA-Z0-9_-]+$/`, max 64 chars; `default` cannot be deleted.
+- Layout IDs must pass `/^[a-zA-Z0-9_-]+$/`, max 64 chars, and `${id}.json` must pass `isSafePersistedFilename` (Windows reserved device names such as `con`/`nul`/`com1` are rejected at the ID boundary); `default` cannot be deleted.
 - Layout writes use optimistic concurrency via `baseUpdatedAt`. The client refreshes revisions and retries `409`/server failures with bounded backoff; do not replace newer local edits with stale save responses.
 - Programmatic load/create/save-response changes must go through `setActiveLayoutProgrammatic()` so `skipAutoSaveRef` suppresses stale auto-saves. Saves are serialized through `savePromiseRef`; dirty furniture changes debounce for 2 seconds.
 - `PixelOffice` re-syncs `GameEngine` through serialized `furnitureKey` and `seatsKey` dependencies. If the engine starts reading another `PlacedFurniture` field, include it in `furnitureKey`.

--- a/README.md
+++ b/README.md
@@ -220,11 +220,15 @@ Furniture uses per-type directories with `manifest.json` for dimensions and rota
 | `OPENCLAW_AGENTS_DIR` | `~/.openclaw/agents` | Path to agent session transcripts |
 | `DATA_DIR` | `./data` | Persistence directory for preferences and layouts |
 
+Agent preferences and layouts are written through a flushed same-directory temporary file, atomically renamed into place, and followed by a parent-directory sync on POSIX. A failure before replacement therefore leaves the previous JSON file intact instead of exposing a truncated target.
+
 ### Agent data-source modes
 
 The server follows a finite-state machine and the single-writer principle: CLI polling and ingest writes are never active at the same time. `cli` always keeps CLI polling active, and `ingest` starts ingest-only without polling. Ingest mode requires `INGEST_API_TOKEN`. Configuring a token does not enable pushes in explicit `cli` mode; use `ingest` or `auto` when collector delivery should own agent state.
 
 `auto` starts with CLI polling. When an ingest token is configured and CLI execution fails specifically because `OPENCLAW_BIN` is missing (`ENOENT` or `ENOTDIR`), the server makes an at-most-once, sticky transition to ingest-only. This hysteresis prevents later polling from taking ownership back; returning to CLI ownership after fallback requires restarting the server once the executable is available. Transient failures—including non-zero exits, timeouts, permission errors, malformed output, and unknown errors—preserve the previous snapshot and do not switch modes. Without an ingest token, `auto` remains in CLI mode even when the executable is missing.
+
+CLI polling inherits the server environment except for `INGEST_API_TOKEN`, which is removed before spawning `OPENCLAW_BIN` so the ingest bearer token is not exposed to the child process tree.
 
 While CLI polling owns agent state, authenticated ingest requests are rejected with `409 Conflict` before rate limiting or payload validation. `/api/status` reports `dataSourceConfig`, `dataSourceEffective`, `dataSourceTransitioned`, `cliPolling`, and `lastIngestAt`.
 

--- a/server/childProcess.test.ts
+++ b/server/childProcess.test.ts
@@ -37,4 +37,21 @@ describe("CLI child-process environment", () => {
     expect(execFileStub).toHaveBeenCalledOnce();
     expect(process.env.INGEST_API_TOKEN).toBe("must-not-reach-child");
   });
+
+  it("removes differently-cased ingest token keys from the CLI environment", async () => {
+    vi.stubEnv("Ingest_Api_Token", "mixed-case-secret");
+    const execFileStub = vi.fn((...args: unknown[]) => {
+      const options = args[2] as { env: NodeJS.ProcessEnv };
+      expect(
+        Object.keys(options.env).some(
+          key => key.toUpperCase() === "INGEST_API_TOKEN",
+        ),
+      ).toBe(false);
+      const callback = args[3] as (error: null, stdout: string, stderr: string) => void;
+      callback(null, '{"sessions":[],"count":0}', "");
+    });
+
+    await expect(pollSessions(execFileStub as unknown as typeof execFile))
+      .resolves.toMatchObject({ sessions: [], count: 0 });
+  });
 });

--- a/server/childProcess.test.ts
+++ b/server/childProcess.test.ts
@@ -1,0 +1,40 @@
+import type { execFile } from "node:child_process";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+
+describe("CLI child-process environment", () => {
+  let io: typeof import("./index").io | undefined;
+  let pollSessions: typeof import("./index").pollSessions;
+
+  beforeAll(async () => {
+    vi.stubEnv("DATA_SOURCE", "ingest");
+    vi.stubEnv("INGEST_API_TOKEN", "must-not-reach-child");
+    vi.stubEnv("PIXEL_CHILD_ENV_SENTINEL", "preserved");
+    vi.resetModules();
+    const serverModule = await import("./index");
+    io = serverModule.io;
+    pollSessions = serverModule.pollSessions;
+  });
+
+  afterAll(() => {
+    io?.close();
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+
+  it("does not pass INGEST_API_TOKEN to the OpenClaw CLI while preserving unrelated variables", async () => {
+    const execFileStub = vi.fn((...args: unknown[]) => {
+      const options = args[2] as { env?: NodeJS.ProcessEnv };
+      const callback = args[3] as (error: null, stdout: string, stderr: string) => void;
+
+      expect(options.env).not.toHaveProperty("INGEST_API_TOKEN");
+      expect(options.env).toMatchObject({ PIXEL_CHILD_ENV_SENTINEL: "preserved" });
+      callback(null, JSON.stringify({ sessions: [], count: 0 }), "");
+      return {};
+    });
+
+    await expect(pollSessions(execFileStub as unknown as typeof execFile))
+      .resolves.toEqual({ sessions: [], count: 0 });
+    expect(execFileStub).toHaveBeenCalledOnce();
+    expect(process.env.INGEST_API_TOKEN).toBe("must-not-reach-child");
+  });
+});

--- a/server/childProcess.test.ts
+++ b/server/childProcess.test.ts
@@ -23,11 +23,12 @@ describe("CLI child-process environment", () => {
 
   it("does not pass INGEST_API_TOKEN to the OpenClaw CLI while preserving unrelated variables", async () => {
     const execFileStub = vi.fn((...args: unknown[]) => {
-      const options = args[2] as { env?: NodeJS.ProcessEnv };
+      const options = args[2] as { env?: NodeJS.ProcessEnv; timeout?: number; maxBuffer?: number };
       const callback = args[3] as (error: null, stdout: string, stderr: string) => void;
 
       expect(options.env).not.toHaveProperty("INGEST_API_TOKEN");
       expect(options.env).toMatchObject({ PIXEL_CHILD_ENV_SENTINEL: "preserved" });
+      expect(options).toMatchObject({ timeout: 10_000, maxBuffer: 10 * 1024 * 1024 });
       callback(null, JSON.stringify({ sessions: [], count: 0 }), "");
       return {};
     });

--- a/server/index.ts
+++ b/server/index.ts
@@ -12,7 +12,7 @@ import express from "express";
 import helmet from "helmet";
 import { createServer } from "http";
 import { Server as SocketIOServer } from "socket.io";
-import { readFileSync, writeFileSync, existsSync, mkdirSync, readdirSync, unlinkSync, createReadStream } from "node:fs";
+import { readFileSync, existsSync, mkdirSync, readdirSync, unlinkSync, createReadStream } from "node:fs";
 import { stat as statAsync } from "node:fs/promises";
 import { createHmac, randomUUID, timingSafeEqual } from "node:crypto";
 import { join, resolve } from "node:path";
@@ -38,6 +38,7 @@ import {
 } from "./ingestSessions";
 import { isValidLayoutId } from "./layouts";
 import { logger } from "./logger";
+import { atomicWriteFileSync } from "./persistence";
 import { parseLayoutMutationBody, parseOfficeLayoutDoc, parsePersistedPrefs, parseRecipe, parseSpriteBody, parseTagsBody, parseToggleBody, type OfficeLayoutDoc, type PersistedPrefs } from "./validation";
 import { ALL_TAGS, TAG_COLORS, DEFAULT_ROOMS, resolveRoomByTags, type AgentState, type AgentActivity, type SubAgentInfo, type TickerMessage, type Room, type AgentTag } from "../shared/types";
 const app = express();
@@ -288,7 +289,7 @@ function savePersistedPrefs() {
       prefs[id] = { pixelEnabled: agent.pixelEnabled, characterSpriteId: agent.characterSpriteId, tags: agent.tags, recipe: agent.recipe };
     }
     mkdirSync(DATA_DIR, { recursive: true });
-    writeFileSync(PERSIST_PATH, JSON.stringify(prefs, null, 2));
+    atomicWriteFileSync(PERSIST_PATH, JSON.stringify(prefs, null, 2));
   } catch (err) {
     logger.error({ err, subsystem: "persist" }, "failed to save prefs");
   }
@@ -336,7 +337,7 @@ interface CliSessionsResult {
  * Uses `openclaw sessions --all-agents --json --active <minutes>` to get
  * recently-active sessions, then maps them to agent states.
  */
-function pollSessions(): Promise<CliSessionsResult> {
+export function pollSessions(runExecFile: typeof execFile = execFile): Promise<CliSessionsResult> {
   return new Promise((resolve) => {
     const args = [
       "sessions",
@@ -345,7 +346,10 @@ function pollSessions(): Promise<CliSessionsResult> {
       "--active", String(ACTIVE_THRESHOLD_MIN),
     ];
 
-    execFile(OPENCLAW_BIN, args, { timeout: 10000 }, (err, stdout, stderr) => {
+    const childEnv = { ...process.env };
+    delete childEnv.INGEST_API_TOKEN;
+
+    runExecFile(OPENCLAW_BIN, args, { timeout: 10000, env: childEnv }, (err, stdout, stderr) => {
       if (err) {
         const cliFailureKind = classifyCliExecError(err);
         logger.error({ err, subsystem: "poll" }, "cli error");
@@ -1224,7 +1228,7 @@ function saveLayout(layout: OfficeLayoutDoc): void {
   layout.updatedAt = Date.now();
   const validated = parseOfficeLayoutDoc(layout);
   if (!validated) throw new Error(`Invalid layout document: ${layout.id}`);
-  writeFileSync(join(LAYOUTS_DIR, `${validated.id}.json`), JSON.stringify(validated, null, 2));
+  atomicWriteFileSync(join(LAYOUTS_DIR, `${validated.id}.json`), JSON.stringify(validated, null, 2));
 }
 
 function deleteLayout(id: string): boolean {
@@ -1516,4 +1520,3 @@ if (require.main === module) {
 }
 
 export { app, server, io, startServer };
-

--- a/server/index.ts
+++ b/server/index.ts
@@ -15,7 +15,7 @@ import { Server as SocketIOServer } from "socket.io";
 import { readFileSync, existsSync, mkdirSync, readdirSync, unlinkSync, createReadStream } from "node:fs";
 import { stat as statAsync } from "node:fs/promises";
 import { createHmac, randomUUID, timingSafeEqual } from "node:crypto";
-import { join, resolve } from "node:path";
+import { basename, dirname, join, resolve } from "node:path";
 import { createInterface } from "node:readline";
 import { applyAgentSnapshot } from "./agentSnapshots";
 import { correlationMiddleware, httpRequestLogMiddleware } from "./correlation";
@@ -289,7 +289,11 @@ function savePersistedPrefs() {
       prefs[id] = { pixelEnabled: agent.pixelEnabled, characterSpriteId: agent.characterSpriteId, tags: agent.tags, recipe: agent.recipe };
     }
     mkdirSync(DATA_DIR, { recursive: true });
-    atomicWriteFileSync(PERSIST_PATH, JSON.stringify(prefs, null, 2));
+    atomicWriteFileSync(
+      dirname(PERSIST_PATH),
+      basename(PERSIST_PATH),
+      JSON.stringify(prefs, null, 2),
+    );
   } catch (err) {
     logger.error({ err, subsystem: "persist" }, "failed to save prefs");
   }
@@ -346,8 +350,14 @@ export function pollSessions(runExecFile: typeof execFile = execFile): Promise<C
       "--active", String(ACTIVE_THRESHOLD_MIN),
     ];
 
-    const childEnv = { ...process.env };
-    delete childEnv.INGEST_API_TOKEN;
+    // Environment keys are case-insensitive on Windows. Filtering entries
+    // avoids leaking a differently-cased spelling after spreading process.env
+    // into an ordinary case-sensitive object.
+    const childEnv = Object.fromEntries(
+      Object.entries(process.env).filter(
+        ([key]) => key.toUpperCase() !== "INGEST_API_TOKEN",
+      ),
+    );
 
     runExecFile(OPENCLAW_BIN, args, { timeout: 10000, env: childEnv }, (err, stdout, stderr) => {
       if (err) {
@@ -1228,7 +1238,12 @@ function saveLayout(layout: OfficeLayoutDoc): void {
   layout.updatedAt = Date.now();
   const validated = parseOfficeLayoutDoc(layout);
   if (!validated) throw new Error(`Invalid layout document: ${layout.id}`);
-  atomicWriteFileSync(join(LAYOUTS_DIR, `${validated.id}.json`), JSON.stringify(validated, null, 2));
+  const layoutPath = join(LAYOUTS_DIR, `${validated.id}.json`);
+  atomicWriteFileSync(
+    dirname(layoutPath),
+    basename(layoutPath),
+    JSON.stringify(validated, null, 2),
+  );
 }
 
 function deleteLayout(id: string): boolean {

--- a/server/layouts.test.ts
+++ b/server/layouts.test.ts
@@ -24,4 +24,16 @@ describe("isValidLayoutId", () => {
     expect(isValidLayoutId("x".repeat(64))).toBe(true);
     expect(isValidLayoutId("x".repeat(65))).toBe(false);
   });
+
+  it("accepts leading underscore and hyphen prefixes that the ID regex allows", () => {
+    expect(isValidLayoutId("_foo")).toBe(true);
+    expect(isValidLayoutId("-bar")).toBe(true);
+  });
+
+  it("rejects Windows reserved device names so persistence cannot 500 after a 400-eligible ID", () => {
+    expect(isValidLayoutId("con")).toBe(false);
+    expect(isValidLayoutId("nul")).toBe(false);
+    expect(isValidLayoutId("COM1")).toBe(false);
+    expect(isValidLayoutId("aux")).toBe(false);
+  });
 });

--- a/server/layouts.ts
+++ b/server/layouts.ts
@@ -1,4 +1,9 @@
+import { isSafePersistedFilename } from "./persistence";
+
 /** Validate layout ID to prevent path traversal attacks. */
 export function isValidLayoutId(id: unknown): boolean {
-  return typeof id === "string" && /^[a-zA-Z0-9_-]+$/.test(id) && id.length <= 64;
+  return typeof id === "string"
+    && /^[a-zA-Z0-9_-]+$/.test(id)
+    && id.length <= 64
+    && isSafePersistedFilename(`${id}.json`);
 }

--- a/server/persistence.http.test.ts
+++ b/server/persistence.http.test.ts
@@ -1,0 +1,84 @@
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { Express } from "express";
+import type { Server as SocketIOServer } from "socket.io";
+import request from "supertest";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("./persistence", async () => {
+  const actual = await vi.importActual<typeof import("./persistence")>("./persistence");
+  return {
+    ...actual,
+    atomicWriteFileSync: vi.fn(actual.atomicWriteFileSync),
+  };
+});
+
+import { atomicWriteFileSync } from "./persistence";
+
+describe("atomic server persistence call paths", () => {
+  let app: Express;
+  let io: SocketIOServer;
+  let dataDir: string;
+  const appOrigin = "https://pixel.test";
+
+  beforeAll(async () => {
+    dataDir = mkdtempSync(join(tmpdir(), "pixel-agents-persistence-http-"));
+    vi.stubEnv("DATA_DIR", dataDir);
+    vi.stubEnv("DATA_SOURCE", "ingest");
+    vi.stubEnv("INGEST_API_TOKEN", "test-secret");
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("CORS_ORIGIN", appOrigin);
+    vi.resetModules();
+
+    const serverModule = await import("./index");
+    app = serverModule.app;
+    io = serverModule.io;
+  });
+
+  beforeEach(() => {
+    vi.mocked(atomicWriteFileSync).mockClear();
+  });
+
+  afterAll(() => {
+    io.close();
+    rmSync(dataDir, { recursive: true, force: true });
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+
+  it("routes agent preference writes through the atomic replacement helper", async () => {
+    await request(app)
+      .post("/api/agents/main/toggle")
+      .set("Origin", appOrigin)
+      .send({ enabled: false })
+      .expect(200);
+
+    const target = join(dataDir, "agent-prefs.json");
+    expect(atomicWriteFileSync).toHaveBeenCalledWith(target, expect.any(String));
+    expect(JSON.parse(readFileSync(target, "utf8"))).toMatchObject({
+      main: { pixelEnabled: false },
+    });
+  });
+
+  it("routes layout writes through the atomic replacement helper", async () => {
+    await request(app)
+      .put("/api/layouts/atomic-route")
+      .set("Origin", appOrigin)
+      .send({
+        name: "Atomic Route",
+        width: 24,
+        height: 16,
+        furniture: [],
+        seats: {},
+      })
+      .expect(200);
+
+    const target = join(dataDir, "layouts", "atomic-route.json");
+    expect(atomicWriteFileSync).toHaveBeenCalledWith(target, expect.any(String));
+    expect(JSON.parse(readFileSync(target, "utf8"))).toMatchObject({
+      id: "atomic-route",
+      name: "Atomic Route",
+    });
+  });
+});

--- a/server/persistence.http.test.ts
+++ b/server/persistence.http.test.ts
@@ -55,7 +55,11 @@ describe("atomic server persistence call paths", () => {
       .expect(200);
 
     const target = join(dataDir, "agent-prefs.json");
-    expect(atomicWriteFileSync).toHaveBeenCalledWith(target, expect.any(String));
+    expect(atomicWriteFileSync).toHaveBeenCalledWith(
+      dataDir,
+      "agent-prefs.json",
+      expect.any(String),
+    );
     expect(JSON.parse(readFileSync(target, "utf8"))).toMatchObject({
       main: { pixelEnabled: false },
     });
@@ -74,11 +78,48 @@ describe("atomic server persistence call paths", () => {
       })
       .expect(200);
 
-    const target = join(dataDir, "layouts", "atomic-route.json");
-    expect(atomicWriteFileSync).toHaveBeenCalledWith(target, expect.any(String));
+    const layoutsDir = join(dataDir, "layouts");
+    const target = join(layoutsDir, "atomic-route.json");
+    expect(atomicWriteFileSync).toHaveBeenCalledWith(
+      layoutsDir,
+      "atomic-route.json",
+      expect.any(String),
+    );
     expect(JSON.parse(readFileSync(target, "utf8"))).toMatchObject({
       id: "atomic-route",
       name: "Atomic Route",
     });
+  });
+
+  it("rejects an encoded traversal layout path before persistence", async () => {
+    await request(app)
+      .put("/api/layouts/%2e%2e%2fescape")
+      .set("Origin", appOrigin)
+      .send({
+        name: "Traversal",
+        width: 24,
+        height: 16,
+        furniture: [],
+        seats: {},
+      })
+      .expect(400);
+
+    expect(atomicWriteFileSync).not.toHaveBeenCalled();
+  });
+
+  it("rejects an invalid layout ID at the route boundary before persistence", async () => {
+    await request(app)
+      .put("/api/layouts/bad.id")
+      .set("Origin", appOrigin)
+      .send({
+        name: "Invalid ID",
+        width: 24,
+        height: 16,
+        furniture: [],
+        seats: {},
+      })
+      .expect(400);
+
+    expect(atomicWriteFileSync).not.toHaveBeenCalled();
   });
 });

--- a/server/persistence.http.test.ts
+++ b/server/persistence.http.test.ts
@@ -107,6 +107,42 @@ describe("atomic server persistence call paths", () => {
     expect(atomicWriteFileSync).not.toHaveBeenCalled();
   });
 
+  it("accepts a leading-underscore layout ID at the route boundary", async () => {
+    await request(app)
+      .put("/api/layouts/_foo")
+      .set("Origin", appOrigin)
+      .send({
+        name: "Underscore",
+        width: 24,
+        height: 16,
+        furniture: [],
+        seats: {},
+      })
+      .expect(200);
+
+    expect(atomicWriteFileSync).toHaveBeenCalledWith(
+      join(dataDir, "layouts"),
+      "_foo.json",
+      expect.any(String),
+    );
+  });
+
+  it("rejects a Windows reserved layout ID with 400 before persistence", async () => {
+    await request(app)
+      .put("/api/layouts/con")
+      .set("Origin", appOrigin)
+      .send({
+        name: "Reserved",
+        width: 24,
+        height: 16,
+        furniture: [],
+        seats: {},
+      })
+      .expect(400);
+
+    expect(atomicWriteFileSync).not.toHaveBeenCalled();
+  });
+
   it("rejects an invalid layout ID at the route boundary before persistence", async () => {
     await request(app)
       .put("/api/layouts/bad.id")

--- a/server/persistence.test.ts
+++ b/server/persistence.test.ts
@@ -1,11 +1,12 @@
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
   mkdtempSync,
   readFileSync,
   readdirSync,
+  renameSync,
   rmSync,
   writeFileSync,
 } from "node:fs";
@@ -26,10 +27,54 @@ describe("atomicWriteFileSync", () => {
     const target = join(directory, "agent-prefs.json");
     writeFileSync(target, "previous");
 
-    atomicWriteFileSync(target, "replacement");
+    atomicWriteFileSync(directory, "agent-prefs.json", "replacement");
 
     expect(readFileSync(target, "utf8")).toBe("replacement");
     expect(readdirSync(directory)).toEqual(["agent-prefs.json"]);
+  });
+
+  it("flushes the temporary file and syncs the directory after rename", () => {
+    const directory = mkdtempSync(join(tmpdir(), "pixel-agents-atomic-durability-"));
+    directories.push(directory);
+    const operations: string[] = [];
+    const writeFile = vi.fn<typeof writeFileSync>((path, contents, options) => {
+      operations.push("write");
+      writeFileSync(path, contents, options);
+    });
+    const renameFile = vi.fn<typeof import("node:fs").renameSync>((from, to) => {
+      operations.push("rename");
+      renameSync(from, to);
+    });
+    const openDirectory = vi.fn(() => {
+      operations.push("open-directory");
+      return 42;
+    });
+    const syncFile = vi.fn(() => operations.push("sync-directory"));
+    const closeFile = vi.fn(() => operations.push("close-directory"));
+
+    atomicWriteFileSync(directory, "durable.json", "contents", {
+      closeFile,
+      openDirectory,
+      renameFile,
+      syncFile,
+      writeFile,
+    });
+
+    expect(writeFile).toHaveBeenCalledWith(
+      expect.stringMatching(/\.tmp$/),
+      "contents",
+      { encoding: "utf8", flag: "wx", flush: true },
+    );
+    expect(openDirectory).toHaveBeenCalledWith(directory, "r");
+    expect(syncFile).toHaveBeenCalledWith(42);
+    expect(closeFile).toHaveBeenCalledWith(42);
+    expect(operations).toEqual([
+      "write",
+      "rename",
+      "open-directory",
+      "sync-directory",
+      "close-directory",
+    ]);
   });
 
   it("preserves the previous file and cleans up the temporary file when rename fails", () => {
@@ -41,10 +86,68 @@ describe("atomicWriteFileSync", () => {
       throw Object.assign(new Error("fault-injected rename failure"), { code: "EIO" });
     };
 
-    expect(() => atomicWriteFileSync(target, "replacement", { renameFile }))
+    expect(() => atomicWriteFileSync(directory, "default.json", "replacement", { renameFile }))
       .toThrow("fault-injected rename failure");
 
     expect(readFileSync(target, "utf8")).toBe("previous");
     expect(readdirSync(directory)).toEqual(["default.json"]);
+  });
+
+  it("preserves both operation and cleanup failures in an AggregateError", () => {
+    const directory = mkdtempSync(join(tmpdir(), "pixel-agents-atomic-aggregate-"));
+    directories.push(directory);
+    const renameError = new Error("fault-injected rename failure");
+    const cleanupError = new Error("fault-injected cleanup failure");
+
+    expect(() => atomicWriteFileSync(directory, "default.json", "replacement", {
+      renameFile: () => { throw renameError; },
+      unlinkFile: () => { throw cleanupError; },
+    })).toThrow(expect.objectContaining({
+      errors: [renameError, cleanupError],
+    }));
+  });
+
+  it("preserves simultaneous directory sync and close failures", () => {
+    const directory = mkdtempSync(join(tmpdir(), "pixel-agents-atomic-sync-close-"));
+    directories.push(directory);
+    const syncError = new Error("fault-injected sync failure");
+    const closeError = new Error("fault-injected close failure");
+
+    expect(() => atomicWriteFileSync(directory, "default.json", "replacement", {
+      openDirectory: () => 42,
+      syncFile: () => { throw syncError; },
+      closeFile: () => { throw closeError; },
+    })).toThrow(expect.objectContaining({
+      errors: [syncError, closeError],
+    }));
+  });
+
+  it.each([
+    "../escape.json",
+    "nested/escape.json",
+    "/absolute/escape.json",
+    "C:\\absolute\\escape.json",
+    "\\\\server\\share\\escape.json",
+    "nested\\escape.json",
+    "CON.json",
+    "nul.JSON",
+    "layout.",
+    "layout. ",
+  ])("rejects a filename outside the allowed directory: %s", (fileName) => {
+    const directory = mkdtempSync(join(tmpdir(), "pixel-agents-atomic-path-"));
+    directories.push(directory);
+    const writeFile = vi.fn<typeof writeFileSync>();
+    const renameFile = vi.fn();
+
+    expect(() => atomicWriteFileSync(
+      directory,
+      fileName,
+      "contents",
+      { writeFile, renameFile },
+    ))
+      .toThrow("Invalid persisted filename");
+    expect(writeFile).not.toHaveBeenCalled();
+    expect(renameFile).not.toHaveBeenCalled();
+    expect(readdirSync(directory)).toEqual([]);
   });
 });

--- a/server/persistence.test.ts
+++ b/server/persistence.test.ts
@@ -12,6 +12,8 @@ import {
 } from "node:fs";
 import { atomicWriteFileSync } from "./persistence";
 
+const itPosix = process.platform === "win32" ? it.skip : it;
+
 describe("atomicWriteFileSync", () => {
   const directories: string[] = [];
 
@@ -33,7 +35,7 @@ describe("atomicWriteFileSync", () => {
     expect(readdirSync(directory)).toEqual(["agent-prefs.json"]);
   });
 
-  it("flushes the temporary file and syncs the directory after rename", () => {
+  itPosix("flushes the temporary file and syncs the directory after rename", () => {
     const directory = mkdtempSync(join(tmpdir(), "pixel-agents-atomic-durability-"));
     directories.push(directory);
     const operations: string[] = [];
@@ -107,7 +109,22 @@ describe("atomicWriteFileSync", () => {
     }));
   });
 
-  it("preserves simultaneous directory sync and close failures", () => {
+  itPosix("keeps the replaced target when directory sync fails after rename", () => {
+    const directory = mkdtempSync(join(tmpdir(), "pixel-agents-atomic-sync-failure-"));
+    directories.push(directory);
+    const target = join(directory, "default.json");
+    writeFileSync(target, "previous");
+    const syncError = new Error("fault-injected sync failure");
+
+    expect(() => atomicWriteFileSync(directory, "default.json", "replacement", {
+      syncFile: () => { throw syncError; },
+    })).toThrow(syncError);
+
+    expect(readFileSync(target, "utf8")).toBe("replacement");
+    expect(readdirSync(directory)).toEqual(["default.json"]);
+  });
+
+  itPosix("preserves simultaneous directory sync and close failures", () => {
     const directory = mkdtempSync(join(tmpdir(), "pixel-agents-atomic-sync-close-"));
     directories.push(directory);
     const syncError = new Error("fault-injected sync failure");

--- a/server/persistence.test.ts
+++ b/server/persistence.test.ts
@@ -1,0 +1,50 @@
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { atomicWriteFileSync } from "./persistence";
+
+describe("atomicWriteFileSync", () => {
+  const directories: string[] = [];
+
+  afterEach(() => {
+    for (const directory of directories.splice(0)) {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  it("atomically replaces an existing persisted file without leaving a temporary file", () => {
+    const directory = mkdtempSync(join(tmpdir(), "pixel-agents-atomic-write-"));
+    directories.push(directory);
+    const target = join(directory, "agent-prefs.json");
+    writeFileSync(target, "previous");
+
+    atomicWriteFileSync(target, "replacement");
+
+    expect(readFileSync(target, "utf8")).toBe("replacement");
+    expect(readdirSync(directory)).toEqual(["agent-prefs.json"]);
+  });
+
+  it("preserves the previous file and cleans up the temporary file when rename fails", () => {
+    const directory = mkdtempSync(join(tmpdir(), "pixel-agents-atomic-failure-"));
+    directories.push(directory);
+    const target = join(directory, "default.json");
+    writeFileSync(target, "previous");
+    const renameFile = () => {
+      throw Object.assign(new Error("fault-injected rename failure"), { code: "EIO" });
+    };
+
+    expect(() => atomicWriteFileSync(target, "replacement", { renameFile }))
+      .toThrow("fault-injected rename failure");
+
+    expect(readFileSync(target, "utf8")).toBe("previous");
+    expect(readdirSync(directory)).toEqual(["default.json"]);
+  });
+});

--- a/server/persistence.test.ts
+++ b/server/persistence.test.ts
@@ -23,6 +23,17 @@ describe("atomicWriteFileSync", () => {
     }
   });
 
+  it("accepts layout-id leaves that start with underscore or hyphen", () => {
+    const directory = mkdtempSync(join(tmpdir(), "pixel-agents-atomic-prefix-"));
+    directories.push(directory);
+
+    atomicWriteFileSync(directory, "_foo.json", "underscore");
+    atomicWriteFileSync(directory, "-bar.json", "hyphen");
+
+    expect(readFileSync(join(directory, "_foo.json"), "utf8")).toBe("underscore");
+    expect(readFileSync(join(directory, "-bar.json"), "utf8")).toBe("hyphen");
+  });
+
   it("atomically replaces an existing persisted file without leaving a temporary file", () => {
     const directory = mkdtempSync(join(tmpdir(), "pixel-agents-atomic-write-"));
     directories.push(directory);

--- a/server/persistence.ts
+++ b/server/persistence.ts
@@ -7,7 +7,10 @@ import {
   writeFileSync,
 } from "node:fs";
 import { randomUUID } from "node:crypto";
-import { dirname } from "node:path";
+import { dirname, resolve } from "node:path";
+
+const SAFE_PERSISTED_FILENAME_RE = /^[a-zA-Z0-9][a-zA-Z0-9._-]{0,127}$/;
+const WINDOWS_RESERVED_BASENAME_RE = /^(?:con|prn|aux|nul|com[1-9]|lpt[1-9])(?:\.|$)/i;
 
 function isMissingFileError(error: unknown): boolean {
   return typeof error === "object"
@@ -17,8 +20,19 @@ function isMissingFileError(error: unknown): boolean {
 }
 
 type AtomicWriteOptions = Readonly<{
+  closeFile?: typeof closeSync;
+  openDirectory?: typeof openSync;
   renameFile?: typeof renameSync;
+  syncFile?: typeof fsyncSync;
+  unlinkFile?: typeof unlinkSync;
+  writeFile?: typeof writeFileSync;
 }>;
+
+function isSafePersistedFilename(fileName: string): boolean {
+  return SAFE_PERSISTED_FILENAME_RE.test(fileName)
+    && !fileName.endsWith(".")
+    && !WINDOWS_RESERVED_BASENAME_RE.test(fileName);
+}
 
 /**
  * Durably replace a file without exposing a partially written target.
@@ -28,16 +42,31 @@ type AtomicWriteOptions = Readonly<{
  * rename; syncing the parent directory then persists the directory entry.
  */
 export function atomicWriteFileSync(
-  filePath: string,
+  directoryPath: string,
+  fileName: string,
   contents: string,
   options: AtomicWriteOptions = {},
 ): void {
+  if (!isSafePersistedFilename(fileName)) {
+    throw new Error(`Invalid persisted filename: ${fileName}`);
+  }
+  const allowedDirectory = resolve(directoryPath);
+  const filePath = resolve(allowedDirectory, fileName);
+  if (dirname(filePath) !== allowedDirectory) {
+    throw new Error(`Persisted file escapes its allowed directory: ${fileName}`);
+  }
+
   const temporaryPath = `${filePath}.${process.pid}.${randomUUID()}.tmp`;
+  const closeFile = options.closeFile ?? closeSync;
+  const openDirectory = options.openDirectory ?? openSync;
   const renameFile = options.renameFile ?? renameSync;
+  const syncFile = options.syncFile ?? fsyncSync;
+  const unlinkFile = options.unlinkFile ?? unlinkSync;
+  const writeFile = options.writeFile ?? writeFileSync;
   let renamed = false;
 
   try {
-    writeFileSync(temporaryPath, contents, {
+    writeFile(temporaryPath, contents, {
       encoding: "utf8",
       flag: "wx",
       flush: true,
@@ -47,17 +76,30 @@ export function atomicWriteFileSync(
 
     // Windows does not support opening directories as file descriptors.
     if (process.platform !== "win32") {
-      const directoryFd = openSync(dirname(filePath), "r");
+      const directoryFd = openDirectory(allowedDirectory, "r");
+      let syncError: unknown;
       try {
-        fsyncSync(directoryFd);
-      } finally {
-        closeSync(directoryFd);
+        syncFile(directoryFd);
+      } catch (error) {
+        syncError = error;
       }
+      try {
+        closeFile(directoryFd);
+      } catch (closeError) {
+        if (syncError !== undefined) {
+          throw new AggregateError(
+            [syncError, closeError],
+            `Directory sync and close both failed for ${allowedDirectory}`,
+          );
+        }
+        throw closeError;
+      }
+      if (syncError !== undefined) throw syncError;
     }
   } catch (error) {
     if (!renamed) {
       try {
-        unlinkSync(temporaryPath);
+        unlinkFile(temporaryPath);
       } catch (cleanupError) {
         if (!isMissingFileError(cleanupError)) {
           throw new AggregateError(

--- a/server/persistence.ts
+++ b/server/persistence.ts
@@ -7,7 +7,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import { randomUUID } from "node:crypto";
-import { dirname, resolve } from "node:path";
+import { basename, dirname, resolve } from "node:path";
 
 const SAFE_PERSISTED_FILENAME_RE = /^[a-zA-Z0-9][a-zA-Z0-9._-]{0,127}$/;
 const WINDOWS_RESERVED_BASENAME_RE = /^(?:con|prn|aux|nul|com[1-9]|lpt[1-9])(?:\.|$)/i;
@@ -47,11 +47,15 @@ export function atomicWriteFileSync(
   contents: string,
   options: AtomicWriteOptions = {},
 ): void {
-  if (!isSafePersistedFilename(fileName)) {
+  // `basename` is both an executable containment boundary and a sanitizer
+  // recognized by static taint analysis. The equality check rejects any path
+  // syntax before the sanitized leaf reaches filesystem APIs.
+  const safeFileName = basename(fileName);
+  if (safeFileName !== fileName || !isSafePersistedFilename(safeFileName)) {
     throw new Error(`Invalid persisted filename: ${fileName}`);
   }
   const allowedDirectory = resolve(directoryPath);
-  const filePath = resolve(allowedDirectory, fileName);
+  const filePath = resolve(allowedDirectory, safeFileName);
   if (dirname(filePath) !== allowedDirectory) {
     throw new Error(`Persisted file escapes its allowed directory: ${fileName}`);
   }

--- a/server/persistence.ts
+++ b/server/persistence.ts
@@ -1,0 +1,72 @@
+import {
+  closeSync,
+  fsyncSync,
+  openSync,
+  renameSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { randomUUID } from "node:crypto";
+import { dirname } from "node:path";
+
+function isMissingFileError(error: unknown): boolean {
+  return typeof error === "object"
+    && error !== null
+    && "code" in error
+    && error.code === "ENOENT";
+}
+
+type AtomicWriteOptions = Readonly<{
+  renameFile?: typeof renameSync;
+}>;
+
+/**
+ * Durably replace a file without exposing a partially written target.
+ *
+ * The temporary file lives beside the target so rename remains atomic on
+ * POSIX filesystems. `flush` syncs the completed temporary file before the
+ * rename; syncing the parent directory then persists the directory entry.
+ */
+export function atomicWriteFileSync(
+  filePath: string,
+  contents: string,
+  options: AtomicWriteOptions = {},
+): void {
+  const temporaryPath = `${filePath}.${process.pid}.${randomUUID()}.tmp`;
+  const renameFile = options.renameFile ?? renameSync;
+  let renamed = false;
+
+  try {
+    writeFileSync(temporaryPath, contents, {
+      encoding: "utf8",
+      flag: "wx",
+      flush: true,
+    });
+    renameFile(temporaryPath, filePath);
+    renamed = true;
+
+    // Windows does not support opening directories as file descriptors.
+    if (process.platform !== "win32") {
+      const directoryFd = openSync(dirname(filePath), "r");
+      try {
+        fsyncSync(directoryFd);
+      } finally {
+        closeSync(directoryFd);
+      }
+    }
+  } catch (error) {
+    if (!renamed) {
+      try {
+        unlinkSync(temporaryPath);
+      } catch (cleanupError) {
+        if (!isMissingFileError(cleanupError)) {
+          throw new AggregateError(
+            [error, cleanupError],
+            `Atomic write and temporary-file cleanup failed for ${filePath}`,
+          );
+        }
+      }
+    }
+    throw error;
+  }
+}

--- a/server/persistence.ts
+++ b/server/persistence.ts
@@ -9,7 +9,9 @@ import {
 import { randomUUID } from "node:crypto";
 import { basename, dirname, resolve } from "node:path";
 
-const SAFE_PERSISTED_FILENAME_RE = /^[a-zA-Z0-9][a-zA-Z0-9._-]{0,127}$/;
+// First character may be `_` or `-` so layout IDs (`/^[a-zA-Z0-9_-]+$/`) remain
+// representable as `${id}.json` without a second, stricter leaf alphabet.
+const SAFE_PERSISTED_FILENAME_RE = /^[a-zA-Z0-9_-][a-zA-Z0-9._-]{0,127}$/;
 const WINDOWS_RESERVED_BASENAME_RE = /^(?:con|prn|aux|nul|com[1-9]|lpt[1-9])(?:\.|$)/i;
 
 function isMissingFileError(error: unknown): boolean {
@@ -28,7 +30,7 @@ type AtomicWriteOptions = Readonly<{
   writeFile?: typeof writeFileSync;
 }>;
 
-function isSafePersistedFilename(fileName: string): boolean {
+export function isSafePersistedFilename(fileName: string): boolean {
   return SAFE_PERSISTED_FILENAME_RE.test(fileName)
     && !fileName.endsWith(".")
     && !WINDOWS_RESERVED_BASENAME_RE.test(fileName);


### PR DESCRIPTION
## Summary

Addresses #157 items 1 and 3. Item 2 depends on PR #185; this PR deliberately has no auto-close keyword.

- scrub INGEST_API_TOKEN from the OpenClaw CLI child environment case-insensitively
- persist preferences and layouts via flushed exclusive temp files, atomic same-directory rename, and POSIX directory sync
- reject unsafe leaf names, Windows device names, canonicalization aliases, traversal, and nested paths before filesystem sinks
- preserve exact target semantics and aggregate simultaneous operation/cleanup failures
- update persistence documentation

## Verification

- focused hardening tests: 21/21
- full suite: 393/393
- coverage suite: 393/393
- typecheck: passed
- production build: passed
- production audit: 0 vulnerabilities
- runtime persistence smoke: passed on the original implementation commit
- privacy, staged-path, and secret scans: clean

## Dependency

Item 2, valid authenticated requests consuming the unauthenticated limiter, remains covered by PR #185. Do not close #157 until both PRs land.

## Summary by Sourcery

Harden CLI child-process isolation and server-side JSON persistence against secret leakage, unsafe paths, and durability failures.

Bug Fixes:
- Prevent ingest API tokens, including differently cased environment keys, from being inherited by spawned CLI processes.
- Harden preference and layout persistence against partial writes, unsafe filenames, traversal, aliases, and Windows-reserved device names.
- Preserve replacement and cleanup failures, including simultaneous directory sync and close errors, through aggregate error reporting.

Enhancements:
- Use durable same-directory atomic replacement for persisted JSON files, including temporary-file flushing and POSIX directory synchronization.
- Validate layout identifiers against the hardened persisted-filename rules before filesystem operations.

Documentation:
- Document durable persistence behavior and removal of the ingest token from CLI child environments.

Tests:
- Add coverage for child-process secret filtering, persistence call paths, filename and layout-ID validation, durable write ordering, replacement preservation, and aggregated failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security**
  - CLI-launched processes no longer receive `INGEST_API_TOKEN`, including case variations.
  - Persistence rejects unsafe filenames and path traversal attempts.
  - Layout identifiers reject reserved device names and other invalid values.

- **Reliability**
  - Agent preferences and layouts use atomic file replacement with improved durability.
  - Temporary files are cleaned up after failed writes.
  - Existing files are protected when persistence operations fail.

- **Documentation**
  - Added documentation covering atomic persistence, layout identifier requirements, and CLI environment sanitization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- kody-pr-summary:start -->
## PR description

Hardens session ingestion child processes and server-side persistence:

- Prevents the ingest API token from leaking to spawned CLI processes when the environment variable uses a different letter casing, which is especially relevant on Windows where environment keys are case-insensitive.
- Updates atomic persistence calls to pass a validated directory and filename separately.
- Restricts persisted filenames to a safe format, blocks path traversal and Windows-reserved names, and verifies that the resolved file remains in the allowed directory.
- Improves atomic-write durability by flushing temporary file contents and syncing the destination directory after rename.
- Preserves cleanup errors and simultaneous directory-sync/close errors in `AggregateError` responses when multiple operations fail.
- Adds coverage for mixed-case ingest token filtering, traversal and invalid layout IDs, filename validation, durable write ordering, and error aggregation.
- Confirms that agent preferences and validated layouts continue to use the hardened persistence path.

---

Harden the atomic persisted-file writer by stripping any path components from the supplied filename before it reaches filesystem APIs. `atomicWriteFileSync` now computes the basename and rejects the call if it differs from the input, and the same basename is used in the resolved path before the allowed-directory check. The relative-path test suite is updated to skip POSIX-only durability assertions on Windows, and a new test verifies that when a fault-injected directory sync fails after the rename completes, the target file is still preserved with the replacement contents.

---

## Summary

This PR hardens the server-side ingest path, layout persistence, and CLI child-process handling for issue #157.

### CLI child-process hardening
- Centralizes the OpenClaw CLI exec options (10s timeout, 10 MiB stdout cap) in `dataSource.ts` and reuses them from `pollSessions` and tests.
- Routes every CLI execution failure through a small `CliPollHealth` state machine: logs the first failure in full, suppresses repeated same-kind failures, and emits a periodic warning every 20 failed cycles (~1 minute at the default 3-second interval). A successful poll after failures logs a single recovery line.
- Reports the raw error object alongside classified failure kinds so operators can diagnose what the CLI actually did, instead of only the category.

### Auto-fallback hysteresis tightened
- Expands the operator-action-required failure set (still `auto`-only with an ingest token configured, still at-most-once and sticky) to cover path problems (`ENOENT`, `ENOTDIR`, `EISDIR`, `EACCES`, `EPERM`, `ENOEXEC`, `EFTYPE`, `ELOOP`, `ENAMETOOLONG`) and the shared 10 MiB `ERR_CHILD_PROCESS_STDIO_MAXBUFFER` ceiling.
- Keeps transient categories (`EAGAIN`, `EBUSY`, `EMFILE`, timeouts, malformed output, unknown errors) as snapshot-preserving only.

### Rate limiting
- Generalizes the sliding-window helper and gives 429 responses proper `Retry-After`, `X-RateLimit-Limit`, and `X-RateLimit-Remaining` headers.
- Adds two new per-IP buckets for non-ingest mutations: `PREFS_WRITE_RATE_LIMIT_MAX` (60/min) and `LAYOUT_WRITE_RATE_LIMIT_MAX` (90/min, sized with 3x headroom above the editor's 30/minute theoretical autosave ceiling).
- Hoists the `/api/ingest/agents` pre-auth throttle and the `/api` mutation guard ahead of `express.json()` so bounded-but-still-expensive JSON parsing cannot be used to amplify load. `/api` and `/socket.io/` are now explicitly exempt from the public SPA/static GET bucket.
- Parses every rate-limit max as a positive integer at startup; malformed or non-positive values fail fast instead of silently disabling protection.
- Exports `parseRateLimitMax`, `_resetRateLimitBuckets`, `apiWriteRateBuckets`, and helpers as part of the test surface.

### Layout persistence
- Introduces a 100-entry capacity for the layouts directory. `GET /api/layouts` reports `overCapacity` plus `layoutLimit`; legacy installs above the cap still show the first 100 layouts.
- Centralizes capacity counting via an `opendirSync` reader so every directory entry (including non-JSON files) consumes the budget, with the count decision and write running in the same event-loop turn.
- All write paths (default-layout bootstrap, PUT, POST) respond `507 Layout limit reached (100)` when full, and operators must delete before creating. README documents the limit and recovery steps.
- Path construction for layout files now flows through a schema-validated document; `isValidLayoutId` additionally rejects Windows reserved device names (`con`, `nul`, `COM1`, etc.) and accepts leading `_`/`-` prefixes that the ID regex permits.
- Exposes `isSafePersistedFilename` so `layouts.ts` and the persistence tests share the same leaf-name rule.

### Docs
- README updates cover the new env vars, the 100-layout capacity and recovery flow, the `/api` + `/socket.io/` exemptions from the public GET bucket, the expanded CLI fallback set, the new health-log behavior, and the rate-limit headers/validation rules.
- `useAgentStore` description now reflects the REST-fallback-then-Socket.IO behavior.

### Tests
- Updates `childProcess.test.ts` to pin the 10s/10 MiB exec options.
- Extends `persistence.test.ts` and `persistence.http.test.ts` with leading-underscore filenames and Windows reserved-name rejection at both the leaf and route boundaries.
- Extends `layouts.test.ts` with the same ID-prefix and reserved-name coverage.
<!-- kody-pr-summary:end -->