### PR TITLE
fix(docker): pin Node 22.22.2 alpine by digest and add HEALTHCHECK

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,3 +18,12 @@ updates:
       time: '05:30'
       timezone: Europe/Berlin
     open-pull-requests-limit: 5
+
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: '06:00'
+      timezone: Europe/Berlin
+    open-pull-requests-limit: 5

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,8 @@ ENV PORT=3001 DATA_SOURCE=ingest DATA_DIR=/app/data
 EXPOSE 3001
 
 # Node 22 has global fetch — no wget/curl in the alpine image.
+# Read PORT from the same env the server binds (default 3001).
 HEALTHCHECK --interval=15s --timeout=3s --start-period=10s --retries=3 \
-  CMD ["node", "-e", "fetch('http://127.0.0.1:3001/api/status').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"]
+  CMD ["node", "-e", "fetch('http://127.0.0.1:'+(process.env.PORT||3001)+'/api/status').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"]
 
 CMD ["node", "dist/server/server/index.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,12 @@
 # syntax=docker/dockerfile:1.7
 
+# Pin both stages to the Node 22.22.2 alpine *index* digest so a rebuilt
+# floating tag cannot silently change the build or runtime image.
+# Dependabot's docker ecosystem refreshes these FROM lines.
+
 # ---- Builder stage -----------------------------------------------------------
 # Full dev deps + source, produces the compiled output in /app/dist.
-FROM node:22-alpine AS builder
+FROM node:22.22.2-alpine@sha256:8ea2348b068a9544dae7317b4f3aafcdc032df1647bb7d768a05a5cad1a7683f AS builder
 WORKDIR /app
 # .npmrc carries engine-strict=true; copy it before `npm ci` so the Node floor
 # (22.22.2 on this Node 22 image) is enforced during the image build.
@@ -13,7 +17,7 @@ RUN npm run build
 
 # ---- Runtime stage -----------------------------------------------------------
 # Production deps only + compiled dist. No source, no dev deps, no .git.
-FROM node:22-alpine
+FROM node:22.22.2-alpine@sha256:8ea2348b068a9544dae7317b4f3aafcdc032df1647bb7d768a05a5cad1a7683f
 WORKDIR /app
 ENV NODE_ENV=production
 
@@ -31,5 +35,9 @@ RUN addgroup -S appuser && adduser -S -G appuser -h /app -s /sbin/nologin appuse
 USER appuser
 ENV PORT=3001 DATA_SOURCE=ingest DATA_DIR=/app/data
 EXPOSE 3001
+
+# Node 22 has global fetch — no wget/curl in the alpine image.
+HEALTHCHECK --interval=15s --timeout=3s --start-period=10s --retries=3 \
+  CMD ["node", "-e", "fetch('http://127.0.0.1:3001/api/status').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"]
 
 CMD ["node", "dist/server/server/index.js"]

--- a/server/dockerfile.test.ts
+++ b/server/dockerfile.test.ts
@@ -9,20 +9,19 @@ const dockerfile = readFileSync(
 );
 
 describe("Dockerfile", () => {
-  it("pins both stages to a Node 22.22.2 alpine index digest", () => {
+  it("pins both stages to the same Node 22.22.2 alpine index digest", () => {
     const fromLines = dockerfile.split("\n").filter((line) => line.startsWith("FROM "));
     expect(fromLines).toHaveLength(2);
-    for (const line of fromLines) {
-      expect(line).toMatch(/^FROM node:22\.22\.2-alpine@sha256:[a-f0-9]{64}(?: AS builder)?$/);
-    }
-    expect(fromLines[0]).toContain(" AS builder");
-    expect(fromLines[1]).not.toContain(" AS ");
+    const digest = /@sha256:([a-f0-9]{64})/.exec(fromLines[0])?.[1];
+    expect(digest).toMatch(/^[a-f0-9]{64}$/);
+    expect(fromLines[0]).toBe(`FROM node:22.22.2-alpine@sha256:${digest} AS builder`);
+    expect(fromLines[1]).toBe(`FROM node:22.22.2-alpine@sha256:${digest}`);
   });
 
-  it("healthchecks /api/status with Node fetch", () => {
-    expect(dockerfile).toMatch(/HEALTHCHECK --interval=15s --timeout=3s --start-period=10s --retries=3 \\/);
-    expect(dockerfile).toContain("/api/status");
-    expect(dockerfile).toContain('CMD ["node", "-e"');
-    expect(dockerfile).toContain("process.exit(r.ok?0:1)");
+  it("healthchecks /api/status with Node fetch on process.env.PORT", () => {
+    expect(dockerfile).toContain(
+      "HEALTHCHECK --interval=15s --timeout=3s --start-period=10s --retries=3 \\\n"
+      + '  CMD ["node", "-e", "fetch(\'http://127.0.0.1:\'+(process.env.PORT||3001)+\'/api/status\').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"]',
+    );
   });
 });

--- a/server/dockerfile.test.ts
+++ b/server/dockerfile.test.ts
@@ -13,6 +13,7 @@ describe("Dockerfile", () => {
     const fromLines = dockerfile.split("\n").filter((line) => line.startsWith("FROM "));
     expect(fromLines).toHaveLength(2);
     const digest = /@sha256:([a-f0-9]{64})/.exec(fromLines[0])?.[1];
+    expect(digest).toMatch(/^[a-f0-9]{64}$/);
     expect(fromLines[0]).toBe(`FROM node:22.22.2-alpine@sha256:${digest} AS builder`);
     expect(fromLines[1]).toBe(`FROM node:22.22.2-alpine@sha256:${digest}`);
   });

--- a/server/dockerfile.test.ts
+++ b/server/dockerfile.test.ts
@@ -13,7 +13,6 @@ describe("Dockerfile", () => {
     const fromLines = dockerfile.split("\n").filter((line) => line.startsWith("FROM "));
     expect(fromLines).toHaveLength(2);
     const digest = /@sha256:([a-f0-9]{64})/.exec(fromLines[0])?.[1];
-    expect(digest).toMatch(/^[a-f0-9]{64}$/);
     expect(fromLines[0]).toBe(`FROM node:22.22.2-alpine@sha256:${digest} AS builder`);
     expect(fromLines[1]).toBe(`FROM node:22.22.2-alpine@sha256:${digest}`);
   });

--- a/server/dockerfile.test.ts
+++ b/server/dockerfile.test.ts
@@ -1,0 +1,28 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const dockerfile = readFileSync(
+  join(dirname(fileURLToPath(import.meta.url)), "..", "Dockerfile"),
+  "utf8",
+);
+
+describe("Dockerfile", () => {
+  it("pins both stages to a Node 22.22.2 alpine index digest", () => {
+    const fromLines = dockerfile.split("\n").filter((line) => line.startsWith("FROM "));
+    expect(fromLines).toHaveLength(2);
+    for (const line of fromLines) {
+      expect(line).toMatch(/^FROM node:22\.22\.2-alpine@sha256:[a-f0-9]{64}(?: AS builder)?$/);
+    }
+    expect(fromLines[0]).toContain(" AS builder");
+    expect(fromLines[1]).not.toContain(" AS ");
+  });
+
+  it("healthchecks /api/status with Node fetch", () => {
+    expect(dockerfile).toMatch(/HEALTHCHECK --interval=15s --timeout=3s --start-period=10s --retries=3 \\/);
+    expect(dockerfile).toContain("/api/status");
+    expect(dockerfile).toContain('CMD ["node", "-e"');
+    expect(dockerfile).toContain("process.exit(r.ok?0:1)");
+  });
+});


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
## Summary

This PR strengthens the container build by pinning both Docker stages to the same verified Node.js 22.22.2 Alpine image digest and adding a built-in health check for the service status endpoint.

## Changes

- **Reproducible Docker images**
  - Replaces the floating `node:22-alpine` image in both the builder and runtime stages with `node:22.22.2-alpine@sha256:8ea2348b…`.
  - Ensures both stages use the same Node 22.22.2 Alpine image and prevents upstream tag changes from silently altering builds.
  - The Dockerfile comments document the pin and identify Dependabot as the mechanism for refreshing the digest.

- **Container health monitoring**
  - Adds a Docker `HEALTHCHECK` that requests `http://127.0.0.1:$PORT/api/status`.
  - Uses Node 22’s global `fetch`, avoiding additional runtime dependencies.
  - Reads the port from `PORT`, defaulting to `3001` to match the application’s normal runtime configuration.
  - Checks the service every 15 seconds with a 3-second timeout, 10-second startup grace period, and three failed checks before marking the container unhealthy.

- **Automated Docker dependency updates**
  - Adds a weekly Dependabot configuration for the root `Dockerfile`, scheduled for Monday at 06:00 Europe/Berlin.
  - Limits the Docker updater to five open pull requests, consistent with the repository’s other Dependabot configuration.

- **Regression coverage**
  - Adds tests that verify:
    - The Dockerfile contains exactly two `FROM` instructions.
    - Both stages use `node:22.22.2-alpine` with the same 64-character SHA-256 digest.
    - The builder stage retains the expected `AS builder` name.
    - The health check targets `/api/status` using `process.env.PORT` with the `3001` fallback.

## Functional Impact

Deployments now use a fixed, verifiable base image for both compilation and runtime, making builds more deterministic and reducing supply-chain drift. Containers expose a standard health signal to orchestrators based on the actual `/api/status` endpoint, allowing platforms to identify and recover from failed or unresponsive instances. Dependabot keeps the digest current through reviewable weekly update pull requests, while the new tests prevent accidental changes to the image pin or health-check contract.
<!-- kody-pr-summary:end -->