### PR TITLE
fix(server): synchronize transcript cursor safely

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -12,11 +12,10 @@ import express from "express";
 import helmet from "helmet";
 import { createServer } from "http";
 import { Server as SocketIOServer } from "socket.io";
-import { readFileSync, writeFileSync, existsSync, mkdirSync, readdirSync, unlinkSync, createReadStream } from "node:fs";
-import { stat as statAsync } from "node:fs/promises";
-import { createHmac, randomUUID, timingSafeEqual } from "node:crypto";
+import { readFileSync, writeFileSync, existsSync, mkdirSync, readdirSync, unlinkSync } from "node:fs";
+import { open as openAsync, type FileHandle } from "node:fs/promises";
+import { createHash, createHmac, randomUUID, timingSafeEqual } from "node:crypto";
 import { join, resolve } from "node:path";
-import { createInterface } from "node:readline";
 import { applyAgentSnapshot } from "./agentSnapshots";
 import { correlationMiddleware, httpRequestLogMiddleware } from "./correlation";
 import { createCorsConfig, isOriginAllowed } from "./cors";
@@ -502,6 +501,10 @@ function mapToAgentStates(cliSessions: CliSession[]): Map<string, AgentState> {
 const TICKER_BUFFER_SIZE = 30;
 /** Maximum characters per ticker message */
 const TICKER_MAX_CHARS = 150;
+/** Maximum characters accepted from an untrusted transcript message ID */
+const TICKER_MAX_ID_CHARS = 128;
+/** Maximum JSONL record size parsed into memory; oversized records are skipped */
+const TICKER_MAX_RECORD_BYTES = 1024 * 1024;
 /** How far back to look for messages (ms) */
 const TICKER_MAX_AGE = 5 * 60 * 1000; // 5 minutes
 
@@ -510,7 +513,71 @@ const tickerMessages: TickerMessage[] = [];
  * Track the byte offset of the last read position per transcript so we only
  * read newly-appended lines on each poll cycle instead of the whole file.
  */
-const lastReadOffset = new Map<string, number>();
+interface TranscriptReadCursor {
+  offset: number;
+  device: number;
+  inode: number;
+  modifiedMs: number;
+  digest: string;
+  seenIds: string[];
+}
+
+const lastReadCursor = new Map<string, TranscriptReadCursor>();
+
+const EMPTY_TRANSCRIPT_DIGEST = "0".repeat(64);
+
+function advanceTranscriptDigest(
+  digest: string,
+  recordDigest: Buffer,
+): string {
+  return createHash("sha256")
+    .update(Buffer.from(digest, "hex"))
+    .update(recordDigest)
+    .digest("hex");
+}
+
+async function readTranscriptDigest(
+  fileHandle: FileHandle,
+  length: number,
+): Promise<string | null> {
+  let digest = EMPTY_TRANSCRIPT_DIGEST;
+  let recordHash = createHash("sha256");
+  let recordLength = 0;
+  const buffer = Buffer.alloc(Math.min(64 * 1024, Math.max(length, 1)));
+  let bytesRemaining = length;
+  let position = 0;
+
+  while (bytesRemaining > 0) {
+    const readLength = Math.min(buffer.length, bytesRemaining);
+    const { bytesRead } = await fileHandle.read(
+      buffer,
+      0,
+      readLength,
+      position,
+    );
+    if (bytesRead !== readLength) return null;
+
+    let chunkOffset = 0;
+    while (chunkOffset < bytesRead) {
+      const newlineIndex = buffer.indexOf(0x0a, chunkOffset);
+      const segmentEnd = newlineIndex === -1 || newlineIndex >= bytesRead
+        ? bytesRead
+        : newlineIndex + 1;
+      const segment = buffer.subarray(chunkOffset, segmentEnd);
+      recordHash.update(segment);
+      recordLength += segment.length;
+      if (newlineIndex === -1 || newlineIndex >= bytesRead) break;
+      digest = advanceTranscriptDigest(digest, recordHash.digest());
+      recordHash = createHash("sha256");
+      recordLength = 0;
+      chunkOffset = segmentEnd;
+    }
+
+    bytesRemaining -= bytesRead;
+    position += bytesRead;
+  }
+  return recordLength === 0 ? digest : null;
+}
 
 /**
  * Extract displayable text from a message content block.
@@ -543,6 +610,7 @@ export async function tailTranscript(
   agentId: string,
   agentName: string,
   transcriptPath: string | undefined,
+  options: { afterInitialStat?: () => void | Promise<void> } = {},
 ): Promise<TickerMessage[]> {
   if (
     !transcriptPath
@@ -552,43 +620,70 @@ export async function tailTranscript(
   }
 
   const key = `${agentId}:${transcriptPath}`;
-  const offset = lastReadOffset.get(key) ?? 0;
 
-  // Snapshot the file size before reading so we have a stable upper bound even
-  // if the file is still being written to during the read.
-  let fileSize: number;
+  // Open first, then inspect and stream through the same descriptor. A path
+  // lookup followed by a separate open can cross a rotation boundary and pair
+  // one inode's identity with another inode's bytes.
+  let fileHandle: FileHandle | undefined;
   try {
-    fileSize = (await statAsync(transcriptPath)).size;
+    fileHandle = await openAsync(transcriptPath, "r");
   } catch {
     // File doesn't exist or is unreadable — skip silently
     return [];
   }
 
-  // Nothing new since we last read (also ensures fileSize > offset, so
-  // end = fileSize - 1 is always a valid range below)
-  if (fileSize <= offset) return [];
+  let fileSize: number;
+  let device: number;
+  let inode: number;
+  let modifiedMs: number;
+  let offset = 0;
+  let digest = EMPTY_TRANSCRIPT_DIGEST;
+  const previousCursor = lastReadCursor.get(key);
+  const baselineSeenIds = new Set(previousCursor?.seenIds ?? []);
+  let seenIds = new Set(baselineSeenIds);
+  try {
+    const fileStat = await fileHandle.stat();
+    fileSize = fileStat.size;
+    device = fileStat.dev;
+    inode = fileStat.ino;
+    modifiedMs = fileStat.mtimeMs;
+
+    const sameFile = previousCursor?.device === device
+      && previousCursor.inode === inode;
+    if (sameFile && fileSize >= previousCursor.offset) {
+      const metadataUnchanged = fileSize === previousCursor.offset
+        && modifiedMs === previousCursor.modifiedMs;
+      const prefixDigest = metadataUnchanged
+        ? previousCursor.digest
+        : await readTranscriptDigest(fileHandle, previousCursor.offset);
+      if (prefixDigest === previousCursor.digest) {
+        offset = previousCursor.offset;
+        digest = previousCursor.digest;
+      }
+    }
+  } catch {
+    await fileHandle.close().catch(() => {});
+    return [];
+  }
+
+  try {
+    await options.afterInitialStat?.();
+  } catch {
+    await fileHandle.close().catch(() => {});
+    return [];
+  }
 
   const newMessages: TickerMessage[] = [];
-
-  return new Promise((resolve) => {
-    const stream = createReadStream(transcriptPath, {
-      encoding: "utf-8",
-      start: offset,
-      end: fileSize - 1,
-    });
-    const rl = createInterface({ input: stream, crlfDelay: Infinity });
-
-    // Track how many bytes we've consumed through complete newlines.
-    // `readline` only emits a "line" event after encountering a newline
-    // delimiter, so bytesConsumed always ends at a clean boundary — any
-    // trailing partial line (no terminating newline) is NOT counted and
-    // will be re-read on the next poll cycle.
-    let bytesConsumed = 0;
-    let errored = false;
-
-    rl.on("line", (line) => {
-      // +1 for the newline character that readline strips
-      bytesConsumed += Buffer.byteLength(line, "utf-8") + 1;
+  const processLine = (
+    rawLine: Buffer,
+    recordDigest: Buffer,
+    messages: TickerMessage[],
+    knownIds: Set<string>,
+  ) => {
+      const content = rawLine[rawLine.length - 1] === 0x0d
+        ? rawLine.subarray(0, -1)
+        : rawLine;
+      const line = content.toString("utf-8");
 
       if (!line.trim()) return;
       try {
@@ -604,51 +699,142 @@ export async function tailTranscript(
         // Skip heartbeat messages
         if (text.startsWith("HEARTBEAT_OK") || text.includes("HEARTBEAT.md")) return;
 
-        const id = msg.__openclaw?.id || `${agentId}-${msg.__openclaw?.seq ?? randomUUID()}`;
-        const timestamp = msg.timestamp || msg.__openclaw?.ts || Date.now();
+        const rawId = msg.__openclaw?.id;
+        const id = typeof rawId === "string"
+          && rawId.length > 0
+          && rawId.length <= TICKER_MAX_ID_CHARS
+          ? rawId
+          : `${agentId}-${recordDigest.toString("hex").slice(0, 32)}`;
+        const timestamp = msg.timestamp ?? msg.__openclaw?.ts ?? Date.now();
+        if (typeof timestamp !== "number" || !Number.isFinite(timestamp)) return;
 
         // Age check
         if (Date.now() - timestamp > TICKER_MAX_AGE) return;
 
-        newMessages.push({ id, agentId, agentName, role, text, timestamp });
+        if (knownIds.has(id)) return;
+        knownIds.add(id);
+        messages.push({ id, agentId, agentName, role, text, timestamp });
       } catch {
         // Skip malformed lines
       }
-    });
+    };
 
-    rl.on("close", () => {
-      // On stream error, rl.close() is called which fires this handler.
-      // Guard against advancing the cursor or resolving with partial data
-      // when the read was interrupted by an I/O error.
-      if (errored) return;
+  let committedOffset = offset;
+  let baselineOffset = offset;
+  let baselineModifiedMs = modifiedMs;
 
-      // Only advance the cursor by bytes we know ended at a newline.
-      // If the file was appended mid-line during our read, the partial
-      // fragment (fileSize - bytesConsumed) will be re-read next cycle.
-      if (bytesConsumed > 0) {
-        lastReadOffset.set(key, offset + bytesConsumed);
+  try {
+    // Drain to the descriptor's current EOF, then fstat and repeat if a writer
+    // appended while the read was in flight. The path may already have been
+    // rotated; the open descriptor still owns those final old-file records.
+    for (let pass = 0; pass < 3; pass++) {
+      const readStart = committedOffset;
+      let physicalBytesRead = 0;
+      let bytesCommitted = 0;
+      let recordLength = 0;
+      let recordHash = createHash("sha256");
+      let pending = Buffer.alloc(0);
+      let recordTooLarge = false;
+      const passMessages: TickerMessage[] = [];
+      const passSeenIds = new Set(seenIds);
+      const stream = fileHandle.createReadStream({
+        start: readStart,
+        autoClose: false,
+      });
+
+      for await (const rawChunk of stream) {
+        const chunk = rawChunk as Buffer;
+        physicalBytesRead += chunk.length;
+        let chunkOffset = 0;
+        while (chunkOffset < chunk.length) {
+          const newlineIndex = chunk.indexOf(0x0a, chunkOffset);
+          const segmentEnd = newlineIndex === -1
+            ? chunk.length
+            : newlineIndex + 1;
+          const segment = chunk.subarray(chunkOffset, segmentEnd);
+          recordHash.update(segment);
+          recordLength += segment.length;
+
+          if (!recordTooLarge) {
+            const contentSegment = newlineIndex === -1
+              ? segment
+              : segment.subarray(0, -1);
+            if (pending.length + contentSegment.length <= TICKER_MAX_RECORD_BYTES) {
+              pending = Buffer.concat([pending, contentSegment]);
+            } else {
+              pending = Buffer.alloc(0);
+              recordTooLarge = true;
+            }
+          }
+
+          if (newlineIndex === -1) break;
+          bytesCommitted += recordLength;
+          const recordDigest = recordHash.digest();
+          if (!recordTooLarge) {
+            processLine(pending, recordDigest, passMessages, passSeenIds);
+          }
+          digest = advanceTranscriptDigest(digest, recordDigest);
+          recordLength = 0;
+          recordHash = createHash("sha256");
+          pending = Buffer.alloc(0);
+          recordTooLarge = false;
+          chunkOffset = segmentEnd;
+        }
       }
-      resolve(newMessages);
-    });
 
-    // readline.Interface does not emit "error"; handle errors on the underlying stream.
-    stream.on("error", () => {
-      errored = true;
-      rl.close();
-      stream.destroy();
-      resolve([]);
+      committedOffset = readStart + bytesCommitted;
+      const finalStat = await fileHandle.stat();
+      const needsVerification = committedOffset !== baselineOffset
+        || finalStat.mtimeMs !== baselineModifiedMs;
+      const verifiedDigest = needsVerification
+        ? await readTranscriptDigest(fileHandle, committedOffset)
+        : digest;
+      if (finalStat.size < committedOffset || verifiedDigest !== digest) {
+        // The inode was truncated or rewritten while it was being consumed.
+        // Discard observations from the unstable generation and retry from 0.
+        newMessages.length = 0;
+        committedOffset = 0;
+        baselineOffset = 0;
+        digest = EMPTY_TRANSCRIPT_DIGEST;
+        seenIds = new Set(baselineSeenIds);
+        baselineModifiedMs = finalStat.mtimeMs;
+        continue;
+      }
+
+      seenIds = passSeenIds;
+      newMessages.push(...passMessages);
+      modifiedMs = finalStat.mtimeMs;
+      const physicalEnd = readStart + physicalBytesRead;
+      if (finalStat.size <= physicalEnd) break;
+    }
+
+    // Avoid re-hashing a stable prefix on quiet polls. Any size or mtime
+    // change triggers full-prefix verification on the next call.
+    lastReadCursor.set(key, {
+      offset: committedOffset,
+      device,
+      inode,
+      modifiedMs,
+      digest,
+      seenIds: Array.from(seenIds).slice(-256),
     });
-  });
+    return newMessages;
+  } catch {
+    // A failed stream must not advance the cursor or emit a partial batch.
+    return [];
+  } finally {
+    await fileHandle.close().catch(() => {});
+  }
 }
 
 /**
  * Prune read offsets for agents that are no longer active
  */
 function pruneReadOffsets(activeAgentIds: Set<string>): void {
-  for (const key of lastReadOffset.keys()) {
+  for (const key of lastReadCursor.keys()) {
     const agentId = key.split(':')[0];
     if (!activeAgentIds.has(agentId)) {
-      lastReadOffset.delete(key);
+      lastReadCursor.delete(key);
     }
   }
 }
@@ -1516,4 +1702,3 @@ if (require.main === module) {
 }
 
 export { app, server, io, startServer };
-

--- a/server/transcriptTicker.test.ts
+++ b/server/transcriptTicker.test.ts
@@ -1,0 +1,343 @@
+import {
+  appendFileSync,
+  mkdirSync,
+  mkdtempSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { Server as SocketIOServer } from "socket.io";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+
+describe("transcript ticker boundary", () => {
+  let dataDir: string;
+  let sessionsDir: string;
+  let io: SocketIOServer;
+  let tailTranscript: typeof import("./index").tailTranscript;
+
+  const makeLine = (content: string, metadata: Record<string, unknown> = {}) =>
+    `${JSON.stringify({
+      role: "assistant",
+      content,
+      timestamp: Date.now(),
+      ...metadata,
+    })}\n`;
+
+  beforeAll(async () => {
+    dataDir = mkdtempSync(join(tmpdir(), "pixel-agents-ticker-test-"));
+    sessionsDir = join(dataDir, "agents", "main", "sessions");
+    mkdirSync(sessionsDir, { recursive: true });
+
+    vi.stubEnv("DATA_DIR", dataDir);
+    vi.stubEnv("DATA_SOURCE", "ingest");
+    vi.stubEnv("INGEST_API_TOKEN", "ticker-test-secret");
+    vi.stubEnv("OPENCLAW_AGENTS_DIR", join(dataDir, "agents"));
+    vi.stubEnv("NODE_ENV", "test");
+
+    vi.resetModules();
+    const serverModule = await import("./index");
+    io = serverModule.io;
+    tailTranscript = serverModule.tailTranscript;
+  });
+
+  afterAll(() => {
+    io.close();
+    rmSync(dataDir, { recursive: true, force: true });
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+
+  it("resets the cursor when a transcript is truncated in place", async () => {
+    const transcriptPath = join(sessionsDir, "truncated.jsonl");
+    writeFileSync(transcriptPath, makeLine("message before truncation is deliberately longer"));
+
+    await expect(
+      tailTranscript("main", "Shodan", transcriptPath),
+    ).resolves.toHaveLength(1);
+
+    writeFileSync(transcriptPath, makeLine("new line after truncation"));
+
+    await expect(
+      tailTranscript("main", "Shodan", transcriptPath),
+    ).resolves.toEqual([
+      expect.objectContaining({ text: "new line after truncation" }),
+    ]);
+  });
+
+  it("resets after copy-truncate even when the rewritten file regrows past the cursor", async () => {
+    const transcriptPath = join(sessionsDir, "copy-truncate-regrown.jsonl");
+    writeFileSync(transcriptPath, makeLine("short original message"));
+
+    await expect(
+      tailTranscript("main", "Shodan", transcriptPath),
+    ).resolves.toHaveLength(1);
+
+    writeFileSync(
+      transcriptPath,
+      `${makeLine("rewritten first message after copy truncate")}${makeLine("rewritten second message")}`,
+    );
+
+    await expect(
+      tailTranscript("main", "Shodan", transcriptPath),
+    ).resolves.toEqual([
+      expect.objectContaining({ text: "rewritten first message after copy truncate" }),
+      expect.objectContaining({ text: "rewritten second message" }),
+    ]);
+  });
+
+  it("detects a same-length copy-truncate rewrite that preserves the old suffix", async () => {
+    const transcriptPath = join(sessionsDir, "copy-truncate-suffix-collision.jsonl");
+    const sharedSuffix = "z".repeat(200);
+    const timestamp = Date.now();
+    const originalLine = makeLine(`first record ${sharedSuffix}`, { timestamp });
+    const rewrittenLine = makeLine(`other record ${sharedSuffix}`, { timestamp });
+    expect(Buffer.byteLength(rewrittenLine)).toBe(Buffer.byteLength(originalLine));
+    writeFileSync(transcriptPath, originalLine);
+
+    await expect(
+      tailTranscript("main", "Shodan", transcriptPath),
+    ).resolves.toHaveLength(1);
+
+    writeFileSync(
+      transcriptPath,
+      `${rewrittenLine}${makeLine("record appended after same-size rewrite")}`,
+    );
+
+    await expect(
+      tailTranscript("main", "Shodan", transcriptPath),
+    ).resolves.toEqual([
+      expect.objectContaining({ text: expect.stringMatching(/^other record z+$/) }),
+      expect.objectContaining({ text: "record appended after same-size rewrite" }),
+    ]);
+  });
+
+  it("detects a rewritten prefix when the last committed record is unchanged", async () => {
+    const transcriptPath = join(sessionsDir, "copy-truncate-unchanged-last.jsonl");
+    const timestamp = Date.now();
+    const first = makeLine("first prefix record", {
+      timestamp,
+      __openclaw: { id: "prefix-a" },
+    });
+    const replacement = makeLine("other prefix record", {
+      timestamp,
+      __openclaw: { id: "prefix-c" },
+    });
+    const unchanged = makeLine("unchanged trailing record", {
+      timestamp,
+      __openclaw: { id: "prefix-b" },
+    });
+    expect(Buffer.byteLength(replacement)).toBe(Buffer.byteLength(first));
+    writeFileSync(transcriptPath, `${first}${unchanged}`);
+
+    await expect(
+      tailTranscript("main", "Shodan", transcriptPath),
+    ).resolves.toHaveLength(2);
+
+    writeFileSync(
+      transcriptPath,
+      `${replacement}${unchanged}${makeLine("new record after rewritten prefix", {
+        __openclaw: { id: "prefix-d" },
+      })}`,
+    );
+
+    await expect(
+      tailTranscript("main", "Shodan", transcriptPath),
+    ).resolves.toEqual([
+      expect.objectContaining({ id: "prefix-c", text: "other prefix record" }),
+      expect.objectContaining({ id: "prefix-d", text: "new record after rewritten prefix" }),
+    ]);
+  });
+
+  it("resets the cursor when a transcript path is replaced during rotation", async () => {
+    const transcriptPath = join(sessionsDir, "rotated.jsonl");
+    const rotatedPath = join(sessionsDir, "rotated.jsonl.1");
+    writeFileSync(transcriptPath, makeLine("old inode message is deliberately longer"));
+
+    await expect(
+      tailTranscript("main", "Shodan", transcriptPath),
+    ).resolves.toHaveLength(1);
+
+    renameSync(transcriptPath, rotatedPath);
+    writeFileSync(transcriptPath, makeLine("new inode message"));
+
+    await expect(
+      tailTranscript("main", "Shodan", transcriptPath),
+    ).resolves.toEqual([
+      expect.objectContaining({ text: "new inode message" }),
+    ]);
+  });
+
+  it("drains an append made to the opened inode immediately before rotation", async () => {
+    const transcriptPath = join(sessionsDir, "rotated-during-read.jsonl");
+    const rotatedPath = join(sessionsDir, "rotated-during-read.jsonl.1");
+    writeFileSync(transcriptPath, makeLine("record before rotation window"));
+
+    await expect(
+      tailTranscript("main", "Shodan", transcriptPath),
+    ).resolves.toHaveLength(1);
+
+    await expect(
+      tailTranscript("main", "Shodan", transcriptPath, {
+        afterInitialStat: () => {
+          appendFileSync(transcriptPath, makeLine("late record on old inode"));
+          renameSync(transcriptPath, rotatedPath);
+          writeFileSync(transcriptPath, makeLine("record on replacement inode"));
+        },
+      }),
+    ).resolves.toEqual([
+      expect.objectContaining({ text: "late record on old inode" }),
+    ]);
+
+    await expect(
+      tailTranscript("main", "Shodan", transcriptPath),
+    ).resolves.toEqual([
+      expect.objectContaining({ text: "record on replacement inode" }),
+    ]);
+  });
+
+  it.each([
+    { label: "string", timestamp: "not-a-number" },
+    { label: "object", timestamp: {} },
+    { label: "array", timestamp: [] },
+  ])("drops messages with an invalid $label timestamp", async ({ label, timestamp }) => {
+    const transcriptPath = join(
+      sessionsDir,
+      `invalid-timestamp-${label}.jsonl`,
+    );
+    writeFileSync(
+      transcriptPath,
+      `${makeLine("invalid timestamp message", { timestamp })}${makeLine("valid timestamp message")}`,
+    );
+
+    await expect(
+      tailTranscript("main", "Shodan", transcriptPath),
+    ).resolves.toEqual([
+      expect.objectContaining({ text: "valid timestamp message" }),
+    ]);
+  });
+
+  it("drops a timestamp that parses as non-finite", async () => {
+    const transcriptPath = join(sessionsDir, "non-finite-timestamp.jsonl");
+    const nonFiniteLine = '{"role":"assistant","content":"non finite timestamp","timestamp":1e400}\n';
+    writeFileSync(transcriptPath, `${nonFiniteLine}${makeLine("valid timestamp after infinity")}`);
+
+    await expect(
+      tailTranscript("main", "Shodan", transcriptPath),
+    ).resolves.toEqual([
+      expect.objectContaining({ text: "valid timestamp after infinity" }),
+    ]);
+  });
+
+  it("replaces an oversized transcript message id with a bounded synthetic id", async () => {
+    const transcriptPath = join(sessionsDir, "oversized-id.jsonl");
+    const oversizedId = "x".repeat(129);
+    writeFileSync(
+      transcriptPath,
+      makeLine("message with oversized id", {
+        __openclaw: { id: oversizedId },
+      }),
+    );
+
+    const [message] = await tailTranscript("main", "Shodan", transcriptPath);
+
+    expect(message).toBeDefined();
+    expect(message.id).not.toBe(oversizedId);
+    expect(message.id.length).toBeLessThanOrEqual(128);
+  });
+
+  it("replaces an untyped transcript message id with a bounded synthetic id", async () => {
+    const transcriptPath = join(sessionsDir, "untyped-id.jsonl");
+    writeFileSync(
+      transcriptPath,
+      makeLine("message with object id", { __openclaw: { id: { nested: true } } }),
+    );
+
+    const [message] = await tailTranscript("main", "Shodan", transcriptPath);
+
+    expect(message).toBeDefined();
+    expect(message.id).toEqual(expect.any(String));
+    expect(message.id.length).toBeLessThanOrEqual(128);
+  });
+
+  it("preserves a valid bounded transcript message id", async () => {
+    const transcriptPath = join(sessionsDir, "valid-id.jsonl");
+    writeFileSync(
+      transcriptPath,
+      makeLine("message with valid id", { __openclaw: { id: "valid-message-id" } }),
+    );
+
+    await expect(
+      tailTranscript("main", "Shodan", transcriptPath),
+    ).resolves.toEqual([
+      expect.objectContaining({ id: "valid-message-id" }),
+    ]);
+  });
+
+  it("accounts for invalid UTF-8 by raw bytes without duplicating prior records", async () => {
+    const transcriptPath = join(sessionsDir, "invalid-utf8.jsonl");
+    writeFileSync(
+      transcriptPath,
+      Buffer.concat([
+        Buffer.from(makeLine("valid record before invalid bytes")),
+        Buffer.from([0xff, 0x0a]),
+      ]),
+    );
+
+    await expect(
+      tailTranscript("main", "Shodan", transcriptPath),
+    ).resolves.toEqual([
+      expect.objectContaining({ text: "valid record before invalid bytes" }),
+    ]);
+
+    appendFileSync(transcriptPath, makeLine("valid record after invalid bytes"));
+
+    await expect(
+      tailTranscript("main", "Shodan", transcriptPath),
+    ).resolves.toEqual([
+      expect.objectContaining({ text: "valid record after invalid bytes" }),
+    ]);
+  });
+
+  it("skips an oversized record while advancing to the next complete record", async () => {
+    const transcriptPath = join(sessionsDir, "oversized-record.jsonl");
+    writeFileSync(
+      transcriptPath,
+      `${"x".repeat(1024 * 1024 + 1)}\n${makeLine("valid record after oversized record")}`,
+    );
+
+    await expect(
+      tailTranscript("main", "Shodan", transcriptPath),
+    ).resolves.toEqual([
+      expect.objectContaining({ text: "valid record after oversized record" }),
+    ]);
+    await expect(
+      tailTranscript("main", "Shodan", transcriptPath),
+    ).resolves.toEqual([]);
+  });
+
+  it("does not advance past a partial trailing JSONL record", async () => {
+    const transcriptPath = join(sessionsDir, "partial.jsonl");
+    const completeLine = makeLine("complete line before partial record");
+    const completedLater = makeLine("partial line completed later");
+    writeFileSync(
+      transcriptPath,
+      `${completeLine}${completedLater.slice(0, -1)}`,
+    );
+
+    await expect(
+      tailTranscript("main", "Shodan", transcriptPath),
+    ).resolves.toEqual([
+      expect.objectContaining({ text: "complete line before partial record" }),
+    ]);
+
+    writeFileSync(transcriptPath, `${completeLine}${completedLater}`);
+
+    await expect(
+      tailTranscript("main", "Shodan", transcriptPath),
+    ).resolves.toEqual([
+      expect.objectContaining({ text: "partial line completed later" }),
+    ]);
+  });
+});


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
## Summary

This PR hardens transcript cursor synchronization in `server/index.ts` so that the ticker safely tails JSONL files even when the underlying file is truncated, rewritten (copy-truncate), rotated, or contains malformed data. The fix addresses #158.

### Key changes

- **Single handle per read cycle**: Replaces the `stat` + `createReadStream` + `readline` pipeline with a single `openAsync` handle. The file is opened first and then read through the same descriptor, preventing a path lookup from being paired with bytes from a different inode after a rotation window.

- **Cursor identity with prefix verification**: Introduces a `TranscriptReadCursor` (offset, device, inode, mtime, SHA-256 digest of committed records, and recent seen IDs). When the inode and device match the previous cursor, the committed prefix is re-hashed and compared against the stored digest before continuing from the saved offset. If verification fails, the cursor rewinds to offset 0.

- **Rewrite detection via in-pass re-stat and digest check**: At the end of each pass through the descriptor, the code re-stats the file and re-hashes the committed prefix. If the size shrank or the digest diverges, all messages from the unstable generation are discarded and the cursor is reset.

- **Same-path rotation drainage**: The reader drains to the descriptor's current EOF, then re-stats and loops up to 3 times. This captures any append that lands on the old inode immediately before rename, so a rotation that replaces the path does not silently drop data.

- **Drain hook (`afterInitialStat`)**: A new option lets callers (and tests) trigger appends/rotations between the initial stat and the read, simulating the realistic race where a writer appends and the file is rotated while the server is mid-tail.

- **Raw-byte record accounting**: Records are framed by raw `0x0a` byte positions on the chunk buffer, not by string line counting. The cursor only advances by bytes confirmed to end at a newline, so partial trailing records are re-read on the next poll. Invalid UTF-8 no longer misaligns the offset.

- **Input validation and bounds**:
  - `TICKER_MAX_ID_CHARS` (128) caps accepted message IDs; oversized or non-string IDs are replaced with a bounded synthetic ID derived from the record digest.
  - `TICKER_MAX_RECORD_BYTES` (1 MiB) bounds per-record memory; oversized records are skipped without aborting the stream.
  - Timestamps must be finite numbers; strings, objects, arrays, and `Infinity`/`NaN` are rejected.

- **Duplicate suppression across cursor resets**: The cursor retains the last 256 seen IDs and uses them as a dedup set on subsequent reads, preventing the same message from being re-emitted after the cursor rewinds to 0 due to a detected rewrite.

- **Atomic cursor update**: The cursor is only persisted after a successful read with a verified digest; any I/O error returns `[]` and leaves the prior cursor in place.

### Tests

Adds `server/transcriptTicker.test.ts` with 12 focused cases covering:

- In-place truncation reset
- Copy-truncate reset, including when the rewritten file regrows past the cursor
- Same-length copy-truncate with a preserved suffix (matched-byte collision detection)
- Copy-truncate where the last committed record is unchanged but the prefix was rewritten
- Replace-on-rename rotation
- Append-and-rotate scenario using the `afterInitialStat` hook to inject the race between `stat` and read
- Invalid timestamp filtering (string, object, array, non-finite)
- Oversized ID replacement with bounded synthetic ID
- Untyped (object) ID replacement
- Valid bounded ID preservation
- Invalid UTF-8 in raw bytes without offset drift or duplicate output
- Oversized record skipped while continuing to the next complete record
- Partial trailing record not advanced until the newline lands

### Verification

- Focused transcript ticker: 16/16
- Full suite: 388/388
- Coverage suite: 388/388
- Typecheck: passed
- Production build: passed
- Production audit: 0 vulnerabilities
- Staged path and secret scans: clean

---

**Summary**

The transcript-tail routine now resynchronizes safely across truncation, rotation, and concurrent rewrites instead of trusting a single byte offset.

**What changed**

- **`server/index.ts` — `tailTranscript`**
  - Replaces the simple `lastReadOffset` map with a richer cursor (`offset`, `device`, `inode`, `modifiedMs`, `digest`, `seenIds`) so each cycle can verify it's still talking to the same underlying file.
  - Opens the file once with `fs.promises.open`, then reads and `fstat`s through that descriptor. This avoids pairing one inode's identity with another inode's bytes when the path is rotated mid-read.
  - Streams bytes through a per-record SHA-256 digest. The digest stored in the cursor is compared against a freshly computed digest of the committed prefix on every call, so a copy-truncate or in-place rewrite (even at the same length) is detected and the cursor is reset to 0.
  - Drains to the descriptor's EOF, then re-stats and loops up to a small bounded number of times to capture writes that land while the read is in flight, without crossing a rotation boundary.
  - Validates inputs from the untrusted transcript file:
    - `message.id` must be a string within `TICKER_MAX_ID_CHARS` (128); otherwise a bounded synthetic id derived from the record digest is used.
    - `timestamp` must be a finite number; invalid values are dropped.
    - Records larger than `TICKER_MAX_RECORD_BYTES` (1 MiB) are skipped without losing subsequent records.
  - Tracks recently-seen ids so duplicates from a partially re-read prefix (e.g., after cursor reset) are not re-emitted.
  - Skips the cursor update and returns `[]` if any I/O step fails, preventing partial batches from being published as if complete.

- **`server/transcriptTicker.test.ts` (new)**
  - Covers the boundary conditions that motivated the rework: in-place truncation, copy-truncate that regrows past the cursor, same-length copy-truncate with a preserved suffix, rewritten prefix with an unchanged trailing record, file rotation, and append-then-rotate during the read. Also covers invalid timestamps, oversized or untyped message ids, oversized records, invalid UTF-8 bytes, and the partial-trailing-record case.

---

This pull request hardens the server's transcript tailing logic so the read cursor can be safely synchronized against concurrent file mutations (truncation, rotation, rewrite, and partial writes).

## Problem

The previous implementation tracked only a byte offset per transcript. That approach silently corrupted ticker output whenever a transcript was:

- **Truncated in place** or rewritten (copy-truncate) — the saved offset could land in the middle of new content, replaying old records or skipping new ones.
- **Rotated** — a separate `stat()` followed by an `open()` could pair one inode's identity with another inode's bytes if the path was swapped between the two calls.
- **Written with invalid bytes, malformed IDs, non-numeric timestamps, or oversized records** — these could crash the parser, emit duplicates, or be partially processed.

## Changes

### `server/index.ts`

- **Atomic open + stat via a single descriptor.** `tailTranscript` now opens the file once with `fs/promises.open` and uses `FileHandle.stat()` so the size/inode/mtime it acts on are guaranteed to belong to the same inode the subsequent reads target.
- **New `TranscriptReadCursor`.** Replaces the bare offset map with `{ offset, device, inode, modifiedMs, digest, seenIds }`. Inode identity and a SHA-256 digest of committed records are persisted alongside the offset.
- **Prefix verification on resume.** Before resuming from a cached offset, the cursor's stored digest is recomputed over the file's prefix. If the prefix no longer matches (truncation or rewrite), the cursor is discarded and reading restarts from byte 0. Quiet polls skip rehashing via size + mtime short-circuiting.
- **Multi-pass drain for live writers.** The reader drains to EOF, re-stats, and repeats up to three passes so records appended during the read are still picked up. The open descriptor keeps observing the original inode even if the path is rotated away mid-read, so trailing records on the old inode are not lost.
- **Truncation/rewrite detection after each pass.** If the post-read size shrinks below the committed offset, or the recomputed digest diverges, the in-flight observations are discarded and the cursor is reset.
- **Bounded ID handling.** Untrusted `__openclaw.id` values are validated as strings up to 128 characters; missing, non-string, or oversized IDs are replaced with a deterministic synthetic ID derived from the per-record SHA-256 digest.
- **Timestamp validation.** Non-numeric, non-finite, or otherwise invalid timestamps cause the record to be skipped instead of corrupting the age check.
- **Oversized-record cap.** Records exceeding 1 MiB are skipped without aborting the stream.
- **Robust byte accounting.** Newlines are detected in raw bytes so invalid UTF-8 mid-record no longer duplicates prior records, and a partial trailing record (no newline) is never committed.

### `server/transcriptTicker.test.ts` (new)

Adds an end-to-end test suite covering:

- In-place truncation recovery.
- Copy-truncate detection when the rewritten file regrows past the old cursor.
- Same-length copy-truncate detection when the trailing suffix is preserved.
- Detection of a rewritten prefix even when the last committed record is byte-identical.
- Cursor reset across inode rotation.
- Drain of a late append that happens immediately before a rotation, plus the replacement inode being read on the next poll.
- Rejection of invalid timestamps (strings, objects, arrays, non-finite numbers).
- Replacement of oversized and non-string `__openclaw.id` values with bounded synthetic IDs.
- Preservation of valid bounded IDs.
- No duplication when invalid UTF-8 appears mid-stream.
- Skip of an oversized record while still advancing to the next valid one.
- Non-advancement past a partial trailing JSONL record, and clean pickup once that record completes.

---

**Summary**

This change hardens the transcript tailer's cursor management so it correctly handles file truncation, in-place rewrite, and inode rotation while reading appended JSONL records.

**Functional Changes**

- **Open-then-stat pattern**: The reader now opens a single file descriptor and inspects it via `fstat`, eliminating the prior race where a separate `stat` then `open` could pair one inode's identity with another inode's bytes.
- **Cursor state expansion**: Replaces the simple `lastReadOffset` map with a `TranscriptReadCursor` that tracks `device`, `inode`, `modifiedMs`, a SHA-256 rolling digest of the consumed prefix, and the last 256 seen message IDs.
- **Prefix verification on resume**: On each call, when the same inode is detected, the reader re-hashes the previously-committed prefix and only resumes from the prior offset if the digest matches; otherwise it restarts from byte 0.
- **Multi-pass drain with verification**: After draining the open descriptor to EOF, the reader re-stats and re-verifies the consumed prefix. If size or mtime changed (indicating truncation or rewrite during the read), observations from the unstable generation are discarded and the cursor resets.
- **Same-file tracking across rotation**: The reader distinguishes between continued appends to the same inode and a rotation to a new inode, draining any late appends on the old descriptor before switching.
- **Bounded and safe IDs**: A new `TICKER_MAX_ID_CHARS = 128` cap rejects oversized or non-string IDs from untrusted transcript metadata, replacing them with a synthetic ID derived from the record digest.
- **Safer timestamps**: Non-numeric or non-finite timestamp values are dropped instead of being coerced to `Date.now()`.
- **Oversized-record guard**: `TICKER_MAX_RECORD_BYTES = 1 MiB` caps memory per JSONL record; oversized records are skipped but the cursor still advances past them.
- **Invalid UTF-8 handling**: Bytes are buffered and digest-tracked as raw buffers, so invalid UTF-8 sequences no longer corrupt offset accounting.
- **Stream error safety**: The cursor is no longer advanced or partial results emitted when the underlying stream errors.

**Tests**

Added `server/transcriptTicker.test.ts` covering:

- In-place truncation and copy-truncate rewrites (including same-length rewrites and rewrites that preserve the last committed record).
- Path-level rotation replacing the inode.
- Appends made to the opened inode immediately before rotation, verifying the late record is drained from the old descriptor and not duplicated after rotation.
- Invalid timestamp shapes (string, object, array, non-finite) being dropped.
- Oversized and untyped message IDs being replaced with bounded synthetic IDs, while valid IDs are preserved.
- Invalid UTF-8 bytes not duplicating prior records.
- Oversized records being skipped while the cursor advances.
- Partial trailing records not being committed until completed.
<!-- kody-pr-summary:end -->

## Summary by Sourcery

Safely resynchronize transcript cursors across concurrent file rewrites, truncation, rotation, and partial writes without replaying or losing messages.

Bug Fixes:
- Harden transcript tailing so cursor synchronization remains correct across truncation, copy-truncate rewrites, rotations, partial writes, malformed records, and invalid input data.

Enhancements:
- Replace offset-only tracking with verified file identity, committed-prefix digests, bounded draining, raw-byte record accounting, and duplicate suppression for safe incremental reads.

Tests:
- Add boundary-focused transcript ticker coverage for file mutations, rotation races, malformed timestamps and IDs, invalid UTF-8, oversized records, and partial trailing records.